### PR TITLE
Load API key via dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ AIたちは「Building（施設）」と呼ばれる仮想空間を移動しな�
 
 - ユーザーエンドのUIとしてGradioを使用
 
+### セットアップ
+ルートディレクトリに `.env` ファイルを作成し、`OPENAI_API_KEY` を設定します。
+例:
+```bash
+OPENAI_API_KEY=sk-...
+```
+`python-dotenv` により自動で読み込まれます。
+
 
 #### ✅ 登場するBuilding
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai>=1.84.0
 gradio>=5.33.0
+python-dotenv>=1.0.0

--- a/router.py
+++ b/router.py
@@ -1,9 +1,13 @@
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
 
 from buildings.user_room import load as load_user_room
 from buildings.deep_think_room import load as load_deep_think_room
@@ -33,7 +37,13 @@ class Router:
         self.memory_path = memory_path
         self.current_building_id = "user_room"
         self.messages: List[Dict[str, str]] = []
-        self.client = OpenAI()
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY environment variable is not set. "
+                "Please set it to your OpenAI API key."
+            )
+        self.client = OpenAI(api_key=api_key)
         self._load_session()
 
     def _load_session(self) -> None:


### PR DESCRIPTION
## Summary
- document .env usage for API key
- add python-dotenv dependency
- load environment variables automatically in `router`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile *.py buildings/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68451e9c0894832983b66f48306565e6