### PR TITLE
Enable automatic talk when entering rooms

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,10 +9,12 @@ router = build_router()
 
 
 def respond(message, history):
-    reply = router.handle_user_input(message)
+    replies = router.handle_user_input(message)
     history = history or []
-    history.append({"role": "user", "content": message})
-    history.append({"role": "assistant", "content": reply})
+    if message:
+        history.append({"role": "user", "content": message})
+    for rep in replies:
+        history.append({"role": "assistant", "content": rep})
     return history, history
 
 


### PR DESCRIPTION
## Summary
- allow router to remember auto prompt counts for deep_think_room
- implement `_generate` helper and `run_auto_conversation` loop
- auto reply on room entry and continue for deep_think_room with cap
- adapt main UI to handle multiple replies

## Testing
- `python -m py_compile main.py router.py buildings/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845400f93e483298e8156ce8a36a1a0