### PR TITLE
Fix structured output JSON dump

### DIFF
--- a/router.py
+++ b/router.py
@@ -171,7 +171,9 @@ class Router:
             parsed = response.output_parsed
             say = parsed.say
             next_id = parsed.next_building_id
-            full_response = response.model_dump_json(ensure_ascii=False)
+            # `model_dump_json` does not support ensure_ascii in recent
+            # pydantic versions, so dump to dict first and then to JSON.
+            full_response = json.dumps(response.model_dump(), ensure_ascii=False)
             logging.debug(
                 "Parsed structured response - say: %s, next_building_id: %s",
                 say,


### PR DESCRIPTION
## Summary
- handle model_dump_json compatibility with pydantic v2

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_684c6497534883299ad2e4545fa5a15e