### PR TITLE
Fix history logging

### DIFF
--- a/router.py
+++ b/router.py
@@ -202,7 +202,11 @@ class Router:
             )
         if user_message:
             self._add_to_history({"role": "user", "content": user_message}, building_id=self.current_building_id)
-        self._add_to_history({"role": "assistant", "content": full_response}, building_id=self.current_building_id)
+        parsed_response = json.dumps({"say": say, "next_building_id": next_id}, ensure_ascii=False)
+        self._add_to_history(
+            {"role": "assistant", "content": parsed_response},
+            building_id=self.current_building_id,
+        )
         prev_id = self.current_building_id
         if next_id and next_id in self.buildings:
             logging.info("Moving to building: %s", next_id)


### PR DESCRIPTION
## Summary
- save smaller assistant messages to conversation history

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python main.py` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_684c67ac9210832984f6949b8e31f1e7