### PR TITLE
Enable persona-specific avatars

### DIFF
--- a/ai_sessions/air/base.json
+++ b/ai_sessions/air/base.json
@@ -1,5 +1,6 @@
 {
   "persona_id": "air",
   "persona_name": "エア",
-  "start_building_id": "air_room"
+  "start_building_id": "air_room",
+  "avatar_image": "assets/icons/air.png"
 }

--- a/ai_sessions/eris/base.json
+++ b/ai_sessions/eris/base.json
@@ -1,5 +1,6 @@
 {
   "persona_id": "eris",
   "persona_name": "エリス",
-  "start_building_id": "eris_room"
+  "start_building_id": "eris_room",
+  "avatar_image": "assets/icons/eris.png"
 }

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ NOTE_CSS = """
 /* ① まず器（avatar-container）を拡大 */
 #my_chat .avatar-container {
   width: 60px !important;
+  max-width: 60px !important;
   height: 60px !important;
   min-width: 60px !important;   /* ← ここ大事：吹き出しの左余白確保 */
   min-height: 60px !important;
@@ -46,6 +47,12 @@ NOTE_CSS = """
   margin-right: 0.5em;
   border-radius: 20%;
   object-fit: cover;
+}
+
+/* メッセージの高さがアイコンより低くならないよう調整 */
+#my_chat .message {
+  min-height: 60px;
+  overflow: hidden;
 }
 """
 

--- a/main.py
+++ b/main.py
@@ -41,8 +41,10 @@ NOTE_CSS = """
 }
 
 .inline-avatar {
-  width: 60px;
-  height: 60px;
+  width: 60px !important;
+  height: 60px !important;
+  max-width: 60px !important;
+  max-height: 60px !important;
   float: left;
   margin-right: 0.5em;
   border-radius: 20%;

--- a/main.py
+++ b/main.py
@@ -40,11 +40,11 @@ NOTE_CSS = """
 }
 
 .inline-avatar {
-  width: 1.4em;
-  height: 1.4em;
-  vertical-align: middle;
-  margin-right: 0.3em;
-  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  float: left;
+  margin-right: 0.5em;
+  border-radius: 20%;
   object-fit: cover;
 }
 """

--- a/main.py
+++ b/main.py
@@ -38,6 +38,15 @@ NOTE_CSS = """
 .note-box b {
   color: #333350; /* <b> の強調部分にも明示的に上書き */
 }
+
+.inline-avatar {
+  width: 1.4em;
+  height: 1.4em;
+  vertical-align: middle;
+  margin-right: 0.3em;
+  border-radius: 50%;
+  object-fit: cover;
+}
 """
 
 
@@ -64,7 +73,7 @@ def main():
             elem_id="my_chat",
             avatar_images=(
                 "assets/icons/user.png", # ← ユーザー
-                "assets/icons/eris.png" # ← アシスタント
+                None  # アシスタント側はメッセージ内に表示
             ),
             height=800
         )

--- a/router.py
+++ b/router.py
@@ -61,6 +61,7 @@ class Router:
         persona_data = json.loads((persona_base / "base.json").read_text(encoding="utf-8"))
         self.persona_id = persona_data.get("persona_id", persona_base.name)
         self.persona_name = persona_data.get("persona_name", "AI")
+        self.avatar_image = persona_data.get("avatar_image")
         start_building_id = persona_data.get("start_building_id", start_building_id)
         self.building_memory_paths: Dict[str, Path] = {
             b_id: Path("buildings") / b_id / "memory.json" for b_id in self.buildings
@@ -101,6 +102,8 @@ class Router:
 
     def _add_to_history(self, msg: Dict[str, str], building_id: Optional[str] = None) -> None:
         """Append a message to history and trim to 120000 characters."""
+        if msg.get("role") == "assistant" and "persona_id" not in msg:
+            msg["persona_id"] = self.persona_id
         self.messages.append(msg)
         b_id = building_id or self.current_building_id
         hist = self.building_histories.setdefault(b_id, [])


### PR DESCRIPTION
## Summary
- add `avatar_image` paths to each persona's base.json
- track persona_id in histories and load per-persona avatar paths
- display inline avatar images for each assistant message
- adjust CSS and Chatbot configuration to use new avatars

## Testing
- `python -m py_compile main.py router.py saiverse_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684e99b377f883298288ab0e6962b28f