### PR TITLE
Add Ollama model selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from saiverse_manager import SAIVerseManager
 logging.basicConfig(level=logging.INFO)
 manager = SAIVerseManager()
 PERSONA_CHOICES = list(manager.persona_map.keys())
+MODEL_CHOICES = ["gpt-4o", "qwen3:32b"]
 
 NOTE_CSS = """
 /* ① まず器（avatar-container）を拡大 */
@@ -75,6 +76,11 @@ def call_persona(name: str):
     return manager.get_building_history("user_room")
 
 
+def select_model(model_name: str):
+    manager.set_model(model_name)
+    return manager.get_building_history("user_room")
+
+
 def main():
     with gr.Blocks(css=NOTE_CSS) as demo:
         chatbot = gr.Chatbot(
@@ -91,9 +97,11 @@ def main():
         with gr.Row():
             txt = gr.Textbox()
             persona_drop = gr.Dropdown(choices=PERSONA_CHOICES, value=PERSONA_CHOICES[0], label="ペルソナ選択")
+            model_drop = gr.Dropdown(choices=MODEL_CHOICES, value=MODEL_CHOICES[0], label="モデル選択")
             call_btn = gr.Button("ペルソナを呼ぶ")
         txt.submit(respond, txt, chatbot)
         call_btn.click(call_persona, persona_drop, chatbot)
+        model_drop.change(select_model, model_drop, chatbot)
     demo.launch()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.84.0
 gradio>=5.33.0
 python-dotenv>=1.0.0
+requests>=2.32.0


### PR DESCRIPTION
## Summary
- add model dropdown in UI to switch between GPT-4o and Qwen3 32B
- support model selection in `SAIVerseManager` and `Router`
- implement Ollama API calls for local Qwen3 model
- require `requests` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68504e1f83bc8329ac7abb6b95e11ef9