### PR TITLE
Enable streaming responses in SAIVerse

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ AIたちは「Building（施設）」と呼ばれる仮想空間を移動しな�
 - 各種Buildingはファイル単位で切り出し可能な設計に
 
 - ユーザーエンドのUIとしてGradioを使用
+- OpenAI / Gemini / Ollama でストリーミング応答に対応
 
 ### セットアップ
 ルートディレクトリに `.env` ファイルを作成し、`OPENAI_API_KEY` または
@@ -31,6 +32,9 @@ OPENAI_API_KEY=sk-...
 GEMINI_API_KEY=AIza...
 ```
 `python-dotenv` により自動で読み込まれます。
+
+### ストリーミング表示
+`main.py` のGradioインタフェースでは、AIの応答を逐次表示します。OpenAI、Gemini、Ollama の各モデルで利用可能です。
 
 
 #### ✅ 登場するBuilding

--- a/main.py
+++ b/main.py
@@ -80,6 +80,17 @@ def respond(message: str):
     history = manager.get_building_history("user_room")
     return history
 
+def respond_stream(message: str):
+    """Stream AI response for chat."""
+    history = manager.get_building_history("user_room")
+    history.append({"role": "user", "content": message})
+    ai_message = ""
+    for token in manager.handle_user_input_stream(message):
+        ai_message += token
+        yield history + [{"role": "assistant", "content": ai_message}]
+    final = manager.get_building_history("user_room")
+    yield final
+
 
 def call_persona(name: str):
     persona_id = manager.persona_map.get(name)
@@ -120,7 +131,7 @@ def main():
         with gr.Row():
             persona_drop = gr.Dropdown(choices=PERSONA_CHOICES, value=PERSONA_CHOICES[0], label="ペルソナ選択")
             call_btn = gr.Button("ペルソナを呼ぶ")
-        txt.submit(respond, txt, chatbot)
+        txt.submit(respond_stream, txt, chatbot)
         call_btn.click(call_persona, persona_drop, chatbot)
         model_drop.change(select_model, model_drop, chatbot)
     demo.launch()

--- a/saiverse_manager.py
+++ b/saiverse_manager.py
@@ -2,7 +2,7 @@ import base64
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Iterator
 
 from buildings import Building
 from buildings.user_room import load as load_user_room
@@ -127,6 +127,14 @@ class SAIVerseManager:
         for router in self.routers.values():
             router._save_session()
         return replies
+
+    def handle_user_input_stream(self, message: str) -> Iterator[str]:
+        for pid in list(self.occupants.get("user_room", [])):
+            for token in self.routers[pid].handle_user_input_stream(message):
+                yield token
+        self._save_building_histories()
+        for router in self.routers.values():
+            router._save_session()
 
     def summon_persona(self, persona_id: str) -> List[str]:
         if persona_id not in self.routers:


### PR DESCRIPTION
## Summary
- add streaming output support for OpenAI, Gemini, and Ollama models
- expose streaming APIs in Router and SAIVerseManager
- update Gradio UI to show streaming messages
- document streaming usage in README

## Testing
- `python -m py_compile router.py saiverse_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685ac0129e448329aeccdf32c45db46a