### PR TITLE
Enable Gemini free API key with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ AIたちは「Building（施設）」と呼ばれる仮想空間を移動しな�
 
 ### セットアップ
 ルートディレクトリに `.env` ファイルを作成し、`OPENAI_API_KEY` または
-`GEMINI_API_KEY` を設定します。
+`GEMINI_API_KEY` を設定します。Google Gemini には無料枠があるため、
+まず `GEMINI_FREE_API_KEY` を設定しておくと、レート制限内の利用は
+課金なしで行えます。
 例:
 ```bash
 OPENAI_API_KEY=sk-...
 GEMINI_API_KEY=AIza...
+GEMINI_FREE_API_KEY=AIza...
 ```
 `python-dotenv` により自動で読み込まれます。
 


### PR DESCRIPTION
## Summary
- document new `GEMINI_FREE_API_KEY`
- prefer free Gemini API key and log info when falling back to paid key
- implement fallback logic in emotion module
- patch tests to cover new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686671f25b60832983729db67a7ccb48