### PR TITLE
Enable file data in OpenAI client

### DIFF
--- a/tests/test_image_generator.py
+++ b/tests/test_image_generator.py
@@ -25,7 +25,7 @@ class TestImageGenerator(unittest.TestCase):
         with patch.dict(os.environ, {"GEMINI_FREE_API_KEY": "FREE", "GEMINI_API_KEY": ""}):
             text, info, path = generate_image('a cat')
         self.assertIsInstance(info, ToolResult)
-        self.assertEqual(text, 'a cat')
+        self.assertIn('a cat', text)
         self.assertTrue(info.history_snippet)
         self.assertTrue(Path(path).exists())
         mock_genai.Client.assert_called_once_with(api_key='FREE')


### PR DESCRIPTION
## Summary
- embed generated file contents when tools return a file for OpenAI models
- update test for `generate_image`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686916c2b0308329a1c45dbe5c9e2c46