### PR TITLE
Implement pulse-based autonomous actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,18 +116,16 @@ def main():
 
     def background_loop():
         persona_ids = list(manager.personas.keys())
-        last_pulse = time.time()
         pulse_idx = 0
         while True:
             manager.run_scheduled_prompts()
             logging.debug("Background loop tick")
             now = time.time()
-            if persona_ids and now - last_pulse >= 120:
+            if persona_ids and now >= manager.next_scheduled_pulse_time:
                 pid = persona_ids[pulse_idx % len(persona_ids)]
                 logging.info("Background loop running pulse for %s", pid)
                 manager.run_pulse(pid)
-                pulse_idx += 1
-                last_pulse = now
+                pulse_idx = (pulse_idx + 1) % len(persona_ids)
             time.sleep(5)
 
     thread = threading.Thread(target=background_loop, daemon=True)

--- a/main.py
+++ b/main.py
@@ -84,6 +84,11 @@ def respond_stream(message: str):
     yield final
 
 
+def refresh_history():
+    """Return current chat history for polling."""
+    return manager.get_building_history("user_room")
+
+
 def call_persona(name: str):
     persona_id = manager.persona_map.get(name)
     if persona_id:
@@ -148,6 +153,8 @@ def main():
         with gr.Row():
             persona_drop = gr.Dropdown(choices=PERSONA_CHOICES, value=PERSONA_CHOICES[0], label="ペルソナ選択")
             call_btn = gr.Button("ペルソナを呼ぶ")
+        pulse_timer = gr.Timer(value=2.0, render=False)
+        pulse_timer.tick(refresh_history, None, chatbot)
         submit.click(respond_stream, txt, chatbot)
         call_btn.click(call_persona, persona_drop, chatbot)
         model_drop.change(select_model, model_drop, chatbot)

--- a/main.py
+++ b/main.py
@@ -120,9 +120,11 @@ def main():
         pulse_idx = 0
         while True:
             manager.run_scheduled_prompts()
+            logging.debug("Background loop tick")
             now = time.time()
             if persona_ids and now - last_pulse >= 120:
                 pid = persona_ids[pulse_idx % len(persona_ids)]
+                logging.info("Background loop running pulse for %s", pid)
                 manager.run_pulse(pid)
                 pulse_idx += 1
                 last_pulse = now

--- a/main.py
+++ b/main.py
@@ -115,17 +115,10 @@ def main():
         logging.warning(f"DB Manager not found at {db_manager_path}, skipping.")
 
     def background_loop():
-        persona_ids = list(manager.personas.keys())
-        pulse_idx = 0
         while True:
             manager.run_scheduled_prompts()
             logging.debug("Background loop tick")
-            now = time.time()
-            if persona_ids and now >= manager.next_scheduled_pulse_time:
-                pid = persona_ids[pulse_idx % len(persona_ids)]
-                logging.info("Background loop running pulse for %s", pid)
-                manager.run_pulse(pid)
-                pulse_idx = (pulse_idx + 1) % len(persona_ids)
+            manager.maybe_run_scheduled_pulse()
             time.sleep(5)
 
     thread = threading.Thread(target=background_loop, daemon=True)

--- a/saiverse_manager.py
+++ b/saiverse_manager.py
@@ -161,11 +161,15 @@ class SAIVerseManager:
 
     def set_user_online(self, online: bool) -> None:
         self.user_online = online
+        logging.info("User online state set to %s", online)
 
     def run_pulse(self, persona_id: str) -> List[str]:
         if persona_id not in self.personas:
+            logging.warning("run_pulse called with unknown persona id: %s", persona_id)
             return []
+        logging.info("Triggering pulse for %s", persona_id)
         replies = self.personas[persona_id].run_pulse(user_online=self.user_online)
+        logging.info("Pulse for %s produced %d replies", persona_id, len(replies))
         if replies:
             self.city.save_histories()
             for persona in self.personas.values():
@@ -173,7 +177,9 @@ class SAIVerseManager:
         return replies
 
     def run_all_pulses(self) -> List[str]:
+        logging.info("Running pulses for all personas")
         replies: List[str] = []
         for pid in self.personas.keys():
             replies.extend(self.run_pulse(pid))
+        logging.info("Completed run_all_pulses with %d total replies", len(replies))
         return replies

--- a/saiverse_manager.py
+++ b/saiverse_manager.py
@@ -25,6 +25,7 @@ class SAIVerseManager:
         self.model = model
         self.context_length = get_context_length(model)
         self.provider = get_model_provider(model)
+        self.user_online = True
 
         self.buildings = self.city.buildings
         self.building_map = self.city.building_map
@@ -144,4 +145,27 @@ class SAIVerseManager:
             self.city.save_histories()
             for persona in self.personas.values():
                 persona._save_session_metadata()
+        return replies
+
+    # ------------------------------------------------------------------
+    # Pulse management
+    # ------------------------------------------------------------------
+
+    def set_user_online(self, online: bool) -> None:
+        self.user_online = online
+
+    def run_pulse(self, persona_id: str) -> List[str]:
+        if persona_id not in self.personas:
+            return []
+        replies = self.personas[persona_id].run_pulse(user_online=self.user_online)
+        if replies:
+            self.city.save_histories()
+            for persona in self.personas.values():
+                persona._save_session_metadata()
+        return replies
+
+    def run_all_pulses(self) -> List[str]:
+        replies: List[str] = []
+        for pid in self.personas.keys():
+            replies.extend(self.run_pulse(pid))
         return replies

--- a/saiverse_manager.py
+++ b/saiverse_manager.py
@@ -199,9 +199,14 @@ class SAIVerseManager:
         if not self.pulse_order:
             return []
         if now >= self.next_scheduled_pulse_time:
-            pid = self.pulse_order[self.pulse_index % len(self.pulse_order)]
-            self.pulse_index = (self.pulse_index + 1) % len(self.pulse_order)
-            return self.run_pulse(pid)
+            attempts = 0
+            while attempts < len(self.pulse_order):
+                pid = self.pulse_order[self.pulse_index % len(self.pulse_order)]
+                self.pulse_index = (self.pulse_index + 1) % len(self.pulse_order)
+                if self.personas[pid].active:
+                    return self.run_pulse(pid)
+                attempts += 1
+            self.next_scheduled_pulse_time = time.time() + self.pulse_interval
         return []
 
     def run_all_pulses(self) -> List[str]:

--- a/saiverse_manager.py
+++ b/saiverse_manager.py
@@ -85,6 +85,8 @@ class SAIVerseManager:
             self.pulse_running[pid] = False
         self.pulse_interval = 120
         self.next_scheduled_pulse_time = time.time() + self.pulse_interval
+        self.pulse_order = list(self.personas.keys())
+        self.pulse_index = 0
 
 
     def handle_user_input(self, message: str) -> List[str]:
@@ -190,6 +192,17 @@ class SAIVerseManager:
             self.pulse_running[persona_id] = False
             self.next_scheduled_pulse_time = time.time() + self.pulse_interval
         return replies
+
+    def maybe_run_scheduled_pulse(self) -> List[str]:
+        """Run the next scheduled pulse if the interval has elapsed."""
+        now = time.time()
+        if not self.pulse_order:
+            return []
+        if now >= self.next_scheduled_pulse_time:
+            pid = self.pulse_order[self.pulse_index % len(self.pulse_order)]
+            self.pulse_index = (self.pulse_index + 1) % len(self.pulse_order)
+            return self.run_pulse(pid)
+        return []
 
     def run_all_pulses(self) -> List[str]:
         logging.info("Running pulses for all personas")

--- a/system_prompts/pulse.txt
+++ b/system_prompts/pulse.txt
@@ -1,0 +1,16 @@
+{current_persona_system_instruction}
+
+最近の会話内容はこのようになっています:
+{recent_conversation}
+
+以下の情報を基に、今外向けに発話すべきか判断してください。
+建物名: {current_building_name}
+同じ建物のペルソナID: {occupants}
+ユーザーオンライン: {user_online_state}
+
+JSON形式で次のフィールドを返します:
+{
+  "speak": true or false,
+  "info": "発話する場合、システムプロンプトに追加すべき情報",
+  "memory": "覚えておくべき事柄"
+}


### PR DESCRIPTION
## Summary
- create `pulse.txt` system prompt for decision phase
- enable persona to store conscious logs and run autonomous pulses
- expose pulse operations in `SAIVerseManager`

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_687bef582e6883299ebf048faad8d17a