### PR TITLE
feat: support local Hugging Face embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ GEMINI_FREE_API_KEY=AIza...
 ```
 `python-dotenv` により自動で読み込まれます。
 
+#### ローカル埋め込みモデル（Hugging Face）
+Cognee の長期記憶をローカル埋め込みモデルで利用する場合は、`.env` に Hugging Face のモデル名を指定します。
+
+例:
+```bash
+SAIVERSE_COGNEE_HF_EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
+# モデルのベクトル次元に合わせて変更（省略時は768）
+SAIVERSE_COGNEE_HF_EMBED_DIM=384
+```
+
+実行時に指定モデルが自動ダウンロードされ、OpenAI/Gemini なしで埋め込み検索のみを行えます。必要に応じて `pip install sentence-transformers` などでモデルを事前取得してください。
+
 ### ストリーミング表示
 `main.py` のGradioインタフェースでは、AIの応答を逐次表示します。OpenAI、Gemini、Ollama の各モデルで利用可能です。
 

--- a/integrations/cognee_memory.py
+++ b/integrations/cognee_memory.py
@@ -447,6 +447,23 @@ class CogneeMemory:
                 "EMBEDDING_API_KEY": openai_key,
                 "HUGGINGFACE_TOKENIZER": os.getenv("HUGGINGFACE_TOKENIZER", "none"),
             }
+        hf_model = (os.getenv("SAIVERSE_COGNEE_HF_EMBED_MODEL") or "").strip()
+        if hf_model:
+            return {
+                # Persona-scoped storage roots for Cognee
+                "SYSTEM_ROOT_DIRECTORY": sys_root,
+                "DATA_ROOT_DIRECTORY": data_root,
+                # Embedding config for local Hugging Face model
+                "EMBEDDING_PROVIDER": "huggingface",
+                "EMBEDDING_MODEL": hf_model,
+                "EMBEDDING_DIMENSIONS": os.getenv("SAIVERSE_COGNEE_HF_EMBED_DIM", "768"),
+                "HUGGINGFACE_TOKENIZER": "none",
+                # Ensure no remote LLM provider is selected
+                "LLM_PROVIDER": None,
+                "LLM_API_KEY": None,
+                "OPENAI_API_KEY": None,
+                "GEMINI_API_KEY": None,
+            }
         return None
 
     def remember(self, text: str, conv_id: str = "default", speaker: str = "user", meta: Optional[Dict] = None):


### PR DESCRIPTION
## Summary
- add Hugging Face embedding branch to Cognee memory provider
- document local embedding model setup with `.env` example

## Testing
- `python -m unittest discover tests` *(fails: API key not valid and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ac893bf9808329bacdd2a164afdb09