### PR TITLE
fix: honor huggingface embedding override

### DIFF
--- a/integrations/cognee_memory.py
+++ b/integrations/cognee_memory.py
@@ -377,6 +377,10 @@ class CogneeMemory:
         gem_free = (os.getenv("GEMINI_FREE_API_KEY") or "").strip()
         gem_paid = (os.getenv("GEMINI_API_KEY") or "").strip()
         openai_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+        embed_provider = (
+            os.getenv("EMBEDDING_PROVIDER") or os.getenv("SAIVERSE_EMBED_PROVIDER") or ""
+        ).strip().lower()
+        hf_model = (os.getenv("SAIVERSE_COGNEE_HF_EMBED_MODEL") or "").strip()
         # Persona-scoped Cognee system dir under ~/.saiverse/personas/<persona_id>/cognee_system
         persona_root = Path.home() / ".saiverse" / "personas" / str(self.persona_id) / "cognee_system"
         sys_root = str(persona_root)
@@ -401,7 +405,7 @@ class CogneeMemory:
             emb_model = (os.getenv("SAIVERSE_COGNEE_GEMINI_EMBED_MODEL") or "gemini/text-embedding-004").strip()
             if not emb_model.startswith("gemini/"):
                 emb_model = f"gemini/{emb_model}"
-            return {
+            env = {
                 "LLM_PROVIDER": "gemini",
                 "LLM_API_KEY": key,
                 "GEMINI_API_KEY": key,  # LiteLLM expects this
@@ -411,8 +415,12 @@ class CogneeMemory:
                 "SYSTEM_ROOT_DIRECTORY": sys_root,
                 "DATA_ROOT_DIRECTORY": data_root,
                 # Prompts override
-                "GRAPH_PROMPT_PATH": os.path.abspath(os.path.join(os.getcwd(), "integrations/cognee_prompts/generate_graph_prompt_ja.txt")),
-                "SAIVERSE_COGNEE_PROMPTS_DIR": os.path.abspath(os.path.join(os.getcwd(), "integrations/cognee_prompts")),
+                "GRAPH_PROMPT_PATH": os.path.abspath(
+                    os.path.join(os.getcwd(), "integrations/cognee_prompts/generate_graph_prompt_ja.txt")
+                ),
+                "SAIVERSE_COGNEE_PROMPTS_DIR": os.path.abspath(
+                    os.path.join(os.getcwd(), "integrations/cognee_prompts")
+                ),
                 # Embedding config
                 "EMBEDDING_PROVIDER": "gemini",
                 "EMBEDDING_MODEL": emb_model,
@@ -424,6 +432,21 @@ class CogneeMemory:
                 # Surface the decision for debugging if needed
                 "SAIVERSE_GEMINI_KEY_KIND": key_kind,
             }
+            if embed_provider == "huggingface" and hf_model:
+                env.update(
+                    {
+                        "EMBEDDING_PROVIDER": "huggingface",
+                        "EMBEDDING_MODEL": hf_model,
+                        "EMBEDDING_DIMENSIONS": os.getenv(
+                            "SAIVERSE_COGNEE_HF_EMBED_DIM", "768"
+                        ),
+                        "EMBEDDING_API_KEY": None,
+                        "HUGGINGFACE_TOKENIZER": os.getenv(
+                            "HUGGINGFACE_TOKENIZER", "none"
+                        ),
+                    }
+                )
+            return env
         if openai_key:
             model = (os.getenv("SAIVERSE_COGNEE_OPENAI_MODEL") or "openai/gpt-4o-mini").strip()
             if not model.startswith("openai/"):
@@ -431,7 +454,7 @@ class CogneeMemory:
             emb_model = (os.getenv("SAIVERSE_COGNEE_OPENAI_EMBED_MODEL") or "openai/text-embedding-3-large").strip()
             if not emb_model.startswith("openai/"):
                 emb_model = f"openai/{emb_model}"
-            return {
+            env = {
                 "LLM_PROVIDER": "openai",
                 "LLM_API_KEY": openai_key,
                 "OPENAI_API_KEY": openai_key,
@@ -447,7 +470,21 @@ class CogneeMemory:
                 "EMBEDDING_API_KEY": openai_key,
                 "HUGGINGFACE_TOKENIZER": os.getenv("HUGGINGFACE_TOKENIZER", "none"),
             }
-        hf_model = (os.getenv("SAIVERSE_COGNEE_HF_EMBED_MODEL") or "").strip()
+            if embed_provider == "huggingface" and hf_model:
+                env.update(
+                    {
+                        "EMBEDDING_PROVIDER": "huggingface",
+                        "EMBEDDING_MODEL": hf_model,
+                        "EMBEDDING_DIMENSIONS": os.getenv(
+                            "SAIVERSE_COGNEE_HF_EMBED_DIM", "768"
+                        ),
+                        "EMBEDDING_API_KEY": None,
+                        "HUGGINGFACE_TOKENIZER": os.getenv(
+                            "HUGGINGFACE_TOKENIZER", "none"
+                        ),
+                    }
+                )
+            return env
         if hf_model:
             return {
                 # Persona-scoped storage roots for Cognee

--- a/tests/test_cognee_provider_env.py
+++ b/tests/test_cognee_provider_env.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+from unittest import mock
+
+from integrations.cognee_memory import CogneeMemory
+
+
+class TestCogneeProviderEnv(unittest.TestCase):
+    def test_huggingface_override(self):
+        m = CogneeMemory.__new__(CogneeMemory)
+        m.persona_id = "test"
+        env_vars = {
+            "LLM_PROVIDER": "gemini",
+            "GEMINI_API_KEY": "dummy",
+            "EMBEDDING_PROVIDER": "huggingface",
+            "SAIVERSE_COGNEE_HF_EMBED_MODEL": "intfloat/multilingual-e5-base",
+            "SAIVERSE_COGNEE_HF_EMBED_DIM": "768",
+        }
+        with mock.patch.dict(os.environ, env_vars, clear=False):
+            env = m._provider_env()
+        self.assertEqual(env.get("LLM_PROVIDER"), "gemini")
+        self.assertEqual(env.get("EMBEDDING_PROVIDER"), "huggingface")
+        self.assertEqual(env.get("EMBEDDING_MODEL"), "intfloat/multilingual-e5-base")
+        self.assertEqual(env.get("EMBEDDING_DIMENSIONS"), "768")
+        self.assertIsNone(env.get("EMBEDDING_API_KEY"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `EMBEDDING_PROVIDER=huggingface` to override Cognee embedding config even when Gemini/OpenAI LLMs are used
- add unit test for HuggingFace embedding override

## Testing
- `python3 -m unittest tests.test_cognee_provider_env`
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'google', requests)*

------
https://chatgpt.com/codex/tasks/task_e_68adbe8235148329819c9a594d2a7948