### PR TITLE
Refactor SAIVerse manager into service-oriented components

### DIFF
--- a/saiverse_manager/services/city_config_service.py
+++ b/saiverse_manager/services/city_config_service.py
@@ -1,0 +1,137 @@
+"""Services for loading and managing city configuration."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import Session, sessionmaker
+from zoneinfo import ZoneInfo
+
+from database.models import City as CityModel
+
+
+@dataclass
+class CityConfig:
+    """Lightweight container describing a city's configuration."""
+
+    city_id: int
+    city_name: str
+    ui_port: int
+    api_port: int
+    start_in_online_mode: bool
+    timezone_name: str
+    timezone_info: ZoneInfo
+
+
+class CityConfigService:
+    """Encapsulates all logic required to load the city configuration."""
+
+    def __init__(self, city_name: str, db_path: str) -> None:
+        self.city_name = city_name
+        self.db_path = db_path
+        database_url = f"sqlite:///{db_path}"
+        self.engine = create_engine(database_url, connect_args={"check_same_thread": False})
+        self.session_factory = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
+        self._ensure_city_timezone_column()
+
+    def create_session(self) -> Session:
+        """Return a new SQLAlchemy session."""
+        return self.session_factory()
+
+    def load_city_configuration(self) -> Tuple[CityConfig, Dict[str, Dict[str, object]]]:
+        """Load the city configuration and the other cities from the database."""
+        session = self.create_session()
+        try:
+            my_city_config = (
+                session.query(CityModel)
+                .filter(CityModel.CITYNAME == self.city_name)
+                .first()
+            )
+            if not my_city_config:
+                raise ValueError(
+                    f"City '{self.city_name}' not found in the database. Please run 'python database/seed.py' first."
+                )
+
+            timezone_name = getattr(my_city_config, "TIMEZONE", "UTC") or "UTC"
+            timezone_name = timezone_name.strip() or "UTC"
+            timezone_info = self._resolve_timezone(timezone_name)
+
+            config = CityConfig(
+                city_id=my_city_config.CITYID,
+                city_name=my_city_config.CITYNAME,
+                ui_port=my_city_config.UI_PORT,
+                api_port=my_city_config.API_PORT,
+                start_in_online_mode=my_city_config.START_IN_ONLINE_MODE,
+                timezone_name=timezone_name,
+                timezone_info=timezone_info,
+            )
+
+            other_cities = self._load_other_cities(session, my_city_config.CITYID)
+            return config, other_cities
+        finally:
+            session.close()
+
+    def load_other_cities(
+        self, current_city_id: int | None = None
+    ) -> Dict[str, Dict[str, object]]:
+        """Public helper to fetch other city configurations."""
+        session = self.create_session()
+        try:
+            return self._load_other_cities(session, current_city_id)
+        finally:
+            session.close()
+
+    def _ensure_city_timezone_column(self) -> None:
+        """Ensure that the CITY table has a TIMEZONE column."""
+        try:
+            inspector = inspect(self.engine)
+            columns = {col["name"] for col in inspector.get_columns("city")}
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.warning(
+                "Failed to inspect city table for timezone column: %s", exc
+            )
+            return
+
+        if "TIMEZONE" in columns:
+            return
+
+        logging.info("Adding TIMEZONE column to city table.")
+        try:
+            with self.engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "ALTER TABLE city ADD COLUMN TIMEZONE TEXT DEFAULT 'UTC' NOT NULL"
+                    )
+                )
+                conn.execute(
+                    text("UPDATE city SET TIMEZONE = 'UTC' WHERE TIMEZONE IS NULL")
+                )
+        except Exception as exc:  # pragma: no cover - depends on DB state
+            logging.error("Failed to add TIMEZONE column to city table: %s", exc)
+
+    def _load_other_cities(
+        self, session: Session, current_city_id: int | None
+    ) -> Dict[str, Dict[str, object]]:
+        query = session.query(CityModel)
+        if current_city_id is not None:
+            query = query.filter(CityModel.CITYID != current_city_id)
+
+        other_cities = query.all()
+        return {
+            city.CITYNAME: {
+                "city_id": city.CITYID,
+                "api_base_url": f"http://127.0.0.1:{city.API_PORT}",
+                "timezone": getattr(city, "TIMEZONE", "UTC") or "UTC",
+            }
+            for city in other_cities
+        }
+
+    @staticmethod
+    def _resolve_timezone(name: str) -> ZoneInfo:
+        try:
+            return ZoneInfo(name)
+        except Exception:  # pragma: no cover - depends on system tz database
+            logging.warning("Invalid timezone '%s'. Falling back to UTC.", name)
+            return ZoneInfo("UTC")

--- a/saiverse_manager/services/gateway_bootstrapper.py
+++ b/saiverse_manager/services/gateway_bootstrapper.py
@@ -1,0 +1,24 @@
+"""Helper for wiring Discord gateway integration based on environment variables."""
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+
+class GatewayBootstrapper:
+    """Determine whether the Discord gateway should be initialised."""
+
+    def __init__(self, initializer: Callable[[], None], env: dict[str, str] | None = None) -> None:
+        self._initializer = initializer
+        self._env = env if env is not None else os.environ
+
+    def is_enabled(self) -> bool:
+        value = self._env.get("SAIVERSE_GATEWAY_ENABLED", "0")
+        return value.lower() in {"1", "true", "yes"}
+
+    def start_if_enabled(self) -> bool:
+        """Invoke the initializer if the gateway integration is enabled."""
+        if not self.is_enabled():
+            return False
+        self._initializer()
+        return True

--- a/saiverse_manager/services/history_loader.py
+++ b/saiverse_manager/services/history_loader.py
@@ -1,0 +1,110 @@
+"""Utilities for loading building data, avatars, and histories."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import mimetypes
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from sqlalchemy.orm import Session
+
+from buildings import Building
+from database.models import Building as BuildingModel
+
+
+@dataclass
+class AvatarAssets:
+    """Container for avatar assets used by the manager."""
+
+    default_avatar: str
+    host_avatar: str
+
+
+class HistoryLoader:
+    """Loads building definitions, avatar assets, and conversation histories."""
+
+    def __init__(self, city_name: str, saiverse_home: Path | None = None) -> None:
+        self.city_name = city_name
+        self.saiverse_home = saiverse_home or Path.home() / ".saiverse"
+        self.backup_dir = self.saiverse_home / "backups"
+        self.backup_dir.mkdir(parents=True, exist_ok=True)
+
+    def load_buildings(self, session: Session, city_id: int) -> List[Building]:
+        """Read buildings for the given city from the database."""
+        db_buildings = (
+            session.query(BuildingModel)
+            .filter(BuildingModel.CITYID == city_id)
+            .all()
+        )
+        buildings: List[Building] = []
+        for db_b in db_buildings:
+            building = Building(
+                building_id=db_b.BUILDINGID,
+                name=db_b.BUILDINGNAME,
+                capacity=db_b.CAPACITY or 1,
+                system_instruction=db_b.SYSTEM_INSTRUCTION or "",
+                entry_prompt=db_b.ENTRY_PROMPT or "",
+                auto_prompt=db_b.AUTO_PROMPT or "",
+                description=db_b.DESCRIPTION or "",
+                auto_interval_sec=
+                db_b.AUTO_INTERVAL_SEC if hasattr(db_b, "AUTO_INTERVAL_SEC") else 10,
+            )
+            buildings.append(building)
+
+        logging.info("Loaded and created %s buildings from database.", len(buildings))
+        return buildings
+
+    def build_memory_paths(self, buildings: Iterable[Building]) -> Dict[str, Path]:
+        """Return mapping of building IDs to their history file paths."""
+        return {
+            b.building_id: self.saiverse_home
+            / "cities"
+            / self.city_name
+            / "buildings"
+            / b.building_id
+            / "log.json"
+            for b in buildings
+        }
+
+    def load_histories(self, memory_paths: Dict[str, Path]) -> Dict[str, List[Dict[str, str]]]:
+        """Load history JSON files if they exist."""
+        histories: Dict[str, List[Dict[str, str]]] = {}
+        for building_id, path in memory_paths.items():
+            if path.exists():
+                try:
+                    histories[building_id] = json.loads(
+                        path.read_text(encoding="utf-8")
+                    )
+                except json.JSONDecodeError:
+                    logging.warning("Failed to load building history %s", building_id)
+                    histories[building_id] = []
+            else:
+                histories[building_id] = []
+        return histories
+
+    def load_avatar_assets(
+        self,
+        default_avatar_path: Path = Path("assets/icons/blank.png"),
+        host_avatar_path: Path = Path("assets/icons/host.png"),
+    ) -> AvatarAssets:
+        """Prepare default and host avatar assets in base64 format."""
+        default_avatar = self._load_avatar(default_avatar_path)
+        host_avatar = self._load_avatar(host_avatar_path) or default_avatar
+        return AvatarAssets(default_avatar=default_avatar, host_avatar=host_avatar)
+
+    @staticmethod
+    def _load_avatar(path: Path) -> str:
+        if not path.exists():
+            return ""
+        mime = mimetypes.guess_type(path.name)[0] or "image/png"
+        data_b = path.read_bytes()
+        b64 = base64.b64encode(data_b).decode("ascii")
+        return f"data:{mime};base64,{b64}"
+
+    def ensure_history_directories(self, memory_paths: Iterable[Path]) -> None:
+        """Make sure the directories for history files exist."""
+        for path in memory_paths:
+            path.parent.mkdir(parents=True, exist_ok=True)

--- a/saiverse_manager/services/sds_client.py
+++ b/saiverse_manager/services/sds_client.py
@@ -1,0 +1,82 @@
+"""Client wrapper around the SDS REST endpoints."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import requests
+
+
+class SDSClientError(RuntimeError):
+    """Error raised when SDS communication fails."""
+
+
+@dataclass
+class SDSClient:
+    """A thin wrapper that encapsulates SDS interactions."""
+
+    city_name: str
+    city_id: int
+    api_port: int
+    sds_url: str
+    session: requests.Session = field(default_factory=requests.Session)
+
+    def __post_init__(self) -> None:
+        self.sds_url = self.sds_url.rstrip("/")
+
+    def register_city(self) -> bool:
+        """Attempt to register the city with the SDS."""
+        register_url = f"{self.sds_url}/register"
+        payload = {
+            "city_name": self.city_name,
+            "city_id_pk": self.city_id,
+            "api_port": self.api_port,
+        }
+        try:
+            response = self.session.post(register_url, json=payload, timeout=5)
+            response.raise_for_status()
+            logging.info("Successfully registered with SDS at %s", self.sds_url)
+            return True
+        except requests.exceptions.RequestException as exc:
+            logging.error("Could not register with SDS: %s", exc)
+            return False
+
+    def send_heartbeat(self) -> bool:
+        """Send a heartbeat to the SDS."""
+        heartbeat_url = f"{self.sds_url}/heartbeat"
+        payload = {"city_name": self.city_name}
+        try:
+            response = self.session.post(heartbeat_url, json=payload, timeout=2)
+            response.raise_for_status()
+            logging.debug("Heartbeat sent to SDS for %s", self.city_name)
+            return True
+        except requests.exceptions.RequestException as exc:
+            logging.warning("Could not send heartbeat to SDS: %s", exc)
+            return False
+
+    def fetch_city_directory(self) -> Dict[str, Dict[str, object]]:
+        """Fetch currently registered cities from the SDS."""
+        cities_url = f"{self.sds_url}/cities"
+        try:
+            response = self.session.get(cities_url, timeout=5)
+            response.raise_for_status()
+            cities_data = response.json()
+            if self.city_name in cities_data:
+                del cities_data[self.city_name]
+            return cities_data
+        except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+            raise SDSClientError(str(exc)) from exc
+
+    def clone_with_session(self, session: Optional[requests.Session]) -> "SDSClient":
+        """Return a new instance that uses the provided session."""
+        if session is None:
+            return self
+        return SDSClient(
+            city_name=self.city_name,
+            city_id=self.city_id,
+            api_port=self.api_port,
+            sds_url=self.sds_url,
+            session=session,
+        )

--- a/tests/test_saiverse_services.py
+++ b/tests/test_saiverse_services.py
@@ -1,0 +1,196 @@
+import base64
+import sys
+from pathlib import Path
+
+# Ensure repository root is importable when running the tests standalone.
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import pytest
+import requests
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.models import Base, Building as BuildingModel, City as CityModel, User as UserModel
+from saiverse_manager.services import (
+    AvatarAssets,
+    CityConfigService,
+    GatewayBootstrapper,
+    HistoryLoader,
+    SDSClient,
+    SDSClientError,
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"status: {self.status_code}")
+
+    def json(self):
+        return self._json_data
+
+
+class FakeSession:
+    def __init__(self):
+        self.requests = []
+        self.next_response = FakeResponse()
+
+    def configure(self, *, status_code=200, json_data=None):
+        self.next_response = FakeResponse(status_code=status_code, json_data=json_data)
+
+    def post(self, url, json=None, timeout=None):
+        self.requests.append(("POST", url, json, timeout))
+        return self.next_response
+
+    def get(self, url, timeout=None):
+        self.requests.append(("GET", url, None, timeout))
+        return self.next_response
+
+
+@pytest.fixture
+def temporary_database(tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    with SessionLocal() as session:
+        user = UserModel(USERID=1, PASSWORD="pw", USERNAME="Tester", LOGGED_IN=False)
+        session.add(user)
+        session.flush()
+
+        city = CityModel(
+            USERID=user.USERID,
+            CITYNAME="TestCity",
+            UI_PORT=9000,
+            API_PORT=9100,
+            START_IN_ONLINE_MODE=True,
+            TIMEZONE="UTC",
+        )
+        session.add(city)
+        session.flush()
+
+        other_city = CityModel(
+            USERID=user.USERID,
+            CITYNAME="OtherCity",
+            UI_PORT=9001,
+            API_PORT=9101,
+            START_IN_ONLINE_MODE=False,
+            TIMEZONE="Asia/Tokyo",
+        )
+        session.add(other_city)
+
+        building = BuildingModel(
+            CITYID=city.CITYID,
+            BUILDINGID="bld-1",
+            BUILDINGNAME="Lounge",
+            CAPACITY=3,
+            SYSTEM_INSTRUCTION="",
+            ENTRY_PROMPT="",
+            AUTO_PROMPT="",
+            DESCRIPTION="A quiet place",
+            AUTO_INTERVAL_SEC=15,
+        )
+        session.add(building)
+        session.commit()
+
+    yield db_path
+
+
+def test_city_config_service_loads_city_and_other_cities(temporary_database):
+    service = CityConfigService("TestCity", str(temporary_database))
+    config, other_cities = service.load_city_configuration()
+
+    assert config.city_name == "TestCity"
+    assert config.api_port == 9100
+    assert config.timezone_name == "UTC"
+    assert set(other_cities.keys()) == {"OtherCity"}
+    assert other_cities["OtherCity"]["api_base_url"] == "http://127.0.0.1:9101"
+    assert other_cities["OtherCity"]["timezone"] == "Asia/Tokyo"
+
+    reloaded = service.load_other_cities(config.city_id)
+    assert list(reloaded.keys()) == ["OtherCity"]
+
+
+def test_history_loader_handles_paths_and_histories(tmp_path, temporary_database):
+    service = CityConfigService("TestCity", str(temporary_database))
+    config, _ = service.load_city_configuration()
+
+    history_loader = HistoryLoader(config.city_name, saiverse_home=tmp_path / "saiverse")
+    session = service.create_session()
+    try:
+        buildings = history_loader.load_buildings(session, config.city_id)
+    finally:
+        session.close()
+
+    assert len(buildings) == 1
+    paths = history_loader.build_memory_paths(buildings)
+    history_loader.ensure_history_directories(paths.values())
+    path = next(iter(paths.values()))
+    sample_history = [{"role": "host", "content": "Hello"}]
+    path.write_text("[{'role': 'host', 'content': 'Hello'}]".replace("'", '"'), encoding="utf-8")
+
+    histories = history_loader.load_histories(paths)
+    assert histories[buildings[0].building_id] == sample_history
+
+    default_file = tmp_path / "default.png"
+    host_file = tmp_path / "host.png"
+    default_file.write_bytes(b"default")
+    host_file.write_bytes(b"host")
+    assets = history_loader.load_avatar_assets(default_file, host_file)
+    assert isinstance(assets, AvatarAssets)
+    assert assets.default_avatar.startswith("data:image/png;base64,")
+    assert base64.b64decode(assets.default_avatar.split(",", 1)[1]) == b"default"
+
+
+def test_sds_client_success_and_failure():
+    session = FakeSession()
+    client = SDSClient(
+        city_name="TestCity",
+        city_id=1,
+        api_port=9100,
+        sds_url="http://example.com",
+        session=session,
+    )
+
+    session.configure(status_code=200)
+    assert client.register_city() is True
+
+    session.configure(status_code=500)
+    assert client.register_city() is False
+
+    session.configure(status_code=200)
+    assert client.send_heartbeat() is True
+
+    session.configure(status_code=500)
+    assert client.send_heartbeat() is False
+
+    session.configure(json_data={"TestCity": {}, "Other": {"city_id": 2}})
+    cities = client.fetch_city_directory()
+    assert "TestCity" not in cities
+    assert "Other" in cities
+
+    session.configure(status_code=500)
+    with pytest.raises(SDSClientError):
+        client.fetch_city_directory()
+
+
+def test_gateway_bootstrapper_controls_initialisation():
+    calls = []
+
+    def initializer():
+        calls.append(True)
+
+    bootstrapper = GatewayBootstrapper(initializer, env={})
+    assert bootstrapper.start_if_enabled() is False
+    assert calls == []
+
+    bootstrapper = GatewayBootstrapper(initializer, env={"SAIVERSE_GATEWAY_ENABLED": "true"})
+    assert bootstrapper.start_if_enabled() is True
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- extract city configuration, history loading, SDS connectivity, and gateway bootstrap responsibilities into dedicated service classes under `saiverse_manager/services`
- convert `saiverse_manager` into a package that injects these services to orchestrate initialization and background work
- add focused unit tests for the new services and document the verified use cases supported by the refactor

## Testing
- pytest tests/test_saiverse_services.py

------
https://chatgpt.com/codex/tasks/task_e_6904a2998e588329aa22692d71754681