### PR TITLE
アイテム・スケジュール・UIまわりの大幅拡充

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,8 @@ python scripts/memory_topics_ui.py
 - Note: On `sea_framework` branch, conversation flow is being migrated to SEA runtime
 
 **SEARuntime** (`sea/runtime.py`)
-- Executes playbooks (workflow graphs) for conversation routing
+- Executes playbooks (workflow graphs) for conversation routing using LangGraph
 - Two meta-playbooks: `meta_user` (handles user input) and `meta_auto` (autonomous pulse)
-- Supports both lightweight fallback executor and LangGraph compilation
 - Playbooks are JSON files in `sea/playbooks/` or stored in DB `playbooks` table
 - **Lightweight model support**: LLM nodes can specify `model_type: "lightweight"` to use a faster, cheaper model for simple tasks (e.g., router decisions)
   - Each persona has two model settings: `DEFAULT_MODEL` (normal) and `LIGHTWEIGHT_MODEL` (optional)
@@ -251,9 +250,9 @@ python scripts/memory_topics_ui.py
 
 ### Branch Context
 - **Current branch**: `sea_framework`
-- **Status**: SEA runtime and playbook system partially integrated, replacing direct `run_pulse()` calls
+- **Status**: SEA runtime and playbook system fully integrated with LangGraph, replacing direct `run_pulse()` calls
 - **Meta playbooks**: `meta_user.json` (user input flow), `meta_auto.json` (autonomous pulse flow)
-- **Pending work**: Full migration of conversation paths to SEA, playbook DB persistence, building-scoped playbooks
+- **Pending work**: Building-scoped playbooks, advanced playbook features
 
 ### Testing
 - Tests use `unittest` framework (pytest also works)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,13 +231,25 @@ python scripts/memory_topics_ui.py
 
 ### Code Changes
 - **Before making changes**: Review recent session reflections in `docs/session_reflection_*.md` to avoid repeating mistakes
+
+- **Debugging mindset (CRITICAL)**:
+  1. **Logs and console output are the PRIMARY source of truth**: Always check terminal logs, browser console, and network tab FIRST before making changes
+  2. **Never guess or assume**: If something doesn't work, identify EXACTLY what doesn't work by checking observable facts (logs, DOM inspection, network requests)
+  3. **One problem at a time**: Don't switch approaches until you understand WHY the current approach failed
+  4. **Ask "What don't I know?"**: If unclear, identify the missing information and how to obtain it (add logging, inspect DOM, check documentation) instead of guessing
+  5. **Avoid speculative fixes**: Don't try multiple approaches hoping one works. Understand the root cause first.
+
 - **When debugging UI issues**:
   1. **Listen carefully**: Pay close attention to what the user is actually doing (e.g., "sidebar button" vs "home screen button")
   2. **Gather observable data first**: Add logging, check terminal output, check browser console BEFORE making changes
   3. **Understand the working case**: If something works in one scenario but not another, investigate the DIFFERENCE, don't assume the cause
   4. **One change at a time**: Make focused changes that can be verified, not multiple speculative fixes
   5. **Verify assumptions**: Don't assume "timing issue" or "selector issue" - confirm with logs
-  6. **Framework behavior**: Understand how the framework works (e.g., Gradio's autoscroll triggers on visibility changes, not just data updates)
+  6. **Use browser DevTools effectively**:
+     - Console: Check for errors, test selectors directly (`document.querySelector('#element')`)
+     - Elements: Inspect actual DOM structure and CSS
+     - Network: Verify request URLs and responses
+  7. **Framework behavior**: Understand how the framework works (e.g., Gradio's autoscroll triggers on visibility changes, not just data updates)
 - **When touching external APIs**: Always check official docs first (especially Gemini structured output limitations)
 - **Playbook modifications**: Validate that `next` node pointers form valid graphs (no accidental loops). After editing JSON files in `sea/playbooks/`, always run `python scripts/import_playbook.py --file <path>` to import the changes into the database
 - **Database changes**: Write migration in `database/migrate.py`, test with `--db-file` on copy first
@@ -276,6 +288,8 @@ python scripts/memory_topics_ui.py
 - **Gemini context window is very large (1M+ tokens)** - Do not assume large context is the cause of errors. Gemini handles 100K+ tokens routinely. The system is designed to work with large conversation histories.
 - **Playbook node transitions**: always verify `next` pointers form valid DAGs
 - **When refactoring**: complete the entire change or revert; do not leave codebase in mixed state
+- **Gradio `visible=False` does NOT add components to DOM**: Components with `visible=False` are not rendered in the HTML. If you need to access them from JavaScript, use `visible=True` with CSS `display: none !important` instead.
+- **Gradio custom API endpoints are unreliable**: Adding custom FastAPI routes via `@demo.app.get()` or `demo.app.add_api_route()` may conflict with Gradio's internal routing. Prefer Gradio's native event system (Button/Textbox + `.click()`) for Python-JavaScript communication.
 - **Gradio SelectData.index type**: Always check for both `list` and `tuple` with `isinstance(idx, (list, tuple))` before accessing `idx[0]`. Gradio returns `list` type (e.g., `[row, col]`), not `tuple`. Missing this check causes silent failures in table selection handlers.
 - **Gradio Chatbot autoscroll**: The `autoscroll=True` parameter works, but only triggers when the component becomes visible after being hidden. If updating data while already visible, autoscroll may not activate. To force autoscroll, temporarily hide the component (add CSS class), update data, then show it again. This visibility transition triggers the autoscroll behavior.
 - **Gradio dynamic inline styles**: When Gradio components apply inline styles via JavaScript after page load, CSS rules (even with `!important`) cannot override them. Solution: Use JavaScript monkey patching to hijack `element.style.setProperty()` and replace values before they're applied. See `docs/session_reflection_2025-12-03_sidebar_detail_panel.md` for detailed example.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,9 @@ python scripts/memory_topics_ui.py
 - **When refactoring**: complete the entire change or revert; do not leave codebase in mixed state
 - **Gradio SelectData.index type**: Always check for both `list` and `tuple` with `isinstance(idx, (list, tuple))` before accessing `idx[0]`. Gradio returns `list` type (e.g., `[row, col]`), not `tuple`. Missing this check causes silent failures in table selection handlers.
 - **Gradio Chatbot autoscroll**: The `autoscroll=True` parameter works, but only triggers when the component becomes visible after being hidden. If updating data while already visible, autoscroll may not activate. To force autoscroll, temporarily hide the component (add CSS class), update data, then show it again. This visibility transition triggers the autoscroll behavior.
+- **Gradio dynamic inline styles**: When Gradio components apply inline styles via JavaScript after page load, CSS rules (even with `!important`) cannot override them. Solution: Use JavaScript monkey patching to hijack `element.style.setProperty()` and replace values before they're applied. See `docs/session_reflection_2025-12-03_sidebar_detail_panel.md` for detailed example.
+- **Asymmetric bugs indicate implementation mismatch**: If a bug occurs in scenario A but not in scenario B (despite similar logic), the cause is usually an implementation difference, not a timing/race condition. Compare code paths side-by-side to find where they diverge.
+- **CSS text wrapping requires multiple layers**: For reliable wrapping of long URLs/strings in CSS, combine: `word-break: break-word`, `overflow-wrap: anywhere`, `max-width: 100%`, and `overflow-x: hidden` on both content and container elements. A single property is often insufficient, especially with frameworks that inject many nested elements.
 
 ## Dependencies
 
@@ -314,6 +317,7 @@ Critical settings (see `.env.example`):
 - `docs/test_manual.md`: manual test scenarios
 - `docs/sea_integration_plan.md`: SEA framework integration roadmap
 - `docs/roadmap.md`: future features
+- `docs/session_reflection_*.md`: lessons learned from development sessions (Gradio UI patterns, debugging approaches, etc.)
 - `README.md`: comprehensive setup and usage guide
 
 ## Quick Reference

--- a/assets/css/chat.css
+++ b/assets/css/chat.css
@@ -7,17 +7,26 @@
 #chat_header {
   position: fixed;
   top: 0;
-  left: 0;
+  left: 240px; /* Left sidebar width */
   height: 1.5rem;
   z-index: 100;
   background: var(--body-background-fill);
   border-bottom: 1px solid var(--border-color-primary);
-  width: 100vw;
+  width: calc(100vw - 240px - 400px); /* Subtract both sidebars */
   margin-left: auto;
   margin-right: auto;
   margin-bottom: auto;
   padding-left: 2rem;
   padding-right: 2rem;
+  transition: left 0.3s ease, width 0.3s ease;
+}
+
+/* Mobile: Force full width */
+@media screen and (max-width: 768px) {
+  #chat_header {
+    left: 0 !important;
+    width: 100vw !important;
+  }
 }
 
 /* チャット欄をスクロール領域として分離 */
@@ -25,6 +34,7 @@
 #chat_scroll_area {
   height: calc(100dvh - var(--composer-h));
   overflow-y: auto;
+  overflow-x: hidden;
   transition: height 0.1s;
   padding-bottom: 5rem !important;
   background: transparent;
@@ -33,19 +43,33 @@
 /* 入力欄を画面下部に固定 */
 #composer_fixed {
   position: fixed;
-  left: 0; right: 0; bottom: 0;
+  left: 240px;
+  right: 400px;
+  bottom: 0;
   z-index: 100;
   background: var(--body-background-fill);
   border-top: 1px solid var(--border-color-primary);
   box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
-  max-width: 700px;
-  margin-left: auto;
-  margin-right: auto;
+  max-width: none; /* Remove fixed width to match chatbot area */
+  width: calc(100vw - 240px - 400px); /* Match available space */
+  margin-left: 0;
+  margin-right: 0;
+  transition: left 0.3s ease, right 0.3s ease, width 0.3s ease;
+}
+
+/* Mobile: Full width */
+@media screen and (max-width: 768px) {
+  #composer_fixed {
+    left: 0 !important;
+    right: 0 !important;
+    width: 100vw !important;
+  }
 }
 body { padding-bottom: 0 !important; }
 
 #my_chat {
   height: 100% !important;
+  overflow-x: hidden !important;
 }
 
 .saiverse-home {
@@ -102,7 +126,11 @@ body { padding-bottom: 0 !important; }
   }
 
   /* Markdown クランプ解除（保険） */
-  #my_chat .prose, #my_chat [class*="prose"] { max-width: none !important; }
+  #my_chat .prose, #my_chat [class*="prose"] {
+    max-width: none !important;
+    word-break: break-word !important;
+    overflow-wrap: anywhere !important;
+  }
 
   /* 長文の折返し */
   #my_chat pre { white-space: pre-wrap !important; word-break: break-word !important; }
@@ -154,9 +182,9 @@ html[data-theme='dark'] {
 .message-header { display: flex !important; align-items: center; gap: 12px; width: 100%; }
 .message-header .speaker-name { font-weight: 600; font-size: 0.95rem; color: var(--msg-fg); }
 .message-block.user .message-header .speaker-name { color: var(--user-fg); }
-.message-block .bubble { padding: 12px 16px; background-color: var(--msg-bg); color: var(--msg-fg) !important; border-radius: 12px; font-size: 1rem !important; overflow-wrap: break-word; max-width: min(640px, 90vw); box-shadow: 0 2px 6px rgba(0,0,0,0.08); display: flex; flex-direction: column; gap: 8px; }
+.message-block .bubble { padding: 12px 16px; background-color: var(--msg-bg); color: var(--msg-fg) !important; border-radius: 12px; font-size: 1rem !important; overflow-wrap: break-word; word-break: break-word; max-width: min(640px, 90vw); box-shadow: 0 2px 6px rgba(0,0,0,0.08); display: flex; flex-direction: column; gap: 8px; overflow: hidden; }
 .message-block.user .bubble { background-color: var(--user-bg); color: var(--user-fg) !important; }
-.message-block .bubble .bubble-content { line-height: 1.6; }
+.message-block .bubble .bubble-content { line-height: 1.6; word-break: break-word; overflow-wrap: anywhere; }
 .message-block .bubble .bubble-meta { font-size: 0.75rem; color: var(--timestamp-fg); align-self: flex-end; white-space: nowrap; }
 .message-block.user { align-items: flex-start; text-align: left; }
 .message-block.user .avatar-top { align-self: flex-start; }
@@ -203,10 +231,34 @@ html[data-theme='dark'] {
   background: transparent !important;
   box-shadow: none !important;
   padding: 0 !important;
+  max-width: 100% !important;
+  overflow: hidden !important;
+  word-break: break-word !important;
+}
+
+/* Chatbot内の全要素に強制的な折り返しを適用 */
+#my_chat,
+#my_chat * {
+  word-break: break-word !important;
+  overflow-wrap: anywhere !important;
+}
+
+#my_chat .message,
+#my_chat .message-wrap {
+  max-width: 100% !important;
+  overflow-x: hidden !important;
+}
+
+/* Markdown/Prose要素の幅制限と折り返し（PC/モバイル共通） */
+#my_chat .prose,
+#my_chat [class*="prose"] {
+  max-width: 100% !important;
+  word-break: break-word !important;
+  overflow-wrap: anywhere !important;
 }
 
 /* Notes */
-.note-box { background: var(--note-bg); color: var(--note-fg) !important; border-left: 4px solid #ffbf00; padding: 8px 12px; margin: 0; border-radius: 6px; font-size: .92rem; }
+.note-box { background: var(--note-bg); color: var(--note-fg) !important; border-left: 4px solid #ffbf00; padding: 8px 12px; margin: 0; border-radius: 6px; font-size: .92rem; word-break: break-word; overflow-wrap: anywhere; }
 .note-box b { color: var(--note-fg) !important; }
 
 .saiverse-move-radio .wrap {
@@ -236,14 +288,16 @@ details.saiv-thinking summary:focus { outline: none; }
 #my_chat .saiv-avatar > img { border-radius: 12px !important; margin: 0 !important; width: 100% !important; height: 100% !important; object-fit: cover !important; display: block !important; clip-path: inset(0 round 12px) !important; }
 #my_chat .saiv-avatar > picture > img { border-radius: 12px !important; margin: 0 !important; clip-path: inset(0 round 12px) !important; }
 
-:global(.saiverse-sidebar.sidebar) {
-  width: 20vw !important;
-}
+/* Left sidebar: 240px */
 :global(.saiverse-sidebar.sidebar):not(.right) {
-  left: calc(-1 * 20vw) !important;
+  width: 240px !important;
+  left: -240px !important;
 }
+
+/* Right sidebar: 400px (wider for long system prompts) */
 :global(.saiverse-sidebar.sidebar).right {
-  right: calc(-1 * 20vw) !important;
+  width: 400px !important;
+  right: -400px !important;
 }
 
 /* Sidebar toggle を押しやすく */
@@ -320,14 +374,14 @@ html[data-theme='dark'] .saiv-image-grid img {
 }
 
 @media (max-width: 768px) {
-  :global(.saiverse-sidebar.sidebar) {
-    width: 60vw !important;
-  }
+  /* Mobile: Left sidebar 60vw, right sidebar hidden by CSS above */
   :global(.saiverse-sidebar.sidebar):not(.right) {
+    width: 60vw !important;
     left: -60vw !important;
   }
   :global(.saiverse-sidebar.sidebar).right {
-    right: -60vw !important;
+    width: 70vw !important;
+    right: -70vw !important;
   }
 }
 
@@ -361,3 +415,32 @@ html[data-theme='dark'] .saiv-image-grid img {
   border-color: #2563eb !important;
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
 }
+
+/* Responsive design for mobile */
+@media screen and (max-width: 768px) {
+  /* Hide right sidebar (detail panel) on mobile */
+  #detail_sidebar {
+    display: none !important;
+  }
+
+  /* Force reset all sidebar adjustments on mobile - highest priority */
+  div.wrap.sidebar-parent[class*="svelte"] {
+    padding-left: 0 !important;
+  }
+
+  body div.wrap.sidebar-parent {
+    padding-left: 0 !important;
+  }
+
+  #chat_header {
+    left: 0 !important;
+    width: 100vw !important;
+  }
+
+  #composer_fixed {
+    left: 0 !important;
+    right: 0 !important;
+  }
+}
+
+/* NOTE: sidebar-parent padding is now handled in main.py HEAD_VIEWPORT to avoid Gradio scoping */

--- a/database/models.py
+++ b/database/models.py
@@ -41,6 +41,8 @@ class AI(Base):
     IS_DISPATCHED = Column(Boolean, default=False, nullable=False)
     DEFAULT_MODEL = Column(String(255), nullable=True)
     LIGHTWEIGHT_MODEL = Column(String(255), nullable=True)
+    LIGHTWEIGHT_VISION_MODEL = Column(String(255), nullable=True)
+    VISION_MODEL = Column(String(255), nullable=True)
     PRIVATE_ROOM_ID = Column(String(255), ForeignKey("building.BUILDINGID"), nullable=True)
     PREVIOUS_INTERACTION_MODE = Column(String(32), default='auto', nullable=False)
 
@@ -157,6 +159,7 @@ class Item(Base):
     NAME = Column(String(255), nullable=False)
     TYPE = Column(String(64), nullable=False, default="object")
     DESCRIPTION = Column(String(2048), default="", nullable=False)
+    FILE_PATH = Column(String(512), nullable=True)
     STATE_JSON = Column(String, nullable=True)
     CREATED_AT = Column(DateTime, server_default=func.now(), nullable=False)
     UPDATED_AT = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/database/models.py
+++ b/database/models.py
@@ -185,3 +185,29 @@ class PersonaEventLog(Base):
     CREATED_AT = Column(DateTime, server_default=func.now(), nullable=False)
     CONTENT = Column(String, nullable=False)
     STATUS = Column(String(32), default="pending", nullable=False)  # pending / archived
+
+
+class PersonaSchedule(Base):
+    __tablename__ = "persona_schedule"
+    SCHEDULE_ID = Column(Integer, primary_key=True, autoincrement=True)
+    PERSONA_ID = Column(String(255), ForeignKey("ai.AIID"), nullable=False)
+    SCHEDULE_TYPE = Column(String(32), nullable=False)  # "periodic", "oneshot", "interval"
+    META_PLAYBOOK = Column(String(255), nullable=False)  # メタプレイブック名
+    ENABLED = Column(Boolean, default=True, nullable=False)
+    DESCRIPTION = Column(String(512), default="", nullable=False)
+    PRIORITY = Column(Integer, default=0, nullable=False)  # 優先度（大きいほど優先）
+
+    # 定期スケジュール用 (periodic)
+    DAYS_OF_WEEK = Column(String(255), nullable=True)  # JSON: [0,1,2,3,4,5,6] or null (毎日)
+    TIME_OF_DAY = Column(String(8), nullable=True)  # "09:00" 形式
+
+    # 単発スケジュール用 (oneshot)
+    SCHEDULED_DATETIME = Column(DateTime, nullable=True)
+    COMPLETED = Column(Boolean, default=False, nullable=False)
+
+    # 恒常スケジュール用 (interval)
+    INTERVAL_SECONDS = Column(Integer, nullable=True)
+    LAST_EXECUTED_AT = Column(DateTime, nullable=True)
+
+    CREATED_AT = Column(DateTime, server_default=func.now(), nullable=False)
+    UPDATED_AT = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/database/models.py
+++ b/database/models.py
@@ -138,6 +138,7 @@ class Playbook(Base):
     schema_json = Column(Text, nullable=False)
     nodes_json = Column(Text, nullable=False)
     router_callable = Column(Boolean, nullable=False, default=False)  # Can be called from router
+    user_selectable = Column(Boolean, nullable=False, default=False)  # Can be selected by user in UI
     created_at = Column(DateTime, server_default=func.now(), nullable=False)
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/docs/session_reflection_2025-12-03_sidebar_detail_panel.md
+++ b/docs/session_reflection_2025-12-03_sidebar_detail_panel.md
@@ -1,0 +1,287 @@
+# セッション振り返り: サイドバー詳細パネルUI実装 (2025-12-03)
+
+## セッション概要
+
+左サイドバー（ナビゲーション）と右サイドバー（詳細パネル）を実装し、SAIVerseの視認性・操作性・拡張性を大幅に向上させた長期セッション（compact 4回実施）。
+
+**主要な成果**:
+- ✅ 左サイドバー: 240px、ナビゲーション用
+- ✅ 右サイドバー: 400px、Building/ペルソナ/実行状態の詳細パネル（Accordion形式）
+- ✅ PC: 両サイドバー初期表示、中央にチャット領域
+- ✅ モバイル: 両サイドバー初期非表示、スワイプジェスチャーで開閉
+- ✅ レスポンシブ対応、横スクロール防止、長文URL自動折り返し
+
+---
+
+## 🔴 最重要教訓: Gradioの動的インラインスタイル問題
+
+### 問題の本質
+
+**現象**: CSSファイルにサイドバー幅（340px → 240px、右400px）を書いているのに、ブラウザに反映されない。DevToolsで確認すると、CSSルールに打ち消し線が表示され、`element.style` に `width: 20vw !important; left: calc(-20vw) !important;` がインライン適用されている。
+
+**原因**:
+1. **Gradio 5.38.0 の Sidebar コンポーネントは、ページロード後にJavaScriptでインラインスタイルを動的に設定する**
+2. **インラインスタイル（`element.style`）はCSSファイルのルールより優先度が高い**
+3. **`!important` を使っても、インラインスタイルには勝てない**（インライン側も `!important` が付いている）
+
+### 失敗した解決策
+
+1. **CSS `:global()` セレクター**: Gradio のスコープ付きCSSを回避しようとしたが、結局インラインスタイルに負ける
+2. **HEAD_VIEWPORT の inline CSS**: ブラウザには届くが、やはりインラインスタイルに上書きされる
+3. **JavaScript `removeProperty()`**: 一度削除しても、Gradio が即座に再適用してくる
+4. **MutationObserver で監視・修正**: Gradio との無限ループになり、パフォーマンス悪化
+
+### ✅ 成功した解決策: `setProperty` ハイジャック
+
+**戦略**: Gradio がインラインスタイルを設定する**前に**横取りして、値を置き換える。
+
+**実装** (`/home/maha/SAIVerse/ui/app.py`):
+
+```javascript
+function hijackSidebarStyles() {
+    const leftSidebar = document.querySelector('.sidebar.saiverse-sidebar:not(.right)');
+    const rightSidebar = document.querySelector('.sidebar.saiverse-sidebar.right');
+
+    if (leftSidebar) {
+        const leftStyle = leftSidebar.style;
+        const originalLeftSet = leftStyle.setProperty.bind(leftStyle);
+
+        // setProperty をオーバーライド
+        leftStyle.setProperty = function(prop, value, priority) {
+            if (prop === 'width' && value === '20vw') {
+                console.log('[SAIVerse] Intercepted left width 20vw -> 240px');
+                return originalLeftSet('width', '240px', priority);
+            }
+            if (prop === 'left' && value.includes('20vw')) {
+                console.log('[SAIVerse] Intercepted left position calc(-20vw) -> -240px');
+                return originalLeftSet('left', '-240px', priority);
+            }
+            return originalLeftSet(prop, value, priority);
+        };
+
+        // 初期値も設定
+        leftStyle.setProperty('width', '240px', 'important');
+        leftStyle.setProperty('left', '-240px', 'important');
+    }
+
+    // 右サイドバーも同様に 400px に設定
+    if (rightSidebar) { /* ... */ }
+}
+```
+
+**ポイント**:
+- `CSSStyleDeclaration.setProperty` メソッド自体を上書き
+- Gradio が `setProperty('width', '20vw')` を呼ぶと、横取りして `setProperty('width', '240px')` に置き換える
+- 元の関数は `originalLeftSet` として保存し、他のプロパティは通常通り処理
+- ページロード時に1回実行すれば、以降すべての動的スタイル変更に適用される
+
+### 教訓まとめ
+
+| 手法 | 効果 | 理由 |
+|------|------|------|
+| CSS `:global()` | ❌ | インラインスタイルに負ける |
+| `!important` in CSS | ❌ | インライン側も `!important` 付き |
+| `removeProperty()` | ❌ | Gradio が再適用 |
+| MutationObserver | ❌ | 無限ループ |
+| **`setProperty` hijack** | ✅ | **設定される前に値を置換** |
+
+**一般化**: **フレームワークが動的にインラインスタイルを適用する場合、CSSだけでは勝てない。JavaScript API レベルで横取り（monkey patching）するのが最終手段。**
+
+---
+
+## 教訓2: ジェスチャーハンドラーの状態管理
+
+### 問題
+
+**現象**: 左サイドバーが開いている状態で左スワイプすると、左が閉じると同時に右が開く無限ループ。しかし、右が開いている状態で右スワイプすると、右が正しく閉じるだけ。
+
+**原因の誤診**: 最初「タッチのタイミング問題」と考え、`touchstart` で状態をキャプチャする実装を追加した。しかし、**左だけ問題が起きて右は正常**という非対称性が説明できない。
+
+### 論理的な気づき
+
+ユーザーからの指摘:
+> 「もしタイミングの問題だったら、右でも同じことが起きるはずでしょ？でも実際はそうじゃない、右が開いてるときはちゃんと閉じるだけになってるんだよ。」
+
+**真の原因**:
+- **左ハンドラー**: `touchstart` 時の状態をキャプチャして使用（修正済み）
+- **右ハンドラー**: `touchend` 時の**現在の状態**をチェック（未修正）
+
+**何が起きていたか**:
+1. 左が開いている状態で左スワイプ
+2. **左ハンドラー**が先に実行: `leftWasOpenAtStart === true` なので左を閉じる
+3. **右ハンドラー**が後に実行: **この時点で両方閉じている**のを見て、「両方閉じてる + 左スワイプ = 右を開く」判定が成立
+4. 結果: 左が閉じると同時に右が開く
+
+**解決策**: 右ハンドラーも `touchstart` 時に状態をキャプチャするように統一。
+
+```javascript
+let rightWasOpenAtStart = false;
+let leftWasOpenAtStart = false;
+
+const handleTouchStart = (e) => {
+    // タッチ開始時に状態を記録
+    rightWasOpenAtStart = rightSidebar.classList.contains("open");
+    leftWasOpenAtStart = leftSidebar && leftSidebar.classList.contains("open");
+};
+
+const handleTouchEnd = (e) => {
+    // キャプチャした状態を使用（現在の状態ではなく）
+    if (!rightWasOpenAtStart && !leftWasOpenAtStart && isSwipingLeft ...) {
+        rightSidebar.classList.add("open");
+    }
+    else if (rightWasOpenAtStart && isSwipingRight ...) {
+        rightSidebar.classList.remove("open");
+    }
+};
+```
+
+### 教訓
+
+**非対称な不具合は実装の不一致が原因**: 「Aでは起きるがBでは起きない」という現象は、タイミングやレースコンディションではなく、**実装パターンの違い**を疑うべき。
+
+**デバッグのヒント**:
+- 「同じ処理のはずなのに片方だけおかしい」→ コードを並べて比較
+- 「なぜこちらは正常？」を考えると、逆に問題側の原因が見える
+
+---
+
+## 教訓3: 長文URL/文字列の折り返し制御
+
+### 問題
+
+一部のBuildingで、長い画像URL（例: `saiverse/image/20251113_001642_4Sc4Bb77e2a149f79e8c7c25c3858c42.png`）がバブルの幅を超えて、横スクロールバーが出現。
+
+### 原因
+
+- `overflow-wrap: break-word` だけでは不十分
+- Markdownのproseクラスや、Gradio内部の要素に幅制限がない
+- `#my_chat` 自体に `overflow-x: hidden` がない
+
+### 解決策（多層防御）
+
+```css
+/* 1. バブル本体 */
+.message-block .bubble {
+  overflow-wrap: break-word;
+  word-break: break-word;  /* 追加: 長い単語を強制折り返し */
+  overflow: hidden;        /* 追加: はみ出し防止 */
+  max-width: min(640px, 90vw);
+}
+
+/* 2. バブル内容 */
+.message-block .bubble .bubble-content {
+  word-break: break-word;
+  overflow-wrap: anywhere;  /* より柔軟な折り返し */
+}
+
+/* 3. Chatbot全体に強制適用 */
+#my_chat,
+#my_chat * {
+  word-break: break-word !important;
+  overflow-wrap: anywhere !important;
+}
+
+/* 4. コンテナの横スクロール防止 */
+#my_chat {
+  overflow-x: hidden !important;
+}
+
+#chat_scroll_area {
+  overflow-x: hidden;
+}
+
+/* 5. Markdown/Prose要素 */
+#my_chat .prose,
+#my_chat [class*="prose"] {
+  max-width: 100% !important;
+  word-break: break-word !important;
+  overflow-wrap: anywhere !important;
+}
+```
+
+### 教訓
+
+**CSSの折り返し設定は多層防御が必要**:
+- `overflow-wrap: break-word` だけでは不十分（古いブラウザ対策）
+- `word-break: break-word` を併用（強制折り返し）
+- `overflow-wrap: anywhere` でさらに柔軟に
+- コンテナに `overflow-x: hidden` で最終防衛線
+- `max-width: 100%` で親を超えないように制限
+
+**フレームワーク利用時の注意**: Gradio などのフレームワークは内部で多くの要素を生成するため、**ユニバーサルセレクター (`*`) で全子要素に適用**するのが確実。
+
+---
+
+## ファイル変更履歴
+
+### `/home/maha/SAIVerse/ui/app.py`
+- 左サイドバー: 340px → 240px に変更
+- 右サイドバー: Tabs → Accordion に変更（全セクションopen=True）
+- `hijackSidebarStyles()` 関数追加（setProperty ハイジャック）
+- 左右のスワイプジェスチャーハンドラー実装
+- 状態キャプチャ（`leftWasOpenAtStart`, `rightWasOpenAtStart`）
+- PC: 両サイドバー初期表示、モバイル: 両方非表示
+- 詳細パネル更新処理を全UIイベントに追加（move, summon, refresh など）
+
+### `/home/maha/SAIVerse/main.py`
+- `HEAD_VIEWPORT` の CSS を更新（240px/400px）
+- PC版でのパディング調整（`padding-left: 240px; padding-right: 400px;`）
+
+### `/home/maha/SAIVerse/assets/css/chat.css`
+- ヘッダー幅: `width: calc(100vw - 240px - 400px);`
+- Composer幅: 固定700px → `calc(100vw - 240px - 400px)` に変更
+- サイドバー幅: 240px（左）、400px（右）
+- モバイル: 左60vw、右70vw
+- バブル・Markdown・prose要素に `word-break: break-word` と `overflow-wrap: anywhere` 追加
+- `#my_chat` と `#chat_scroll_area` に `overflow-x: hidden` 追加
+- 多層防御で横スクロール完全防止
+
+### `/home/maha/SAIVerse/ui/chat.py`
+- `manager.item_registry` → `manager.items` に修正（AttributeError 対応）
+
+---
+
+## 次回以降への提言
+
+### デバッグ時の心構え
+
+1. **観察可能なデータを先に集める**:
+   - ログ追加、ターミナル出力確認、ブラウザコンソール確認
+   - **推測で修正しない**
+
+2. **動いているケースを理解する**:
+   - 「なぜAは失敗してBは成功？」→ **差分**を調べる
+   - 非対称な不具合は実装の不一致が原因
+
+3. **フレームワークの挙動を理解する**:
+   - Gradio の Sidebar が動的にインラインスタイルを設定することを知らなかった
+   - 公式ドキュメント + DevTools で挙動を確認
+
+4. **一度に一つの変更**:
+   - 複数の推測的修正を同時に入れない
+   - 検証可能な単位で変更
+
+### CSS/JavaScript の知識
+
+- **CSS優先度**: インラインスタイル > `!important` in CSS
+- **JavaScript monkey patching**: フレームワークのメソッドを上書きする最終手段
+- **状態管理**: イベントハンドラーは状態を**いつ**読むかが重要（touchstart vs touchend）
+- **折り返し**: `overflow-wrap`, `word-break`, `overflow` の組み合わせが必要
+
+### ドキュメント更新
+
+- `CLAUDE.md` の「Common Pitfalls」に追加:
+  - **Gradio 動的インラインスタイル問題と setProperty hijack パターン**
+  - **ジェスチャーハンドラーの状態キャプチャパターン**
+  - **長文折り返しの多層防御パターン**
+
+---
+
+## 成果
+
+- 🎉 **視認性**: 左右サイドバーで画面が整理され、中央のチャットが見やすくなった
+- 🎉 **操作性**: モバイルでのジェスチャー操作、PCでの常時表示で使いやすさ向上
+- 🎉 **拡張性**: 右パネルで Building/ペルソナ/実行状態を表示、今後の情報追加も容易
+- 🎉 **堅牢性**: 横スクロール完全防止、長文URL自動折り返し
+
+**compact 4回を挟む長期セッションだったが、大きな成果を得られた。**

--- a/docs/session_reflection_2025-12-06_item_modal_implementation.md
+++ b/docs/session_reflection_2025-12-06_item_modal_implementation.md
@@ -1,0 +1,296 @@
+# セッション振り返り: アイテムモーダル実装 (2025-12-06)
+
+## 実装した機能
+
+右サイドバーのアイテム表示で、document/pictureタイプのアイテムをクリックするとモーダルが開き、ファイルの内容（テキストまたは画像）を表示する機能。
+
+## 遭遇した問題と解決の経緯
+
+### 問題1: JavaScriptが実行されない
+
+**症状:**
+- `ITEM_MODAL_JS`をGradioに注入したが、ブラウザコンソールにログが一切出ない
+- モーダルのクリックイベントも発火しない
+
+**試したアプローチ:**
+1. `gr.HTML(f"<script>{ITEM_MODAL_JS}</script>", visible=False)` → 失敗（スクリプトがDOMに追加されない）
+2. `js_auto_refresh`と単純に文字列連結 → 構文エラー（2つのアロー関数を連結できない）
+
+**解決策:**
+- `demo.load(None, None, None, js=ITEM_MODAL_JS)`で別々に実行
+- `ITEM_MODAL_JS`を`() => { ... }`のアロー関数形式にする
+
+**学び:**
+- Gradioの`demo.load()`の`js`パラメータはアロー関数形式`() => { ... }`が必須
+- `visible=False`のコンポーネントはDOMに追加されない
+
+---
+
+### 問題2: カスタムAPIエンドポイントが404を返す
+
+**症状:**
+- `/api/item/view`エンドポイントをFastAPIに登録
+- `demo.app.routes`のリストには表示される
+- しかし実際にリクエストすると404が返る
+- エンドポイント関数が一度も呼ばれない（ログが出ない）
+
+**試したアプローチ:**
+1. `@demo.app.get("/api/item/view")`デコレータ → 404
+2. `demo.app.add_api_route()`メソッド → 404
+3. Blocksコンテキストの外で登録 → 404
+4. `gr.api(api_name="item_view")`（公式方法） → `/api/call/item_view`も404
+
+**判明したこと:**
+- カスタムエンドポイントはルートリストに表示されるが、Gradioの内部ルーティングで何かがブロックしている
+- Gradioのミドルウェアが先にリクエストを処理してしまう可能性
+
+**最終的な解決策:**
+- カスタムAPIエンドポイントを諦める
+- **Gradioのネイティブイベントシステム**（Button + Textbox + `.click()`）を使用
+
+---
+
+### 問題3: `visible=False`のコンポーネントがDOMに存在しない
+
+**症状:**
+```javascript
+const inputElem = document.querySelector('#item_id_input textarea'); // null
+```
+
+**原因:**
+- `gr.Textbox(visible=False, elem_id="item_id_input")`はDOMに追加されない
+- JavaScriptから参照できない
+
+**解決策:**
+```python
+# visible=True にしてCSSで非表示
+with gr.Row(elem_classes=["hidden-api-components"], visible=True):
+    item_view_button = gr.Button("API", elem_id="item_view_button", visible=True)
+    item_id_hidden = gr.Textbox(label="item_id", elem_id="item_id_hidden", visible=True)
+    result_hidden = gr.Textbox(label="result", elem_id="result_hidden", visible=True)
+```
+
+```css
+.hidden-api-components {
+    display: none !important;
+}
+```
+
+**学び:**
+- **Gradioで`visible=False`のコンポーネントはDOMに追加されない**
+- JavaScriptからアクセスしたい場合は`visible=True` + CSSで非表示にする
+
+---
+
+### 問題4: セレクタのミス
+
+**症状:**
+```javascript
+const button = document.querySelector('#item_view_button button'); // null
+```
+
+**ログから判明した事実:**
+```
+Looking for container: <button class="lg secondary svelte-1ixn6qd" id="item_view_button">...</button>
+```
+
+→ `#item_view_button`は`<button>`要素そのもの（子要素ではない）
+
+**原因:**
+- `#item_view_button button`は「`#item_view_button`の子要素の`<button>`」を探す
+- しかし`#item_view_button`自体が`<button>`なので、子要素は存在しない
+
+**解決策:**
+```javascript
+const button = document.querySelector('#item_view_button'); // 正しい
+```
+
+**学び:**
+- **ログに書かれている事実を最優先で確認する**
+- 推測で実装せず、実際のDOM構造を見る
+
+---
+
+## 最終的な実装
+
+### Python側 (ui/app.py)
+
+```python
+# 1. visible=True + CSS非表示でコンポーネント作成
+with gr.Row(elem_classes=["hidden-api-components"], visible=True):
+    item_view_button = gr.Button("API", elem_id="item_view_button", visible=True)
+    item_id_hidden = gr.Textbox(label="item_id", elem_id="item_id_hidden", visible=True)
+    result_hidden = gr.Textbox(label="result", elem_id="result_hidden", visible=True)
+
+# 2. Python関数
+def get_item_content(item_id: str) -> str:
+    # アイテム情報を取得してJSON文字列を返す
+    return json.dumps({"success": True, "content": "..."})
+
+# 3. イベント接続
+item_view_button.click(
+    fn=get_item_content,
+    inputs=[item_id_hidden],
+    outputs=[result_hidden]
+)
+
+# 4. result_hiddenの変更を監視してPromiseを解決
+result_hidden.change(
+    fn=None,
+    inputs=[result_hidden],
+    outputs=None,
+    js="""
+    (result) => {
+        if (window.__item_content_resolver) {
+            window.__item_content_resolver(result);
+            window.__item_content_resolver = null;
+        }
+        return null;
+    }
+    """
+)
+
+# 5. グローバル関数を作成
+demo.load(None, None, None, js="""
+() => {
+    window.get_item_content_js = async function(item_id) {
+        const button = document.querySelector('#item_view_button');
+        const itemIdInput = document.querySelector('#item_id_hidden textarea');
+
+        itemIdInput.value = item_id;
+        itemIdInput.dispatchEvent(new Event('input', {bubbles: true}));
+
+        return new Promise((resolve) => {
+            window.__item_content_resolver = resolve;
+            setTimeout(() => button.click(), 50);
+        });
+    };
+}
+""")
+```
+
+### JavaScript側 (ui/item_modal.py)
+
+```javascript
+// モーダル表示関数内
+window.get_item_content_js(itemId).then(result => {
+    const data = JSON.parse(result);
+    if (data.success) {
+        // コンテンツを表示
+        if (itemType === 'document') {
+            contentHtml += `<pre>${data.content}</pre>`;
+        } else if (itemType === 'picture') {
+            contentHtml += `<img src="/gradio_api/file=${data.file_path}" />`;
+        }
+        body.innerHTML = contentHtml;
+    }
+});
+```
+
+### 仕組み
+
+1. JavaScriptから`window.get_item_content_js(item_id)`を呼ぶ
+2. 非表示のTextbox (`item_id_hidden`)にitem_idをセット
+3. 非表示のButton (`item_view_button`)をクリック
+4. Python関数`get_item_content()`が実行される
+5. 結果が`result_hidden`に設定される
+6. `result_hidden.change`イベントでPromiseを解決
+7. JavaScriptが結果を受け取り、モーダルに表示
+
+---
+
+## 重要な学び
+
+### 1. Gradioでカスタムエンドポイントは避ける
+
+- FastAPIのカスタムエンドポイントはGradioのルーティングと競合する
+- Gradioのネイティブイベントシステム（Button/Textbox + .click()）を使うべき
+
+### 2. visible=Falseの挙動
+
+- **`visible=False`のコンポーネントはDOMに追加されない**
+- JavaScriptからアクセスする場合は`visible=True` + CSSで非表示
+
+### 3. デバッグのアプローチ
+
+**❌ 悪い例:**
+1. 推測で「これが原因かも」と判断
+2. 別のアプローチを試す
+3. 失敗したらまた別のアプローチ
+4. 無限ループ
+
+**✅ 良い例:**
+1. **ログ・コンソール出力を最優先で確認**
+2. 「何が分からないか」を明確にする
+3. 分かるようにするための調査（DOM確認、ネットワークタブ、公式ドキュメント）
+4. 事実に基づいて実装
+
+### 4. 具体的なデバッグ手順
+
+#### JavaScriptが実行されない場合:
+```javascript
+// 1. スクリプトがロードされているか確認
+console.log('Script loaded!'); // 最初の行に追加
+
+// 2. 関数が定義されているか確認
+console.log('Function exists:', typeof window.myFunction);
+
+// 3. DOM要素が存在するか確認
+console.log('Element:', document.querySelector('#my-element'));
+```
+
+#### APIエンドポイントが404の場合:
+```python
+# 1. ルートリストに含まれているか確認
+for route in demo.app.routes:
+    LOGGER.info(f"Route: {route.path}")
+
+# 2. 関数が呼ばれているか確認（関数の最初の行）
+LOGGER.info("[API] ===== FUNCTION CALLED =====")
+
+# 3. ブラウザのネットワークタブで実際のリクエストURLを確認
+```
+
+#### DOM要素が見つからない場合:
+```javascript
+// 1. ブラウザの開発者ツールで要素を検査
+// 2. コンソールで直接セレクタを試す
+document.querySelector('#my-element')
+
+// 3. 親要素から確認
+document.querySelector('#parent')
+document.querySelector('#parent #child')
+```
+
+---
+
+## 今後の改善点
+
+1. **ログを最優先で見る習慣**
+   - エラーメッセージやコンソール出力に書かれている事実を最初に確認
+   - 推測は最小限にする
+
+2. **一つの問題に集中する**
+   - 「動かない」を分解: JS実行？DOM存在？関数呼び出し？
+   - 一つずつ確認してから次へ
+
+3. **公式ドキュメントを先に読む**
+   - Gradioの仕様が分からない場合、試行錯誤より先にドキュメント確認
+   - claude-code-guideエージェントを活用
+
+4. **ブラウザ開発者ツールの活用**
+   - コンソール（ログ、エラー、直接実行）
+   - 要素検査（DOM構造、CSS）
+   - ネットワークタブ（リクエスト/レスポンス）
+
+---
+
+## まとめ
+
+今回の実装で最も重要だったのは、「推測ではなく事実に基づいてデバッグする」ことでした。
+
+特にセレクタの問題では、ログに`<button id="item_view_button">`と明確に表示されていたにも関わらず、それを見ずに`'#item_view_button button'`というセレクタを使ってしまいました。
+
+**ログに書かれている事実を最優先で確認し、推測を最小限にする**
+
+これが今回の最大の学びです。

--- a/llm_clients/anthropic.py
+++ b/llm_clients/anthropic.py
@@ -27,7 +27,10 @@ class AnthropicClient(OpenAIClient):
         if not base_url.endswith("/"):
             base_url = f"{base_url}/"
 
-        super().__init__(model=model, supports_images=supports_images, api_key=api_key, base_url=base_url)
+        # Anthropic has a 5MB limit for images
+        max_image_bytes = 5 * 1024 * 1024
+
+        super().__init__(model=model, supports_images=supports_images, api_key=api_key, base_url=base_url, max_image_bytes=max_image_bytes)
 
         cfg = config or {}
 

--- a/llm_clients/base.py
+++ b/llm_clients/base.py
@@ -50,6 +50,22 @@ class LLMClient:
     ) -> Iterator[str]:
         raise NotImplementedError
 
+    def generate_with_tool_detection(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: List[Any] | None = None,
+        *,
+        temperature: float | None = None,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        """Generate response with tool call detection (do not execute tools).
+
+        Returns:
+            {"type": "text", "content": str} if no tool call
+            {"type": "tool_call", "tool_name": str, "tool_args": dict} if tool call detected
+        """
+        raise NotImplementedError
+
     def _store_reasoning(self, entries: List[Dict[str, str]] | None) -> None:
         self._latest_reasoning = entries or []
 

--- a/llm_clients/nvidia_nim.py
+++ b/llm_clients/nvidia_nim.py
@@ -1,0 +1,217 @@
+"""NVIDIA NIM client - OpenAI-compatible but with custom structured output."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from .openai import OpenAIClient
+
+
+class NvidiaNIMClient(OpenAIClient):
+    """
+    Client for NVIDIA NIM APIs.
+
+    Nvidia NIM is OpenAI-compatible for most operations, but Mistral models
+    don't support guided_json or response_format for structured output.
+
+    Workaround for structured output:
+    - Define the output schema as a "dummy tool"
+    - Force the model to call that tool via tool_choice
+    - Extract the tool arguments as the structured output
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        supports_images: bool = False,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_key_env: Optional[str] = None,
+        request_kwargs: Optional[Dict[str, Any]] = None,
+        max_image_bytes: Optional[int] = None,
+        convert_system_to_user: bool = False,
+    ) -> None:
+        # Nvidia NIM doesn't need structured_output_backend parameter
+        super().__init__(
+            model=model,
+            supports_images=supports_images,
+            api_key=api_key,
+            base_url=base_url,
+            api_key_env=api_key_env,
+            request_kwargs=request_kwargs,
+            max_image_bytes=max_image_bytes,
+            convert_system_to_user=convert_system_to_user,
+            structured_output_backend=None,  # Not used for NIM
+        )
+        self._nim_base_url = base_url or "https://integrate.api.nvidia.com/v1"
+        self._nim_api_key = api_key
+        # Get API key from environment if not provided directly
+        if not self._nim_api_key and api_key_env:
+            import os
+            self._nim_api_key = os.environ.get(api_key_env)
+
+    def _create_nim_structured_output_via_tool(
+        self,
+        messages: List[Dict[str, Any]],
+        response_schema: Dict[str, Any],
+        temperature: Optional[float],
+    ) -> str:
+        """
+        Get structured output from Nvidia NIM using forced function calling.
+
+        Since Mistral models on Nvidia NIM don't support guided_json or response_format
+        for structured output, we use a workaround:
+        1. Define the output schema as a "dummy tool"
+        2. Force the model to call that tool via tool_choice
+        3. Extract the tool arguments as the structured output
+
+        Returns the JSON string of the structured output.
+        """
+        import httpx
+
+        url = f"{self._nim_base_url}/chat/completions"
+
+        # Create a dummy tool from the response schema
+        dummy_tool = {
+            "type": "function",
+            "function": {
+                "name": "_structured_output",
+                "description": "Output the response in the required structured format. You MUST call this function with the appropriate arguments.",
+                "parameters": self._add_additional_properties(response_schema),
+            }
+        }
+
+        # Build request body
+        body: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "n": 1,
+            "tools": [dummy_tool],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "_structured_output"}
+            },
+        }
+
+        # Add temperature from request_kwargs or parameter
+        if temperature is not None:
+            body["temperature"] = temperature
+        elif "temperature" in self._request_kwargs:
+            body["temperature"] = self._request_kwargs["temperature"]
+
+        # Add top_p if present
+        if "top_p" in self._request_kwargs:
+            body["top_p"] = self._request_kwargs["top_p"]
+
+        # Add max_tokens if present
+        if "max_tokens" in self._request_kwargs:
+            body["max_tokens"] = self._request_kwargs["max_tokens"]
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._nim_api_key}",
+        }
+
+        logging.info("Using forced function calling for structured output (tool: _structured_output)")
+        logging.debug("NIM structured output schema: %s", dummy_tool["function"]["parameters"])
+
+        with httpx.Client(timeout=120.0) as client:
+            response = client.post(url, json=body, headers=headers)
+            response.raise_for_status()
+            resp_json = response.json()
+
+        from .base import raw_logger
+        raw_logger.debug("Nvidia NIM raw:\n%s", json.dumps(resp_json, indent=2, ensure_ascii=False))
+
+        # Extract tool call arguments
+        choices = resp_json.get("choices", [])
+        if not choices:
+            logging.error("Nvidia NIM returned no choices")
+            raise ValueError("No choices in response")
+
+        message = choices[0].get("message", {})
+        tool_calls = message.get("tool_calls", [])
+
+        if not tool_calls:
+            # Fallback: if no tool call, try to get content
+            content = message.get("content", "")
+            if content:
+                logging.warning("No tool call in response, falling back to content")
+                return content
+            logging.error("No tool calls and no content in response")
+            raise ValueError("No tool calls in response")
+
+        # Get the arguments from the first tool call
+        first_call = tool_calls[0]
+        function_data = first_call.get("function", {})
+        arguments = function_data.get("arguments", "{}")
+
+        logging.debug("Extracted structured output: %s", arguments)
+        return arguments
+
+    def generate(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[list] | None = None,
+        history_snippets: Optional[List[str]] | None = None,
+        response_schema: Optional[Dict[str, Any]] = None,
+        *,
+        temperature: float | None = None,
+    ) -> str:
+        """
+        Generate response using Nvidia NIM.
+
+        For structured output, uses guided_json in extra_body instead of response_format.
+        """
+        from tools import OPENAI_TOOLS_SPEC, TOOL_REGISTRY
+        from tools.defs import parse_tool_result
+        from .openai import _prepare_openai_messages
+
+        default_tools = OPENAI_TOOLS_SPEC if tools is None else tools
+        if response_schema is not None and tools is None:
+            tools_spec: List[Dict[str, Any]] | list = []
+        else:
+            tools_spec = default_tools
+        use_tools = bool(tools_spec)
+        snippets: List[str] = list(history_snippets or [])
+        self._store_reasoning([])
+
+        if response_schema and use_tools:
+            logging.warning(
+                "response_schema specified alongside tools; structured output is ignored for tool runs."
+            )
+            response_schema = None
+
+        # For non-tool calls with response_schema, use forced function calling
+        # to get structured output (workaround for Mistral models on Nvidia NIM)
+        if not use_tools and response_schema:
+            try:
+                prepared_messages = _prepare_openai_messages(
+                    messages, self.supports_images, self.max_image_bytes, self.convert_system_to_user
+                )
+                # Use forced function calling to get structured output
+                text_body = self._create_nim_structured_output_via_tool(
+                    messages=prepared_messages,
+                    response_schema=response_schema,
+                    temperature=temperature,
+                )
+            except Exception:
+                logging.exception("Nvidia NIM structured output call failed")
+                return "エラーが発生しました。"
+
+            self._store_reasoning([])
+            if snippets:
+                prefix = "\n".join(snippets)
+                return prefix + ("\n" if text_body and prefix else "") + text_body
+            return text_body
+
+        # For tool calls or non-structured output, use parent OpenAI implementation
+        return super().generate(
+            messages=messages,
+            tools=tools,
+            history_snippets=history_snippets,
+            response_schema=response_schema,
+            temperature=temperature,
+        )

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover - optional dependency
 from saiverse_manager import SAIVerseManager
 from database.paths import default_db_path
 from database.backup import run_startup_backup
-from model_configs import get_model_choices
+from model_configs import get_model_choices, get_model_choices_with_display_names
 from ui import state as ui_state
 from ui.app import build_app
 try:
@@ -42,7 +42,12 @@ try:
 except ValueError:
     _chat_limit_env = 120
 CHAT_HISTORY_LIMIT = max(0, _chat_limit_env)
-MODEL_CHOICES = ["None"] + get_model_choices()
+# Build model choices with display names for UI dropdowns
+# Format: [(display_name, model_id), ...] - Gradio uses (label, value) order
+_model_choices_raw = get_model_choices_with_display_names()
+MODEL_CHOICES = [("None", "None")] + [(display_name, model_id) for model_id, display_name in _model_choices_raw]
+logging.info("Loaded %d model choices with display names", len(MODEL_CHOICES))
+logging.debug("Sample model choices: %s", MODEL_CHOICES[:5])
 
 VERSION = time.strftime("%Y%m%d%H%M%S")  # 例: 20251008121530
 

--- a/main.py
+++ b/main.py
@@ -46,7 +46,46 @@ MODEL_CHOICES = ["None"] + get_model_choices()
 
 VERSION = time.strftime("%Y%m%d%H%M%S")  # 例: 20251008121530
 
-HEAD_VIEWPORT = '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">'
+HEAD_VIEWPORT = '''<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<style>
+/* Critical CSS: Override Gradio sidebar padding and width without scoping */
+div.wrap.sidebar-parent[style] {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+/* Left sidebar width */
+.sidebar.saiverse-sidebar:not(.right) {
+  width: 240px !important;
+  left: -240px !important;
+}
+
+/* Right sidebar width */
+.sidebar.saiverse-sidebar.right {
+  width: 400px !important;
+  right: -400px !important;
+}
+
+@media screen and (min-width: 769px) {
+  div.wrap.sidebar-parent[style] {
+    padding-left: 240px !important;
+    padding-right: 400px !important;
+    transition: padding-left 0.3s ease, padding-right 0.3s ease;
+  }
+}
+
+/* Mobile sidebar widths */
+@media (max-width: 768px) {
+  .sidebar.saiverse-sidebar:not(.right) {
+    width: 60vw !important;
+    left: -60vw !important;
+  }
+  .sidebar.saiverse-sidebar.right {
+    width: 70vw !important;
+    right: -70vw !important;
+  }
+}
+</style>'''
 
 
 CSS_PATH = Path("assets/css/chat.css")

--- a/manager/blueprints.py
+++ b/manager/blueprints.py
@@ -17,6 +17,7 @@ from database.models import (
 )
 from persona_core import PersonaCore
 from buildings import Building
+from model_configs import get_context_length, get_model_provider
 
 
 class BlueprintMixin:
@@ -264,6 +265,10 @@ class BlueprintMixin:
                 self.building_histories[private_room_id] = []
 
             if blueprint.CITYID == self.city_id:
+                blueprint_model = self.model
+                blueprint_provider = get_model_provider(blueprint_model)  # Get provider for model
+                blueprint_context_length = get_context_length(blueprint_model)
+
                 new_persona_core = PersonaCore(
                     city_name=self.city_name,
                     persona_id=new_ai_id,
@@ -282,10 +287,10 @@ class BlueprintMixin:
                     create_persona_callback=self._create_persona,
                 session_factory=self.SessionLocal,
                 start_building_id=target_building_id,
-                model=self.model,
-                context_length=self.context_length,
+                model=blueprint_model,
+                context_length=blueprint_context_length,
                 user_room_id=self.user_room_id,
-                provider=self.provider,
+                provider=blueprint_provider,  # Use provider for model
                 is_dispatched=False,
                 timezone_info=self.timezone_info,
                 timezone_name=self.timezone_name,

--- a/manager/persona.py
+++ b/manager/persona.py
@@ -17,7 +17,7 @@ from database.models import (
     BuildingToolLink,
 )
 from persona_core import PersonaCore
-from model_configs import get_context_length
+from model_configs import get_context_length, get_model_provider
 
 
 class PersonaMixin:
@@ -105,6 +105,7 @@ class PersonaMixin:
 
                 persona_model = db_ai.DEFAULT_MODEL or self.model
                 persona_context_length = get_context_length(persona_model)
+                persona_provider = get_model_provider(persona_model)  # Get provider for persona's model
                 persona_lightweight_model = db_ai.LIGHTWEIGHT_MODEL
 
                 persona = PersonaCore(
@@ -129,7 +130,7 @@ class PersonaMixin:
                     lightweight_model=persona_lightweight_model,
                     context_length=persona_context_length,
                     user_room_id=self.user_room_id,
-                    provider=self.provider,
+                    provider=persona_provider,  # Use provider for persona's model
                     interaction_mode=(db_ai.INTERACTION_MODE or "auto"),
                     is_dispatched=db_ai.IS_DISPATCHED,
                     timezone_info=self.timezone_info,
@@ -282,6 +283,10 @@ class PersonaMixin:
             )
             self.building_histories[new_building_id] = []
 
+            new_persona_model = self.model
+            new_persona_provider = get_model_provider(new_persona_model)  # Get provider for model
+            new_persona_context_length = get_context_length(new_persona_model)
+
             new_persona_core = PersonaCore(
                 city_name=self.city_name,
                 persona_id=new_ai_id,
@@ -300,11 +305,11 @@ class PersonaMixin:
                 create_persona_callback=self._create_persona,
                 session_factory=self.SessionLocal,
                 start_building_id=new_building_id,
-                model=self.model,
+                model=new_persona_model,
                 lightweight_model=None,
-                context_length=self.context_length,
+                context_length=new_persona_context_length,
                 user_room_id=self.user_room_id,
-                provider=self.provider,
+                provider=new_persona_provider,  # Use provider for model
                 is_dispatched=False,
                 timezone_info=self.timezone_info,
                 timezone_name=self.timezone_name,

--- a/manager/runtime.py
+++ b/manager/runtime.py
@@ -383,11 +383,12 @@ class RuntimeService(
         return replies
 
     def handle_user_input_stream(
-        self, message: str, metadata: Optional[Dict[str, Any]] = None
+        self, message: str, metadata: Optional[Dict[str, Any]] = None, meta_playbook: Optional[str] = None
     ) -> Iterator[str]:
         logging.debug(
-            "[runtime] handle_user_input_stream called (metadata_present=%s)",
+            "[runtime] handle_user_input_stream called (metadata_present=%s, meta_playbook=%s)",
             bool(metadata),
+            meta_playbook,
         )
         if not message or not str(message).strip():
             logging.error("[runtime] handle_user_input_stream got empty message; aborting to avoid corrupt routing")
@@ -446,7 +447,7 @@ class RuntimeService(
         for persona in responding_personas:
             if sea_enabled:
                 # SEA runtime pushes to gateway internally; streaming経路では二重出力を避けて返却しない
-                self.manager.run_sea_user(persona, building_id, message, metadata=metadata)
+                self.manager.run_sea_user(persona, building_id, message, metadata=metadata, meta_playbook=meta_playbook)
             elif persona.interaction_mode == "manual":
                 for token in persona.handle_user_input_stream(
                     message, metadata=metadata

--- a/media_summary.py
+++ b/media_summary.py
@@ -32,6 +32,18 @@ def ensure_image_summary(path: Path, mime_type: str) -> Optional[str]:
     return None
 
 
+def ensure_document_summary(path: Path) -> Optional[str]:
+    """Ensure a document summary exists; generate with Gemini if missing."""
+    summary = get_media_summary(path)
+    if summary:
+        return summary
+    generated = _generate_document_summary(path)
+    if generated:
+        save_media_summary(path, generated)
+        return generated
+    return None
+
+
 def _generate_image_summary(path: Path, mime_type: str) -> Optional[str]:
     if types is None:
         LOGGER.warning("Gemini SDK not available; cannot summarize image %s", path)
@@ -48,7 +60,7 @@ def _generate_image_summary(path: Path, mime_type: str) -> Optional[str]:
         return None
 
     prompt_text = (
-        "以下の画像を詳しく説明するのではなく、内容を理解するための要点を120文字以内の日本語で1〜2文にまとめてください。"
+        "以下の画像を詳しく説明するのではなく、内容を理解するための要点を300文字以内の日本語で1〜2文にまとめてください。"
     )
     content = [
         types.Content(
@@ -76,6 +88,69 @@ def _generate_image_summary(path: Path, mime_type: str) -> Optional[str]:
             )
         except Exception as exc:  # pragma: no cover - network dependent
             LOGGER.warning("Gemini image summary generation failed: %s", exc)
+            continue
+        text = getattr(response, "text", None)
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+        # Some SDK responses place text under candidates[0].content.parts
+        try:
+            candidates = getattr(response, "candidates", [])
+            for candidate in candidates or []:
+                parts = getattr(candidate, "content", None)
+                if parts and getattr(parts, "parts", None):
+                    for part in parts.parts:
+                        value = getattr(part, "text", None)
+                        if isinstance(value, str) and value.strip():
+                            return value.strip()
+        except Exception:  # pragma: no cover - defensive
+            LOGGER.debug("Failed to parse Gemini summary response", exc_info=True)
+    return None
+
+
+def _generate_document_summary(path: Path) -> Optional[str]:
+    """Generate a summary for a text document using Gemini."""
+    if types is None:
+        LOGGER.warning("Gemini SDK not available; cannot summarize document %s", path)
+        return None
+    try:
+        free_client, paid_client, active_client = build_gemini_clients()
+    except RuntimeError as exc:
+        LOGGER.warning("Cannot initialise Gemini client for document summary: %s", exc)
+        return None
+
+    try:
+        document_text = path.read_text(encoding="utf-8")
+    except OSError:
+        LOGGER.exception("Failed to read document for summary generation: %s", path)
+        return None
+
+    prompt_text = (
+        "以下の文書の内容を300文字以内の日本語で要約してください。要点を簡潔にまとめてください。\n\n"
+        f"{document_text}"
+    )
+    content = [
+        types.Content(
+            parts=[types.Part(text=prompt_text)],
+            role="user",
+        )
+    ]
+    config = types.GenerateContentConfig(
+        temperature=0.2,
+        max_output_tokens=256,
+    )
+
+    clients = [active_client, paid_client, free_client]
+    for client in clients:
+        if client is None:
+            continue
+        try:
+            response = client.models.generate_content(
+                model="gemini-2.5-flash-lite",
+                contents=content,
+                config=config,
+            )
+        except Exception as exc:  # pragma: no cover - network dependent
+            LOGGER.warning("Gemini document summary generation failed: %s", exc)
             continue
         text = getattr(response, "text", None)
         if isinstance(text, str) and text.strip():

--- a/media_utils.py
+++ b/media_utils.py
@@ -168,10 +168,72 @@ def path_to_data_url(path: Path, mime_type: str) -> Optional[str]:
     return _cached_path_to_data_url(str(path), mime_type, stat.st_mtime)
 
 
-def load_image_bytes_for_llm(path: Path, mime_type: str) -> Tuple[Optional[bytes], Optional[str]]:
+def resize_image_if_needed(data: bytes, mime_type: str, max_bytes: int) -> Tuple[bytes, str]:
+    """
+    Resize an image if it exceeds max_bytes when base64-encoded.
+    Returns (resized_bytes, effective_mime_type).
+    Base64 encoding increases size by ~33%, so we target max_bytes * 0.75 for raw bytes.
+    """
+    if Image is None:
+        LOGGER.warning("PIL not available; cannot resize image")
+        return data, mime_type
+
+    # Base64 encoding increases size by ~33%, so target 75% of max_bytes
+    target_bytes = int(max_bytes * 0.75)
+
+    if len(data) <= target_bytes:
+        return data, mime_type
+
+    try:
+        img = Image.open(BytesIO(data))
+
+        # Calculate scale factor based on byte size ratio
+        scale = (target_bytes / len(data)) ** 0.5  # Square root for 2D scaling
+        new_width = int(img.width * scale)
+        new_height = int(img.height * scale)
+
+        LOGGER.info(
+            "Resizing image from %dx%d (%d bytes) to %dx%d (target: %d bytes)",
+            img.width, img.height, len(data), new_width, new_height, target_bytes
+        )
+
+        # Resize image
+        resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+
+        # Save as JPEG with quality adjustment if still too large
+        buf = BytesIO()
+        quality = 85
+        output_mime = "image/jpeg"
+
+        for attempt in range(3):
+            buf.seek(0)
+            buf.truncate()
+            resized.convert("RGB").save(buf, format="JPEG", quality=quality)
+            result_bytes = buf.getvalue()
+
+            if len(result_bytes) <= target_bytes:
+                LOGGER.info("Resized image to %d bytes (quality=%d)", len(result_bytes), quality)
+                return result_bytes, output_mime
+
+            quality -= 15  # Reduce quality for next attempt
+
+        # If still too large, return the best we got
+        LOGGER.warning(
+            "Could not resize image below target (%d bytes > %d bytes); using best effort",
+            len(result_bytes), target_bytes
+        )
+        return result_bytes, output_mime
+
+    except Exception:
+        LOGGER.exception("Failed to resize image; using original")
+        return data, mime_type
+
+
+def load_image_bytes_for_llm(path: Path, mime_type: str, max_bytes: Optional[int] = None) -> Tuple[Optional[bytes], Optional[str]]:
     """
     Return (bytes, effective_mime) for LLM consumption.
     Converts unsupported formats to PNG when Pillow is available.
+    If max_bytes is specified, resizes image to fit within that limit (accounting for base64 encoding).
     """
     target_mime = mime_type.lower()
     if target_mime not in SUPPORTED_LLM_IMAGE_MIME and Image is not None:
@@ -180,14 +242,29 @@ def load_image_bytes_for_llm(path: Path, mime_type: str) -> Tuple[Optional[bytes
                 buf = BytesIO()
                 img.save(buf, format="PNG")
                 LOGGER.debug("Converted image %s to PNG for LLM input", path)
-                return buf.getvalue(), "image/png"
+                data = buf.getvalue()
+                effective_mime = "image/png"
         except Exception:
             LOGGER.exception("Failed to convert image %s to PNG; falling back to raw bytes", path)
-    try:
-        data = path.read_bytes()
-    except OSError:
-        LOGGER.exception("Failed to read image for LLM: %s", path)
-        return None, None
-    if target_mime not in SUPPORTED_LLM_IMAGE_MIME:
+            try:
+                data = path.read_bytes()
+                effective_mime = target_mime
+            except OSError:
+                LOGGER.exception("Failed to read image for LLM: %s", path)
+                return None, None
+    else:
+        try:
+            data = path.read_bytes()
+            effective_mime = target_mime
+        except OSError:
+            LOGGER.exception("Failed to read image for LLM: %s", path)
+            return None, None
+
+    if effective_mime not in SUPPORTED_LLM_IMAGE_MIME:
         LOGGER.warning("Using raw bytes for potentially unsupported mime '%s'", mime_type)
-    return data, target_mime
+
+    # Resize if max_bytes is specified and image is too large
+    if max_bytes is not None:
+        data, effective_mime = resize_image_if_needed(data, effective_mime, max_bytes)
+
+    return data, effective_mime

--- a/model_configs.py
+++ b/model_configs.py
@@ -1,17 +1,53 @@
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
-CONFIG_PATH = Path("models.json")
+LOGGER = logging.getLogger(__name__)
+
+# Legacy single-file config
+LEGACY_CONFIG_PATH = Path("models.json")
+# New directory-based configs
+MODELS_DIR = Path("models")
 
 
-def load_configs(path: Path = CONFIG_PATH) -> Dict[str, Dict]:
-    if path.exists():
+def load_configs() -> Dict[str, Dict]:
+    """Load model configurations from models/ directory or legacy models.json."""
+    configs: Dict[str, Dict] = {}
+
+    # Try loading from models/ directory first (new structure)
+    if MODELS_DIR.exists() and MODELS_DIR.is_dir():
+        for config_file in sorted(MODELS_DIR.glob("*.json")):
+            try:
+                config_data = json.loads(config_file.read_text(encoding="utf-8"))
+
+                # Extract model ID from config (required field)
+                model_id = config_data.get("model")
+                if not model_id:
+                    LOGGER.warning("Model config %s missing 'model' field, skipping", config_file.name)
+                    continue
+
+                # Store config with model ID as key
+                configs[model_id] = config_data
+                LOGGER.debug("Loaded model config: %s from %s", model_id, config_file.name)
+            except Exception as exc:
+                LOGGER.warning("Failed to load model config from %s: %s", config_file.name, exc)
+
+    # Fallback to legacy models.json if models/ dir is empty or doesn't exist
+    if not configs and LEGACY_CONFIG_PATH.exists():
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
-    return {}
+            legacy_configs = json.loads(LEGACY_CONFIG_PATH.read_text(encoding="utf-8"))
+            # In legacy format, keys are model IDs and values don't have "model" field
+            # Add "model" field to each config for consistency
+            for model_id, config_data in legacy_configs.items():
+                if "model" not in config_data:
+                    config_data["model"] = model_id
+                configs[model_id] = config_data
+            LOGGER.info("Loaded %d models from legacy models.json", len(configs))
+        except Exception as exc:
+            LOGGER.warning("Failed to load legacy models.json: %s", exc)
+
+    return configs
 
 MODEL_CONFIGS = load_configs()
 
@@ -24,8 +60,20 @@ def get_context_length(model: str) -> int:
     return int(MODEL_CONFIGS.get(model, {}).get("context_length", 120000))
 
 
+def get_model_display_name(model: str) -> str:
+    """Get display name for a model, falling back to model ID if not set."""
+    config = MODEL_CONFIGS.get(model, {})
+    return config.get("display_name", model)
+
+
 def get_model_choices() -> list[str]:
+    """Get list of available model IDs."""
     return list(MODEL_CONFIGS.keys())
+
+
+def get_model_choices_with_display_names() -> list[tuple[str, str]]:
+    """Get list of (model_id, display_name) tuples for UI dropdowns."""
+    return [(model_id, get_model_display_name(model_id)) for model_id in get_model_choices()]
 
 
 def get_model_config(model: str) -> Dict:
@@ -51,3 +99,30 @@ def get_model_parameter_defaults(model: str) -> Dict[str, Any]:
         if isinstance(spec, dict) and "default" in spec:
             defaults[name] = spec.get("default")
     return defaults
+
+
+def get_structured_output_backend(model: str) -> str | None:
+    """Get structured output backend for a model (e.g., 'xgrammar', 'outlines')."""
+    config = get_model_config(model)
+    return config.get("structured_output_backend")
+
+
+def supports_structured_output(model: str) -> bool:
+    """Check if a model supports structured output.
+
+    Returns True by default unless explicitly set to False in model config.
+    """
+    config = get_model_config(model)
+    # Default to True unless explicitly set to False
+    return config.get("supports_structured_output", True)
+
+
+def get_agentic_model() -> str:
+    """Get the default model for agentic tasks requiring structured output.
+
+    Priority:
+    1. SAIVERSE_AGENTIC_MODEL environment variable
+    2. Built-in default: gemini-2.0-flash
+    """
+    import os
+    return os.environ.get("SAIVERSE_AGENTIC_MODEL", "gemini-2.0-flash")

--- a/models.json
+++ b/models.json
@@ -294,6 +294,7 @@
     "context_length": 32768,
     "base_url": "https://integrate.api.nvidia.com/v1",
     "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
     "parameters": {
       "temperature": {
         "type": "float",
@@ -329,6 +330,7 @@
     "context_length": 32768,
     "base_url": "https://integrate.api.nvidia.com/v1",
     "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
     "parameters": {
       "temperature": {
         "type": "float",
@@ -359,11 +361,48 @@
       }
     }
   },
+  "qwen/qwen3-next-80b-a3b-instruct": {
+    "provider": "openai",
+    "context_length": 128000,
+    "base_url": "https://integrate.api.nvidia.com/v1",
+    "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
+    "parameters": {
+      "temperature": {
+        "type": "float",
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "default": 0.6,
+        "label": "Temperature",
+        "description": "Controls randomness."
+      },
+      "top_p": {
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "default": 0.7,
+        "label": "Top P",
+        "description": "Nucleus sampling cutoff."
+      },
+      "max_tokens": {
+        "type": "int",
+        "min": 32,
+        "max": 8192,
+        "step": 1,
+        "default": 4096,
+        "label": "Max tokens",
+        "description": "Upper bound on generated tokens."
+      }
+    }
+  },
   "moonshotai/kimi-k2-instruct-0905": {
     "provider": "openai",
     "context_length": 250000,
     "base_url": "https://integrate.api.nvidia.com/v1",
     "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
     "parameters": {
       "temperature": {
         "type": "float",
@@ -394,53 +433,19 @@
       }
     }
   },
-  "mistralai/mistral-large-2411": {
-    "provider": "openai",
-    "context_length": 32000,
-    "base_url": "https://openrouter.ai/api/v1",
-    "api_key_env": "OPENROUTER_API_KEY",
-    "parameters": {
-      "temperature": {
-        "type": "float",
-        "min": 0,
-        "max": 2,
-        "step": 0.1,
-        "default": 1,
-        "label": "Temperature",
-        "description": "Controls randomness."
-      },
-      "top_p": {
-        "type": "float",
-        "min": 0,
-        "max": 1,
-        "step": 0.05,
-        "default": 1,
-        "label": "Top P",
-        "description": "Nucleus sampling cutoff."
-      },
-      "max_tokens": {
-        "type": "int",
-        "min": 32,
-        "max": 120000,
-        "step": 1,
-        "default": 8000,
-        "label": "Max tokens",
-        "description": "Upper bound on generated tokens."
-      }
-    }
-  },
-  "mistralai/mistral-large-2512": {
+  "mistralai/mistral-large-3-675b-instruct-2512": {
     "provider": "openai",
     "context_length": 128000,
-    "base_url": "https://openrouter.ai/api/v1",
-    "api_key_env": "OPENROUTER_API_KEY",
+    "base_url": "https://integrate.api.nvidia.com/v1",
+    "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
     "parameters": {
       "temperature": {
         "type": "float",
         "min": 0,
         "max": 2,
-        "step": 0.1,
-        "default": 1,
+        "step": 0.01,
+        "default": 0.2,
         "label": "Temperature",
         "description": "Controls randomness."
       },
@@ -504,6 +509,7 @@
     "context_length": 120000,
     "base_url": "https://integrate.api.nvidia.com/v1",
     "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
     "parameters": {
       "temperature": {
         "type": "float",
@@ -629,6 +635,7 @@
     "context_length": 120000,
     "base_url": "https://integrate.api.nvidia.com/v1",
     "api_key_env": "NVIDIA_API_KEY",
+    "convert_system_to_user": true,
     "parameters": {
       "temperature": {
         "type": "float",

--- a/models.json
+++ b/models.json
@@ -394,6 +394,41 @@
       }
     }
   },
+  "mistralai/mistral-large-2512": {
+    "provider": "openai",
+    "context_length": 128000,
+    "base_url": "https://openrouter.ai/api/v1",
+    "api_key_env": "OPENROUTER_API_KEY",
+    "parameters": {
+      "temperature": {
+        "type": "float",
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "default": 1,
+        "label": "Temperature",
+        "description": "Controls randomness."
+      },
+      "top_p": {
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "default": 1,
+        "label": "Top P",
+        "description": "Nucleus sampling cutoff."
+      },
+      "max_tokens": {
+        "type": "int",
+        "min": 32,
+        "max": 260000,
+        "step": 1,
+        "default": 8000,
+        "label": "Max tokens",
+        "description": "Upper bound on generated tokens."
+      }
+    }
+  },
   "z-ai/glm-4.6": {
     "provider": "openai",
     "context_length": 32000,

--- a/models.json
+++ b/models.json
@@ -219,6 +219,41 @@
       }
     }
   },
+  "grok-4-1-fast-reasoning": {
+    "provider": "openai",
+    "context_length": 128000,
+    "base_url": "https://api.x.ai/v1",
+    "api_key_env": "XAI_API_KEY",
+    "parameters": {
+      "temperature": {
+        "type": "float",
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "default": 1,
+        "label": "Temperature",
+        "description": "Controls randomness."
+      },
+      "top_p": {
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "default": 1,
+        "label": "Top P",
+        "description": "Nucleus sampling cutoff."
+      },
+      "max_tokens": {
+        "type": "int",
+        "min": 32,
+        "max": 2048,
+        "step": 1,
+        "default": 2048,
+        "label": "Max tokens",
+        "description": "Upper bound on generated tokens."
+      }
+    }
+  },
   "grok-4-0709": {
     "provider": "openai",
     "context_length": 32768,

--- a/models/chatgpt-4o-latest.json
+++ b/models/chatgpt-4o-latest.json
@@ -1,0 +1,36 @@
+{
+  "model": "chatgpt-4o-latest",
+  "display_name": "Chatgpt 4o Latest",
+  "provider": "openai",
+  "context_length": 32000,
+  "supports_images": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1.0,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 4096,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on reply length."
+    }
+  }
+}

--- a/models/claude-opus-4-20250514.json
+++ b/models/claude-opus-4-20250514.json
@@ -1,0 +1,9 @@
+{
+  "model": "claude-opus-4-20250514",
+  "display_name": "Claude Opus 4 20250514",
+  "provider": "anthropic",
+  "context_length": 32000,
+  "thinking_type": "enabled",
+  "thinking_budget": 8192,
+  "supports_images": true
+}

--- a/models/claude-sonnet-4-5.json
+++ b/models/claude-sonnet-4-5.json
@@ -1,0 +1,9 @@
+{
+  "model": "claude-sonnet-4-5",
+  "display_name": "Claude Sonnet 4 5",
+  "provider": "anthropic",
+  "context_length": 32000,
+  "thinking_type": "enabled",
+  "thinking_budget": 4096,
+  "supports_images": true
+}

--- a/models/gemini-2.5-flash-lite-preview-09-2025.json
+++ b/models/gemini-2.5-flash-lite-preview-09-2025.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-2.5-flash-lite-preview-09-2025",
+  "display_name": "Gemini V2.5 Flash Lite Preview 09 2025",
+  "provider": "gemini",
+  "context_length": 128000,
+  "supports_images": true
+}

--- a/models/gemini-2.5-flash-preview-09-2025.json
+++ b/models/gemini-2.5-flash-preview-09-2025.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-2.5-flash-preview-09-2025",
+  "display_name": "Gemini V2.5 Flash Preview 09 2025",
+  "provider": "gemini",
+  "context_length": 128000,
+  "supports_images": true
+}

--- a/models/gemini-2.5-pro.json
+++ b/models/gemini-2.5-pro.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-2.5-pro",
+  "display_name": "Gemini V2.5 Pro",
+  "provider": "gemini",
+  "context_length": 128000,
+  "supports_images": true
+}

--- a/models/gemini-3-pro-preview.json
+++ b/models/gemini-3-pro-preview.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-3-pro-preview",
+  "display_name": "Gemini 3 Pro Preview",
+  "provider": "gemini",
+  "context_length": 128000,
+  "supports_images": true
+}

--- a/models/gpt-4.1.json
+++ b/models/gpt-4.1.json
@@ -1,0 +1,36 @@
+{
+  "model": "gpt-4.1",
+  "display_name": "Gpt V4.1",
+  "provider": "openai",
+  "context_length": 32000,
+  "supports_images": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "0 is deterministic, higher values add randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1.0,
+      "label": "Top P",
+      "description": "Nucleus sampling threshold."
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 4096,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on reply length."
+    }
+  }
+}

--- a/models/gpt-4o-2024-11-20.json
+++ b/models/gpt-4o-2024-11-20.json
@@ -1,0 +1,36 @@
+{
+  "model": "gpt-4o-2024-11-20",
+  "display_name": "Gpt 4o 2024 11 20",
+  "provider": "openai",
+  "context_length": 32000,
+  "supports_images": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1.0,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 4096,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on reply length."
+    }
+  }
+}

--- a/models/gpt-4o.json
+++ b/models/gpt-4o.json
@@ -1,0 +1,36 @@
+{
+  "model": "gpt-4o",
+  "display_name": "Gpt 4o",
+  "provider": "openai",
+  "context_length": 32000,
+  "supports_images": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1.0,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 4096,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on reply length."
+    }
+  }
+}

--- a/models/gpt-5.1.json
+++ b/models/gpt-5.1.json
@@ -1,0 +1,44 @@
+{
+  "model": "gpt-5.1",
+  "display_name": "Gpt V5.1",
+  "provider": "openai",
+  "context_length": 32000,
+  "supports_images": true,
+  "parameters": {
+    "reasoning_effort": {
+      "type": "enum",
+      "options": [
+        "none",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "label": "Reasoning Effort",
+      "description": "Controls how much thinking time the model spends."
+    },
+    "verbosity": {
+      "type": "enum",
+      "options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "high",
+      "label": "Verbosity",
+      "description": "Controls how long or detailed responses should be.",
+      "client_support": [
+        "responses"
+      ]
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8192,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on how many tokens the reply can use."
+    }
+  }
+}

--- a/models/gpt-5.json
+++ b/models/gpt-5.json
@@ -1,0 +1,44 @@
+{
+  "model": "gpt-5",
+  "display_name": "Gpt 5",
+  "provider": "openai",
+  "context_length": 32000,
+  "supports_images": true,
+  "parameters": {
+    "reasoning_effort": {
+      "type": "enum",
+      "options": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "label": "Reasoning Effort",
+      "description": "Controls how much thinking time the model spends."
+    },
+    "verbosity": {
+      "type": "enum",
+      "options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "high",
+      "label": "Verbosity",
+      "description": "Controls how long or detailed responses should be.",
+      "client_support": [
+        "responses"
+      ]
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8192,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on how many tokens the reply can use."
+    }
+  }
+}

--- a/models/gpt-oss-20b.json
+++ b/models/gpt-oss-20b.json
@@ -1,0 +1,6 @@
+{
+  "model": "gpt-oss:20b",
+  "display_name": "Gpt Oss 20b",
+  "provider": "ollama",
+  "context_length": 32768
+}

--- a/models/grok-4-0709.json
+++ b/models/grok-4-0709.json
@@ -1,0 +1,37 @@
+{
+  "model": "grok-4-0709",
+  "display_name": "Grok 4 0709",
+  "provider": "openai",
+  "context_length": 32768,
+  "base_url": "https://api.x.ai/v1",
+  "api_key_env": "XAI_API_KEY",
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 2048,
+      "step": 1,
+      "default": 2048,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/grok-4-1-fast-reasoning.json
+++ b/models/grok-4-1-fast-reasoning.json
@@ -1,0 +1,37 @@
+{
+  "model": "grok-4-1-fast-reasoning",
+  "display_name": "Grok 4 1 Fast Reasoning",
+  "provider": "openai",
+  "context_length": 128000,
+  "base_url": "https://api.x.ai/v1",
+  "api_key_env": "XAI_API_KEY",
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 2048,
+      "step": 1,
+      "default": 2048,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/llama-4-maverick-17b-128e-instruct.json
+++ b/models/llama-4-maverick-17b-128e-instruct.json
@@ -1,0 +1,39 @@
+{
+  "model": "meta/llama-4-maverick-17b-128e-instruct",
+  "display_name": "Llama 4 Maverick (NIM)",
+  "provider": "nvidia_nim",
+  "supports_structured_output": true,
+  "context_length": 250000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 260000,
+      "step": 1,
+      "default": 8000,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/llama4-16x17b.json
+++ b/models/llama4-16x17b.json
@@ -1,0 +1,6 @@
+{
+  "model": "llama4:16x17b",
+  "display_name": "Llama4 16x17b",
+  "provider": "ollama",
+  "context_length": 1000000
+}

--- a/models/mistral-large-3-nim.json
+++ b/models/mistral-large-3-nim.json
@@ -1,0 +1,39 @@
+{
+  "model": "mistralai/mistral-large-3-675b-instruct-2512",
+  "display_name": "Mistral Large 3 (NIM)",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 128000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "default": 0.2,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 260000,
+      "step": 1,
+      "default": 8000,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/moonshotai-kimi-k2-instruct-0905.json
+++ b/models/moonshotai-kimi-k2-instruct-0905.json
@@ -1,0 +1,39 @@
+{
+  "model": "moonshotai/kimi-k2-instruct-0905",
+  "display_name": "Moonshotai Kimi K2 0905",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 250000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 4096,
+      "step": 1,
+      "default": 4096,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/old/gemini-1.5-flash.json
+++ b/models/old/gemini-1.5-flash.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-1.5-flash",
+  "display_name": "Gemini V1.5 Flash",
+  "provider": "gemini",
+  "context_length": 1000000,
+  "supports_images": true
+}

--- a/models/old/gemini-2.0-flash.json
+++ b/models/old/gemini-2.0-flash.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-2.0-flash",
+  "display_name": "Gemini V2.0 Flash",
+  "provider": "gemini",
+  "context_length": 1000000,
+  "supports_images": true
+}

--- a/models/old/gemini-2.5-flash-lite.json
+++ b/models/old/gemini-2.5-flash-lite.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-2.5-flash-lite",
+  "display_name": "Gemini V2.5 Flash Lite",
+  "provider": "gemini",
+  "context_length": 128000,
+  "supports_images": true
+}

--- a/models/old/gemini-2.5-flash.json
+++ b/models/old/gemini-2.5-flash.json
@@ -1,0 +1,7 @@
+{
+  "model": "gemini-2.5-flash",
+  "display_name": "Gemini 2.5 Flash",
+  "provider": "gemini",
+  "context_length": 128000,
+  "supports_images": true
+}

--- a/models/old/hf.co-mmnga-ABEJA-Qwen2.5-32b-Japanese-v1.0-gguf-Q4_K_M.json
+++ b/models/old/hf.co-mmnga-ABEJA-Qwen2.5-32b-Japanese-v1.0-gguf-Q4_K_M.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/mmnga/ABEJA-Qwen2.5-32b-Japanese-v1.0-gguf:Q4_K_M",
+  "display_name": "Mmnga Abeja Qwen2.5 32b Japanese V1.0 Q4 K M",
+  "provider": "ollama",
+  "context_length": 32768
+}

--- a/models/old/hf.co-mmnga-llm-jp-3.1-8x13b-instruct4-gguf-Q4_K_M.json
+++ b/models/old/hf.co-mmnga-llm-jp-3.1-8x13b-instruct4-gguf-Q4_K_M.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/mmnga/llm-jp-3.1-8x13b-instruct4-gguf:Q4_K_M",
+  "display_name": "Mmnga Llm Jp V3.1 8x13b Instruct4 Q4 K M",
+  "provider": "ollama",
+  "context_length": 4096
+}

--- a/models/old/hf.co-mradermacher-shisa-v2-llama3.3-70b-i1-GGUF-Q4_K_M.json
+++ b/models/old/hf.co-mradermacher-shisa-v2-llama3.3-70b-i1-GGUF-Q4_K_M.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/mradermacher/shisa-v2-llama3.3-70b-i1-GGUF:Q4_K_M",
+  "display_name": "Mradermacher Shisa V2 Llama3.3 70b I1 Q4 K M",
+  "provider": "ollama",
+  "context_length": 32768
+}

--- a/models/old/hf.co-unsloth-Mistral-Small-3.2-24B-Instruct-2506-GGUF-Q6_K_XL.json
+++ b/models/old/hf.co-unsloth-Mistral-Small-3.2-24B-Instruct-2506-GGUF-Q6_K_XL.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q6_K_XL",
+  "display_name": "Mistral Small V3.2 24b 2506 Q6 K Xl",
+  "provider": "ollama",
+  "context_length": 128000
+}

--- a/models/old/hf.co-unsloth-Qwen3-32B-GGUF-Q4_K_XL.json
+++ b/models/old/hf.co-unsloth-Qwen3-32B-GGUF-Q4_K_XL.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/unsloth/Qwen3-32B-GGUF:Q4_K_XL",
+  "display_name": "Qwen3 32b Q4 K Xl",
+  "provider": "ollama",
+  "context_length": 32768
+}

--- a/models/old/hf.co-unsloth-gemma-3-1b-it-GGUF-BF16.json
+++ b/models/old/hf.co-unsloth-gemma-3-1b-it-GGUF-BF16.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/unsloth/gemma-3-1b-it-GGUF:BF16",
+  "display_name": "Gemma 3 1b It Bf16",
+  "provider": "ollama",
+  "context_length": 32768
+}

--- a/models/old/hf.co-unsloth-gemma-3-27b-it-GGUF-Q6_K.json
+++ b/models/old/hf.co-unsloth-gemma-3-27b-it-GGUF-Q6_K.json
@@ -1,0 +1,6 @@
+{
+  "model": "hf.co/unsloth/gemma-3-27b-it-GGUF:Q6_K",
+  "display_name": "Gemma 3 27b It Q6 K",
+  "provider": "ollama",
+  "context_length": 128000
+}

--- a/models/old/institute-of-science-tokyo-llama-3.1-swallow-70b-instruct-v0.1.json
+++ b/models/old/institute-of-science-tokyo-llama-3.1-swallow-70b-instruct-v0.1.json
@@ -1,0 +1,39 @@
+{
+  "model": "institute-of-science-tokyo/llama-3.1-swallow-70b-instruct-v0.1",
+  "display_name": "Institute Of Science Tokyo Llama V3.1 Swallow 70b",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 120000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 1024,
+      "step": 1,
+      "default": 1024,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/old/o3.json
+++ b/models/old/o3.json
@@ -1,0 +1,29 @@
+{
+  "model": "o3",
+  "display_name": "O3",
+  "provider": "openai",
+  "context_length": 200000,
+  "parameters": {
+    "reasoning_effort": {
+      "type": "enum",
+      "options": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "label": "Reasoning Effort",
+      "description": "Controls how much time the reasoning model spends thinking."
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 4096,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/old/qwen3-30b.json
+++ b/models/old/qwen3-30b.json
@@ -1,0 +1,6 @@
+{
+  "model": "qwen3:30b",
+  "display_name": "Qwen3 30b",
+  "provider": "ollama",
+  "context_length": 32768
+}

--- a/models/openai-gpt-oss-120b.json
+++ b/models/openai-gpt-oss-120b.json
@@ -1,0 +1,39 @@
+{
+  "model": "openai/gpt-oss-120b",
+  "display_name": "Openai Gpt Oss 120b",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 120000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8000,
+      "step": 1,
+      "default": 8000,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/qwen-qwen3-235b-a22b.json
+++ b/models/qwen-qwen3-235b-a22b.json
@@ -1,0 +1,39 @@
+{
+  "model": "qwen/qwen3-235b-a22b",
+  "display_name": "Qwen Qwen3 235b A22b",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 32768,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8192,
+      "step": 1,
+      "default": 4096,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/qwen-qwen3-next-80b-a3b-instruct.json
+++ b/models/qwen-qwen3-next-80b-a3b-instruct.json
@@ -1,0 +1,39 @@
+{
+  "model": "qwen/qwen3-next-80b-a3b-instruct",
+  "display_name": "Qwen Qwen3 Next 80b A3b",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 128000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 0.6,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 0.7,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8192,
+      "step": 1,
+      "default": 4096,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/qwen3-coder-480b-a35b-instruct.json
+++ b/models/qwen3-coder-480b-a35b-instruct.json
@@ -1,0 +1,39 @@
+{
+  "model": "qwen/qwen3-coder-480b-a35b-instruct",
+  "display_name": "Qwen 3 Coder 480B-A35B (NIM)",
+  "provider": "nvidia_nim",
+  "supports_structured_output": true,
+  "context_length": 250000,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "default": 0.7,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 0.8,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 260000,
+      "step": 1,
+      "default": 8000,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/stockmark-stockmark-2-100b-instruct.json
+++ b/models/stockmark-stockmark-2-100b-instruct.json
@@ -1,0 +1,39 @@
+{
+  "model": "stockmark/stockmark-2-100b-instruct",
+  "display_name": "Stockmark Stockmark 2 100b",
+  "provider": "nvidia_nim",
+  "supports_structured_output": false,
+  "context_length": 32768,
+  "base_url": "https://integrate.api.nvidia.com/v1",
+  "api_key_env": "NVIDIA_API_KEY",
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 1,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 2048,
+      "step": 1,
+      "default": 2048,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/models/z-ai-glm-4.6.json
+++ b/models/z-ai-glm-4.6.json
@@ -1,0 +1,37 @@
+{
+  "model": "z-ai/glm-4.6",
+  "display_name": "Z Ai Glm V4.6",
+  "provider": "openai",
+  "context_length": 32000,
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 0.95,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 120000,
+      "step": 1,
+      "default": 8000,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  }
+}

--- a/persona/core.py
+++ b/persona/core.py
@@ -156,9 +156,10 @@ class PersonaCore(
         # Initialize lightweight LLM client if lightweight_model is provided
         if lightweight_model and str(lightweight_model).strip():
             try:
-                from model_configs import get_context_length
+                from model_configs import get_context_length, get_model_provider
                 lw_context_length = get_context_length(lightweight_model)
-                self.lightweight_llm_client = get_llm_client(lightweight_model, provider, lw_context_length)
+                lw_provider = get_model_provider(lightweight_model)  # Get correct provider for lightweight model
+                self.lightweight_llm_client = get_llm_client(lightweight_model, lw_provider, lw_context_length)
             except Exception as exc:
                 logging.warning(
                     "Failed to initialize lightweight LLM client for persona '%s' with model '%s': %s",

--- a/persona/core.py
+++ b/persona/core.py
@@ -195,6 +195,13 @@ class PersonaCore(
         self._persona_event_ack = persona_event_ack
         self.manager_ref = manager_ref
 
+        # Execution state tracking for UI display
+        self.execution_state: Dict[str, Any] = {
+            "playbook": None,
+            "node": None,
+            "status": "idle"  # idle, running, waiting, completed
+        }
+
     def set_inventory(self, item_ids: List[str]) -> None:
         self.inventory_item_ids = list(item_ids)
     def set_item_registry(self, registry: Dict[str, Dict[str, Any]]) -> None:
@@ -227,3 +234,7 @@ class PersonaCore(
             self._persona_event_ack(self.persona_id, event_ids)
         except Exception as exc:
             logging.debug("Failed to archive events for %s: %s", self.persona_id, exc)
+
+    def get_execution_state(self) -> Dict[str, Any]:
+        """Get the current playbook execution state for UI display."""
+        return dict(self.execution_state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ httpx>=0.27.0
 fastapi==0.116.1
 google-genai==1.26.0
 gradio==5.38.0
+langgraph==1.0.3
 openai==1.97.0
 pydantic==2.11.7
 pydantic-settings==2.5.2

--- a/schedule_manager.py
+++ b/schedule_manager.py
@@ -1,0 +1,355 @@
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
+
+from database.models import PersonaSchedule, AI as AIModel, City as CityModel
+
+if TYPE_CHECKING:
+    from saiverse_manager import SAIVerseManager
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ScheduleManager:
+    """
+    ペルソナのスケジュールを管理し、定期的にチェックして実行するクラス。
+    """
+
+    def __init__(self, saiverse_manager: "SAIVerseManager", check_interval: int = 60):
+        """
+        :param saiverse_manager: SAIVerseManagerインスタンス
+        :param check_interval: スケジュールチェック間隔（秒）
+        """
+        self.manager = saiverse_manager
+        self.check_interval = check_interval
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._last_check_times: Dict[int, datetime] = {}  # schedule_id -> last check time
+        LOGGER.info("[ScheduleManager] Initialized with check interval: %d seconds", check_interval)
+
+    def start(self):
+        """スケジュールチェックループをバックグラウンドで開始"""
+        if self._thread and self._thread.is_alive():
+            LOGGER.warning("[ScheduleManager] Thread is already running.")
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._schedule_loop, daemon=True)
+        self._thread.start()
+        LOGGER.info("[ScheduleManager] Started background schedule checker thread (check_interval=%ds).", self.check_interval)
+        # スレッドが実際に起動したか少し待って確認
+        import time
+        time.sleep(0.1)
+        if self._thread.is_alive():
+            LOGGER.info("[ScheduleManager] Thread is confirmed alive.")
+        else:
+            LOGGER.error("[ScheduleManager] Thread failed to start!")
+
+    def stop(self):
+        """スケジュールチェックループを停止"""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+        LOGGER.info("[ScheduleManager] Stopped schedule checker thread.")
+
+    def _schedule_loop(self):
+        """定期的にスケジュールをチェックして実行するメインループ"""
+        LOGGER.info("[ScheduleManager] Schedule loop started")
+        while not self._stop_event.is_set():
+            self._stop_event.wait(self.check_interval)
+            if self._stop_event.is_set():
+                break
+
+            try:
+                LOGGER.debug("[ScheduleManager] Checking schedules...")
+                self._check_and_execute_schedules()
+            except Exception as e:
+                LOGGER.error("[ScheduleManager] Error in schedule loop: %s", e, exc_info=True)
+        LOGGER.info("[ScheduleManager] Schedule loop ended")
+
+    def _check_and_execute_schedules(self):
+        """全スケジュールをチェックし、発火条件を満たすものを実行"""
+        session = self.manager.SessionLocal()
+        try:
+            # 有効なスケジュールを優先度順に取得
+            schedules = (
+                session.query(PersonaSchedule)
+                .filter(PersonaSchedule.ENABLED == True)
+                .order_by(PersonaSchedule.PRIORITY.desc(), PersonaSchedule.SCHEDULE_ID.desc())
+                .all()
+            )
+
+            LOGGER.debug("[ScheduleManager] Found %d enabled schedules", len(schedules))
+
+            for schedule in schedules:
+                try:
+                    should_run = self._should_execute(schedule, session)
+                    LOGGER.debug(
+                        "[ScheduleManager] Schedule %d (type=%s, persona=%s): should_execute=%s",
+                        schedule.SCHEDULE_ID,
+                        schedule.SCHEDULE_TYPE,
+                        schedule.PERSONA_ID,
+                        should_run,
+                    )
+                    if should_run:
+                        self._execute_schedule(schedule, session)
+                except Exception as e:
+                    LOGGER.error(
+                        "[ScheduleManager] Error checking schedule %d: %s",
+                        schedule.SCHEDULE_ID,
+                        e,
+                        exc_info=True,
+                    )
+        finally:
+            session.close()
+
+    def _should_execute(self, schedule: PersonaSchedule, session) -> bool:
+        """スケジュールを実行すべきかを判定"""
+        schedule_id = schedule.SCHEDULE_ID
+        schedule_type = schedule.SCHEDULE_TYPE
+        now = datetime.now(timezone.utc)
+
+        # ペルソナのタイムゾーンを取得
+        persona_tz = self._get_persona_timezone(schedule.PERSONA_ID, session)
+        local_now = now.astimezone(persona_tz)
+
+        if schedule_type == "periodic":
+            return self._should_execute_periodic(schedule, local_now, schedule_id)
+        elif schedule_type == "oneshot":
+            return self._should_execute_oneshot(schedule, now)
+        elif schedule_type == "interval":
+            return self._should_execute_interval(schedule, now)
+        else:
+            LOGGER.warning("[ScheduleManager] Unknown schedule type: %s", schedule_type)
+            return False
+
+    def _should_execute_periodic(self, schedule: PersonaSchedule, local_now: datetime, schedule_id: int) -> bool:
+        """定期スケジュールの発火判定"""
+        # 曜日チェック
+        if schedule.DAYS_OF_WEEK:
+            try:
+                days = json.loads(schedule.DAYS_OF_WEEK)
+                if local_now.weekday() not in days:
+                    return False
+            except Exception:
+                LOGGER.warning("[ScheduleManager] Failed to parse DAYS_OF_WEEK for schedule %d", schedule_id)
+                return False
+
+        # 時刻チェック
+        if not schedule.TIME_OF_DAY:
+            return False
+
+        target_time = schedule.TIME_OF_DAY
+        current_time = local_now.strftime("%H:%M")
+
+        # 前回のチェック時刻を取得
+        last_check = self._last_check_times.get(schedule_id)
+        self._last_check_times[schedule_id] = local_now
+
+        # 現在時刻が目標時刻と一致し、かつ前回チェックから一定時間経過している場合に実行
+        if current_time == target_time:
+            if last_check is None or (local_now - last_check).total_seconds() > 60:
+                return True
+
+        return False
+
+    def _should_execute_oneshot(self, schedule: PersonaSchedule, now: datetime) -> bool:
+        """単発スケジュールの発火判定"""
+        if schedule.COMPLETED:
+            LOGGER.debug("[ScheduleManager] Schedule %d already completed", schedule.SCHEDULE_ID)
+            return False
+
+        if not schedule.SCHEDULED_DATETIME:
+            LOGGER.warning("[ScheduleManager] Schedule %d has no SCHEDULED_DATETIME", schedule.SCHEDULE_ID)
+            return False
+
+        # スケジュール時刻を過ぎているかチェック
+        scheduled_time = schedule.SCHEDULED_DATETIME
+        if scheduled_time.tzinfo is None:
+            scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
+
+        should_execute = now >= scheduled_time
+        LOGGER.debug(
+            "[ScheduleManager] Oneshot schedule %d: now=%s, scheduled=%s, should_execute=%s",
+            schedule.SCHEDULE_ID,
+            now.isoformat(),
+            scheduled_time.isoformat(),
+            should_execute,
+        )
+        return should_execute
+
+    def _should_execute_interval(self, schedule: PersonaSchedule, now: datetime) -> bool:
+        """恒常スケジュールの発火判定"""
+        if not schedule.INTERVAL_SECONDS:
+            return False
+
+        last_executed = schedule.LAST_EXECUTED_AT
+        if last_executed is None:
+            # 初回実行
+            return True
+
+        if last_executed.tzinfo is None:
+            last_executed = last_executed.replace(tzinfo=timezone.utc)
+
+        elapsed = (now - last_executed).total_seconds()
+        return elapsed >= schedule.INTERVAL_SECONDS
+
+    def _generate_schedule_prompt(self, schedule: PersonaSchedule, session, persona_id: str) -> str:
+        """スケジュール実行時のプロンプトを生成"""
+        now = datetime.now(timezone.utc)
+        persona_tz = self._get_persona_timezone(persona_id, session)
+        local_now = now.astimezone(persona_tz)
+
+        # スケジュールタイプに応じた実行日時の取得
+        scheduled_time_str = ""
+        if schedule.SCHEDULE_TYPE == "periodic":
+            # 定期スケジュールの場合、曜日と時刻を表示
+            days_str = "毎日"
+            if schedule.DAYS_OF_WEEK:
+                try:
+                    day_list = json.loads(schedule.DAYS_OF_WEEK)
+                    day_names = ["月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日", "日曜日"]
+                    days_str = ", ".join([day_names[d] for d in day_list if 0 <= d < 7])
+                except Exception:
+                    pass
+            scheduled_time_str = f"{days_str} {schedule.TIME_OF_DAY or '??:??'}"
+
+        elif schedule.SCHEDULE_TYPE == "oneshot":
+            # 単発スケジュールの場合、設定された日時を表示
+            if schedule.SCHEDULED_DATETIME:
+                dt_utc = schedule.SCHEDULED_DATETIME
+                if dt_utc.tzinfo is None:
+                    dt_utc = dt_utc.replace(tzinfo=timezone.utc)
+                dt_local = dt_utc.astimezone(persona_tz)
+                scheduled_time_str = dt_local.strftime("%Y年%m月%d日 %H:%M")
+
+        elif schedule.SCHEDULE_TYPE == "interval":
+            # 恒常スケジュールの場合、インターバルを表示
+            interval_sec = schedule.INTERVAL_SECONDS or 0
+            if interval_sec >= 3600:
+                hours = interval_sec // 3600
+                scheduled_time_str = f"{hours}時間ごと"
+            elif interval_sec >= 60:
+                minutes = interval_sec // 60
+                scheduled_time_str = f"{minutes}分ごと"
+            else:
+                scheduled_time_str = f"{interval_sec}秒ごと"
+
+        # プロンプトを生成
+        prompt = f"""<system>
+スケジュールが実行されました。
+
+現在の日時: {local_now.strftime("%Y年%m月%d日 %H:%M")} ({persona_tz})
+スケジュールタイプ: {schedule.SCHEDULE_TYPE}
+スケジュール設定: {scheduled_time_str}
+スケジュールの説明: {schedule.DESCRIPTION or "（説明なし）"}
+</system>"""
+
+        LOGGER.debug("[ScheduleManager] Generated prompt: %s", prompt)
+        return prompt
+
+    def _execute_schedule(self, schedule: PersonaSchedule, session):
+        """スケジュールを実行"""
+        persona_id = schedule.PERSONA_ID
+        meta_playbook = schedule.META_PLAYBOOK
+
+        LOGGER.info(
+            "[ScheduleManager] Executing schedule %d for persona %s (type=%s, playbook=%s)",
+            schedule.SCHEDULE_ID,
+            persona_id,
+            schedule.SCHEDULE_TYPE,
+            meta_playbook,
+        )
+
+        # ペルソナを取得
+        persona = self.manager.all_personas.get(persona_id)
+        if not persona:
+            LOGGER.warning("[ScheduleManager] Persona %s not found in all_personas", persona_id)
+            return
+
+        # ペルソナの現在地を取得
+        building_id = getattr(persona, "current_building_id", None)
+        if not building_id:
+            LOGGER.warning("[ScheduleManager] Persona %s has no current_building_id", persona_id)
+            return
+
+        # スケジュール実行用のプロンプトを生成
+        user_input = self._generate_schedule_prompt(schedule, session, persona_id)
+
+        # メタプレイブックを実行
+        try:
+            sea_enabled = hasattr(self.manager, "sea_enabled") and self.manager.sea_enabled
+            LOGGER.debug(
+                "[ScheduleManager] SEA framework check: sea_enabled=%s, has_sea_runtime=%s",
+                sea_enabled,
+                hasattr(self.manager, "sea_runtime"),
+            )
+
+            if sea_enabled:
+                # SEA有効時はrun_meta_userを使用
+                occupants = self.manager.occupants.get(building_id, [])
+                LOGGER.info(
+                    "[ScheduleManager] Calling sea_runtime.run_meta_user with playbook=%s, building=%s, prompt_length=%d",
+                    meta_playbook,
+                    building_id,
+                    len(user_input),
+                )
+                self.manager.sea_runtime.run_meta_user(
+                    persona=persona,
+                    user_input=user_input,
+                    building_id=building_id,
+                    metadata={"schedule_id": schedule.SCHEDULE_ID, "schedule_type": schedule.SCHEDULE_TYPE},
+                    meta_playbook=meta_playbook,
+                )
+                LOGGER.info("[ScheduleManager] sea_runtime.run_meta_user completed")
+            else:
+                LOGGER.warning("[ScheduleManager] SEA framework not enabled, schedule execution skipped")
+
+            # 実行後の状態更新
+            self._update_schedule_after_execution(schedule, session)
+
+        except Exception as e:
+            LOGGER.error(
+                "[ScheduleManager] Failed to execute schedule %d: %s",
+                schedule.SCHEDULE_ID,
+                e,
+                exc_info=True,
+            )
+
+    def _update_schedule_after_execution(self, schedule: PersonaSchedule, session):
+        """スケジュール実行後の状態を更新"""
+        now = datetime.now(timezone.utc)
+
+        if schedule.SCHEDULE_TYPE == "oneshot":
+            # 単発スケジュールは完了フラグを立てる
+            schedule.COMPLETED = True
+            session.commit()
+            LOGGER.info("[ScheduleManager] Oneshot schedule %d marked as completed", schedule.SCHEDULE_ID)
+
+        elif schedule.SCHEDULE_TYPE == "interval":
+            # 恒常スケジュールは最終実行時刻を更新
+            schedule.LAST_EXECUTED_AT = now
+            session.commit()
+            LOGGER.info("[ScheduleManager] Interval schedule %d updated LAST_EXECUTED_AT", schedule.SCHEDULE_ID)
+
+    def _get_persona_timezone(self, persona_id: str, session) -> ZoneInfo:
+        """ペルソナのホームCityのタイムゾーンを取得"""
+        try:
+            persona_model = session.query(AIModel).filter(AIModel.AIID == persona_id).first()
+            if not persona_model:
+                LOGGER.warning("[ScheduleManager] Persona %s not found in database", persona_id)
+                return ZoneInfo("UTC")
+
+            city_model = session.query(CityModel).filter(CityModel.CITYID == persona_model.HOME_CITYID).first()
+            if not city_model or not city_model.TIMEZONE:
+                LOGGER.warning("[ScheduleManager] City timezone not found for persona %s", persona_id)
+                return ZoneInfo("UTC")
+
+            return ZoneInfo(city_model.TIMEZONE)
+        except Exception as e:
+            LOGGER.warning("[ScheduleManager] Failed to get timezone for persona %s: %s", persona_id, e)
+            return ZoneInfo("UTC")

--- a/schedule_manager.py
+++ b/schedule_manager.py
@@ -152,7 +152,7 @@ class ScheduleManager:
 
         # 現在時刻が目標時刻と一致し、かつ前回チェックから一定時間経過している場合に実行
         if current_time == target_time:
-            if last_check is None or (local_now - last_check).total_seconds() > 60:
+            if last_check is None or (local_now - last_check).total_seconds() >= 60:
                 return True
 
         return False

--- a/scripts/import_playbook.py
+++ b/scripts/import_playbook.py
@@ -4,13 +4,14 @@
 Usage:
   python scripts/import_playbook.py --file path/to/playbook.json \
       [--scope public|personal|building] [--persona-id PERSONA] [--building-id BUILDING] \
-      [--router-callable | --no-router-callable]
+      [--router-callable | --no-router-callable] [--user-selectable | --no-user-selectable]
 
 Notes:
 - scope=personal なら persona-id が必要。
 - scope=building なら building-id が必要。
 - description/name は JSON から取るが、--name/--description で上書きも可能。
 - --router-callable: playbookをrouterから呼び出せるようにする。指定しない場合はJSONのrouter_callableフィールドを参照。
+- --user-selectable: meta playbookをUIで選択可能にする。指定しない場合はJSONのuser_selectableフィールドを参照。
 """
 
 from __future__ import annotations
@@ -63,7 +64,9 @@ def main() -> None:
     parser.add_argument("--description", help="Override description")
     parser.add_argument("--router-callable", dest="router_callable", action="store_true", help="Mark playbook as callable from router")
     parser.add_argument("--no-router-callable", dest="router_callable", action="store_false", help="Mark playbook as not callable from router")
-    parser.set_defaults(router_callable=None)
+    parser.add_argument("--user-selectable", dest="user_selectable", action="store_true", help="Mark meta playbook as selectable by user in UI")
+    parser.add_argument("--no-user-selectable", dest="user_selectable", action="store_false", help="Mark meta playbook as not selectable by user in UI")
+    parser.set_defaults(router_callable=None, user_selectable=None)
     args = parser.parse_args()
 
     path = Path(args.file)
@@ -89,9 +92,11 @@ def main() -> None:
         building_id=building_id,
         playbook_json=json.dumps(data, ensure_ascii=False),
         router_callable=args.router_callable,
+        user_selectable=args.user_selectable,
     )
     router_status = "router-callable" if (args.router_callable if args.router_callable is not None else data.get("router_callable", False)) else "not router-callable"
-    print(f"Imported playbook '{name}' (scope={scope}, {router_status}).")
+    user_status = "user-selectable" if (args.user_selectable if args.user_selectable is not None else data.get("user_selectable", False)) else "not user-selectable"
+    print(f"Imported playbook '{name}' (scope={scope}, {router_status}, {user_status}).")
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_models_to_directory.py
+++ b/scripts/migrate_models_to_directory.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Migrate models.json to models/ directory structure."""
+
+import json
+import re
+from pathlib import Path
+
+
+def sanitize_filename(model_id: str) -> str:
+    """Convert model ID to a valid filename."""
+    # Replace slashes and colons with hyphens
+    sanitized = model_id.replace("/", "-").replace(":", "-")
+    # Remove other problematic characters
+    sanitized = re.sub(r"[^\w\-.]", "-", sanitized)
+    return sanitized
+
+
+def generate_display_name(model_id: str) -> str:
+    """Generate a human-readable display name from model ID."""
+    # Split by common separators
+    parts = re.split(r"[/:\-_]", model_id)
+
+    # Capitalize and clean up parts
+    cleaned_parts = []
+    for part in parts:
+        # Skip common prefixes/suffixes
+        if part.lower() in ("hf.co", "unsloth", "gguf", "instruct", "v0.1"):
+            continue
+        # Handle version numbers
+        if re.match(r"^\d+\.\d+", part):
+            part = f"v{part}"
+        # Capitalize
+        cleaned_parts.append(part.capitalize())
+
+    return " ".join(cleaned_parts)
+
+
+def main():
+    models_json_path = Path("models.json")
+    models_dir = Path("models")
+
+    if not models_json_path.exists():
+        print("models.json not found!")
+        return
+
+    # Load existing models.json
+    with models_json_path.open("r", encoding="utf-8") as f:
+        models = json.load(f)
+
+    print(f"Found {len(models)} models in models.json")
+
+    # Create models directory
+    models_dir.mkdir(exist_ok=True)
+
+    # Track existing files to avoid overwriting
+    existing_files = {f.stem: f for f in models_dir.glob("*.json")}
+
+    migrated_count = 0
+    skipped_count = 0
+
+    for model_id, config in models.items():
+        # Generate filename
+        filename = sanitize_filename(model_id) + ".json"
+        file_path = models_dir / filename
+
+        # Check if file already exists
+        if file_path.stem in existing_files:
+            print(f"  ⏭️  Skipping {model_id} (file already exists: {filename})")
+            skipped_count += 1
+            continue
+
+        # Build new config structure
+        new_config = {
+            "model": model_id,
+            "display_name": config.get("display_name") or generate_display_name(model_id),
+            **config  # Include all original fields
+        }
+
+        # Add structured_output_backend for Nvidia NIM Mistral models
+        if "mistralai" in model_id.lower() and config.get("base_url") == "https://integrate.api.nvidia.com/v1":
+            if "structured_output_backend" not in new_config:
+                new_config["structured_output_backend"] = "xgrammar"
+                print(f"  ✨ Added xgrammar backend to {model_id}")
+
+        # Write to file
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(new_config, f, indent=2, ensure_ascii=False)
+            f.write("\n")  # Add trailing newline
+
+        print(f"  ✅ Migrated {model_id} -> {filename}")
+        migrated_count += 1
+
+    print(f"\n✨ Migration complete!")
+    print(f"   Migrated: {migrated_count}")
+    print(f"   Skipped (already exist): {skipped_count}")
+    print(f"   Total models: {len(models)}")
+    print(f"\nℹ️  You can now review and edit display names in {models_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/sea/langgraph_runner.py
+++ b/sea/langgraph_runner.py
@@ -24,6 +24,7 @@ def compile_playbook(
     say_node_factory: Optional[Callable[[Any], Callable[[dict], Any]]] = None,
     memorize_node_factory: Optional[Callable[[Any], Callable[[dict], Any]]] = None,
     exec_node_factory: Optional[Callable[[Any], Callable[[dict], Any]]] = None,
+    subplay_node_factory: Optional[Callable[[Any], Callable[[dict], Any]]] = None,
 ) -> Optional[Callable[[dict], Any]]:
     """Compile a PlaybookSchema into a LangGraph runnable coroutine.
 
@@ -34,81 +35,153 @@ def compile_playbook(
         return None
 
     from sea.playbook_models import NodeType
+    import logging
+    logger = logging.getLogger(__name__)
 
-    graph = StateGraph(dict)
+    try:
+        graph = StateGraph(dict)
+        logger.debug("[langgraph] Compiling playbook '%s' with %d nodes", playbook.name, len(playbook.nodes))
 
-    for node_def in playbook.nodes:
-        if node_def.id == "exec" and exec_node_factory is not None:
-            graph.add_node(node_def.id, exec_node_factory(node_def))
-        elif node_def.type == NodeType.LLM:
-            graph.add_node(node_def.id, llm_node_factory(node_def))
-        elif node_def.type == NodeType.TOOL:
-            graph.add_node(node_def.id, tool_node_factory(node_def))
-        elif node_def.type == NodeType.SPEAK:
-            graph.add_node(node_def.id, speak_node)
-        elif node_def.type == NodeType.SAY and say_node_factory is not None:
-            graph.add_node(node_def.id, say_node_factory(node_def))
-        elif node_def.type == NodeType.THINK:
-            graph.add_node(node_def.id, think_node)
-        elif node_def.type == NodeType.MEMORY and memorize_node_factory is not None:
-            graph.add_node(node_def.id, memorize_node_factory(node_def))
-        elif node_def.type == NodeType.PASS:
-            graph.add_node(node_def.id, lambda state: state)
+        for node_def in playbook.nodes:
+            logger.debug("[langgraph] Adding node '%s' (type=%s) to playbook '%s'",
+                        node_def.id, node_def.type, playbook.name)
 
-    graph.add_edge(START, playbook.start_node)
-    for node_def in playbook.nodes:
-        # Check for conditional_next first (takes precedence over next)
-        conditional_next = getattr(node_def, "conditional_next", None)
-        if conditional_next:
-            # Create routing function that returns path key (not node ID directly)
-            def make_router(cond_next):
-                def router_fn(state: dict) -> str:
-                    import logging
-                    logger = logging.getLogger(__name__)
+            if node_def.id == "exec" and exec_node_factory is not None:
+                graph.add_node(node_def.id, exec_node_factory(node_def))
+            elif node_def.type == NodeType.LLM:
+                graph.add_node(node_def.id, llm_node_factory(node_def))
+            elif node_def.type == NodeType.TOOL:
+                graph.add_node(node_def.id, tool_node_factory(node_def))
+            elif node_def.type == NodeType.SPEAK:
+                graph.add_node(node_def.id, speak_node)
+            elif node_def.type == NodeType.SAY and say_node_factory is not None:
+                graph.add_node(node_def.id, say_node_factory(node_def))
+            elif node_def.type == NodeType.SAY and say_node_factory is None:
+                logger.error("[langgraph] Cannot add SAY node '%s': say_node_factory is None", node_def.id)
+                return None
+            elif node_def.type == NodeType.THINK:
+                graph.add_node(node_def.id, think_node)
+            elif node_def.type == NodeType.MEMORY and memorize_node_factory is not None:
+                graph.add_node(node_def.id, memorize_node_factory(node_def))
+            elif node_def.type == NodeType.MEMORY and memorize_node_factory is None:
+                logger.error("[langgraph] Cannot add MEMORY node '%s': memorize_node_factory is None", node_def.id)
+                return None
+            elif node_def.type == NodeType.SUBPLAY and subplay_node_factory is not None:
+                graph.add_node(node_def.id, subplay_node_factory(node_def))
+            elif node_def.type == NodeType.SUBPLAY and subplay_node_factory is None:
+                logger.error("[langgraph] Cannot add SUBPLAY node '%s': subplay_node_factory is None", node_def.id)
+                return None
+            elif node_def.type == NodeType.PASS:
+                graph.add_node(node_def.id, lambda state: state)
+            else:
+                logger.error("[langgraph] Unhandled node type '%s' for node '%s' in playbook '%s'",
+                             node_def.type, node_def.id, playbook.name)
+                return None
 
-                    # Resolve field value from state (supports nested keys)
-                    field_path = cond_next.field.split(".")
-                    value = state
-                    for key in field_path:
-                        if isinstance(value, dict):
-                            value = value.get(key)
+        logger.debug("[langgraph] Adding edges for playbook '%s'", playbook.name)
+        try:
+            graph.add_edge(START, playbook.start_node)
+            logger.debug("[langgraph] Added START -> '%s'", playbook.start_node)
+        except Exception as e:
+            logger.error("[langgraph] Failed to add START edge: %s", e, exc_info=True)
+            return None
+
+        for node_def in playbook.nodes:
+            logger.debug("[langgraph] Processing edges for node '%s'", node_def.id)
+            # Check for conditional_next first (takes precedence over next)
+            conditional_next = getattr(node_def, "conditional_next", None)
+            if conditional_next:
+                logger.debug("[langgraph] Node '%s' has conditional_next", node_def.id)
+                # Create routing function that returns path key (not node ID directly)
+                def make_router(cond_next):
+                    def router_fn(state: dict) -> str:
+                        import logging
+                        logger = logging.getLogger(__name__)
+
+                        # Resolve field value from state (supports nested keys)
+                        field_path = cond_next.field.split(".")
+                        value = state
+                        for key in field_path:
+                            if isinstance(value, dict):
+                                value = value.get(key)
+                            else:
+                                value = None
+                                break
+
+                        # Convert to string for matching
+                        value_str = str(value) if value is not None else ""
+
+                        logger.debug("[langgraph] conditional_next: field=%s value=%s cases=%s", cond_next.field, value_str, list(cond_next.cases.keys()))
+
+                        # Return the matched case value (not the target node)
+                        if value_str in cond_next.cases:
+                            result = value_str
+                        elif "default" in cond_next.cases:
+                            result = "default"
                         else:
-                            value = None
-                            break
+                            result = "__end__"
 
-                    # Convert to string for matching
-                    value_str = str(value) if value is not None else ""
+                        logger.debug("[langgraph] conditional_next: selected path=%s -> target=%s", result, cond_next.cases.get(result, "END"))
+                        return result
+                    return router_fn
 
-                    logger.debug("[langgraph] conditional_next: field=%s value=%s cases=%s", cond_next.field, value_str, list(cond_next.cases.keys()))
-
-                    # Return the matched case value (not the target node)
-                    if value_str in cond_next.cases:
-                        result = value_str
-                    elif "default" in cond_next.cases:
-                        result = "default"
+                # Build path_map: case_value -> target_node_or_END
+                path_map = {}
+                for case_value, target_node in conditional_next.cases.items():
+                    if target_node is None:
+                        path_map[case_value] = END
                     else:
-                        result = "__end__"
+                        path_map[case_value] = target_node
+                # Add fallback for unmatched cases
+                if "__end__" not in path_map:
+                    path_map["__end__"] = END
 
-                    logger.debug("[langgraph] conditional_next: selected path=%s -> target=%s", result, cond_next.cases.get(result, "END"))
-                    return result
-                return router_fn
+                try:
+                    graph.add_conditional_edges(node_def.id, make_router(conditional_next), path_map)
+                    logger.debug("[langgraph] Added conditional edges for '%s'", node_def.id)
+                except Exception as e:
+                    logger.error("[langgraph] Failed to add conditional edges for '%s': %s", node_def.id, e, exc_info=True)
+                    return None
+            elif node_def.next:
+                try:
+                    graph.add_edge(node_def.id, node_def.next)
+                    logger.debug("[langgraph] Added edge '%s' -> '%s'", node_def.id, node_def.next)
+                except Exception as e:
+                    logger.error("[langgraph] Failed to add edge '%s' -> '%s': %s", node_def.id, node_def.next, e, exc_info=True)
+                    return None
+            else:
+                try:
+                    graph.add_edge(node_def.id, END)
+                    logger.debug("[langgraph] Added edge '%s' -> END", node_def.id)
+                except Exception as e:
+                    logger.error("[langgraph] Failed to add edge '%s' -> END: %s", node_def.id, e, exc_info=True)
+                    return None
 
-            # Build path_map: case_value -> target_node_or_END
-            path_map = {}
-            for case_value, target_node in conditional_next.cases.items():
-                if target_node is None:
-                    path_map[case_value] = END
-                else:
-                    path_map[case_value] = target_node
-            # Add fallback for unmatched cases
-            if "__end__" not in path_map:
-                path_map["__end__"] = END
+        logger.debug("[langgraph] All edges added successfully for playbook '%s'", playbook.name)
+        logger.debug("[langgraph] Calling graph.compile() for playbook '%s'", playbook.name)
 
-            graph.add_conditional_edges(node_def.id, make_router(conditional_next), path_map)
-        elif node_def.next:
-            graph.add_edge(node_def.id, node_def.next)
-        else:
-            graph.add_edge(node_def.id, END)
+        try:
+            compiled = graph.compile()
+            logger.debug("[langgraph] graph.compile() completed without exception")
+        except Exception as e:
+            logger.error("[langgraph] graph.compile() threw exception: %s", e, exc_info=True)
+            return None
 
-    compiled = graph.compile()
-    return compiled.ainvoke
+        logger.debug("[langgraph] graph.compile() returned: %s (type: %s)",
+                    compiled, type(compiled).__name__ if compiled else "None")
+
+        if compiled is None:
+            logger.error("[langgraph] graph.compile() returned None for playbook '%s'", playbook.name)
+            return None
+
+        # Check if compiled object has ainvoke
+        if not hasattr(compiled, 'ainvoke'):
+            logger.error("[langgraph] Compiled object does not have 'ainvoke' attribute. Available: %s",
+                        dir(compiled))
+            return None
+
+        logger.debug("[langgraph] Compilation successful for playbook '%s', returning ainvoke", playbook.name)
+        return compiled.ainvoke
+    except Exception as exc:
+        logger.exception("[langgraph] Failed to compile playbook '%s': %s", playbook.name, exc)
+        return None

--- a/sea/playbook_models.py
+++ b/sea/playbook_models.py
@@ -47,6 +47,16 @@ class LLMNodeDef(BaseModel):
         default=None,
         description="Key name to store structured output for later nodes. Defaults to node id."
     )
+    available_tools: Optional[List[str]] = Field(
+        default=None,
+        description="List of tool names that the LLM can call. If specified, enables tool calling for this node."
+    )
+    output_keys: Optional[List[Dict[str, str]]] = Field(
+        default=None,
+        description="Map output types to state keys. Examples: [{'text': 'speak_content'}, {'function_call': 'tool_call'}]. "
+                    "Supported types: 'text', 'function_call', 'thought'. "
+                    "Function calls are stored as nested keys: '<key>.name', '<key>.args.<arg_name>'."
+    )
 
 
 class ToolNodeDef(BaseModel):

--- a/sea/playbook_models.py
+++ b/sea/playbook_models.py
@@ -197,6 +197,10 @@ class PlaybookSchema(BaseModel):
         default=False,
         description="If true, this playbook can be called from the router in meta playbooks."
     )
+    user_selectable: bool = Field(
+        default=False,
+        description="If true, this meta playbook can be selected by user in the UI."
+    )
     nodes: List[NodeDef]
     start_node: str
 

--- a/sea/playbooks/public/building_move_playbook.json
+++ b/sea/playbooks/public/building_move_playbook.json
@@ -1,0 +1,66 @@
+{
+  "name": "building_move",
+  "description": "List buildings in the city, choose a destination, and move there.",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "Optional note or hint about where to go"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": true,
+  "nodes": [
+    {
+      "id": "list_buildings",
+      "type": "tool",
+      "action": "list_city_buildings",
+      "args_input": {},
+      "output_key": "buildings_json",
+      "next": "decide_destination"
+    },
+    {
+      "id": "decide_destination",
+      "type": "llm",
+      "action": "以下の建物一覧から、移動先の building_id を1つ選び、JSONで返してください。\n建物一覧:\n{buildings_json}\n現在の入力: {input}\n必ず存在する building_id を選び、移動先が明確になるようにしてください。",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "building_id": {
+            "type": "string",
+            "description": "ID of the building to move to"
+          }
+        },
+        "required": ["building_id"]
+      },
+      "output_key": "move_choice",
+      "next": "move"
+    },
+    {
+      "id": "move",
+      "type": "tool",
+      "action": "move_persona",
+      "args_input": {
+        "building_id": "move_choice.building_id"
+      },
+      "output_key": "move_result",
+      "next": "record"
+    },
+    {
+      "id": "record",
+      "type": "memorize",
+      "action": "{last}",
+      "role": "user",
+      "tags": [
+        "tool",
+        "move_persona"
+      ],
+      "next": null
+    }
+  ],
+  "start_node": "list_buildings"
+}

--- a/sea/playbooks/public/document_create_playbook.json
+++ b/sea/playbooks/public/document_create_playbook.json
@@ -1,0 +1,78 @@
+{
+  "name": "document_create",
+  "description": "Create a new document item with text content",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "Request to create a document"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": true,
+  "nodes": [
+    {
+      "id": "generate_content",
+      "type": "llm",
+      "action": "document_createツールの引数を決定します。ユーザーの要求に基づいて、文書の名前、説明、内容を生成してください。",
+      "next": "record_response",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the document (e.g., '私の日記', 'SAIVerse使い方ガイド')"
+          },
+          "description": {
+            "type": "string",
+            "description": "Brief description of the document"
+          },
+          "content": {
+            "type": "string",
+            "description": "Full text content of the document"
+          }
+        },
+        "required": ["name", "description", "content"]
+      },
+      "output_key": "document_data"
+    },
+    {
+      "id": "record_response",
+      "type": "memorize",
+      "action": "{document_data}",
+      "role": "assistant",
+      "tags": [
+        "tool",
+        "document_create"
+      ],
+      "next": "create"
+    },
+    {
+      "id": "create",
+      "type": "tool",
+      "action": "document_create",
+      "args_input": {
+        "name": "document_data.name",
+        "description": "document_data.description",
+        "content": "document_data.content"
+      },
+      "next": "record_result"
+    },
+    {
+      "id": "record_result",
+      "type": "memorize",
+      "action": "{last}",
+      "role": "user",
+      "tags": [
+        "tool",
+        "document_create"
+      ],
+      "next": null
+    }
+  ],
+  "start_node": "generate_content"
+}

--- a/sea/playbooks/public/item_edit_playbook.json
+++ b/sea/playbooks/public/item_edit_playbook.json
@@ -8,7 +8,7 @@
     }
   ],
   "context_requirements": {
-    "history_depth": 4000,
+    "history_depth": "full",
     "inventory": true,
     "building_items": true,
     "system_prompt": true

--- a/sea/playbooks/public/item_edit_playbook.json
+++ b/sea/playbooks/public/item_edit_playbook.json
@@ -1,0 +1,109 @@
+{
+  "name": "item_edit",
+  "description": "View an item and optionally edit it (update description or patch content for documents)",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "Request to edit an item"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": 4000,
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": true,
+  "nodes": [
+    {
+      "id": "select_item",
+      "type": "llm",
+      "model_type": "lightweight",
+      "action": "item_viewツールの引数を決定します。ユーザーの要求と現在の状況（インベントリと建物内のアイテム）から、閲覧するアイテムのIDを選択してください。",
+      "next": "view",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "item_id": {
+            "type": "string",
+            "description": "ID of the item to view"
+          }
+        },
+        "required": ["item_id"]
+      },
+      "output_key": "selected_item"
+    },
+    {
+      "id": "view",
+      "type": "tool",
+      "model_type": "lightweight",
+      "action": "item_view",
+      "args_input": {
+        "item_id": "selected_item.item_id"
+      },
+      "next": "decide_action"
+    },
+    {
+      "id": "decide_action",
+      "type": "llm",
+      "action": "アイテムの内容を確認しました。ユーザーの要求に応じて、編集するか閲覧だけで終わるかを判断してください。編集する場合は、action_json_stringフィールドにJSON文字列を生成してください。形式: {\"action_type\": \"update_description\" | \"patch_content\", \"description\": \"...\", \"patch\": \"...\"}",
+      "next": null,
+      "conditional_next": {
+        "field": "decision.action",
+        "cases": {
+          "edit": "use_item",
+          "view_only": "record_view"
+        }
+      },
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["edit", "view_only"],
+            "description": "Whether to edit the item or just view it"
+          },
+          "action_json_string": {
+            "type": "string",
+            "description": "JSON string for item_use tool (only if action=edit). Format: {\"action_type\": \"update_description\" | \"patch_content\", \"description\": \"...\", \"patch\": \"...\"}"
+          }
+        },
+        "required": ["action"]
+      },
+      "output_key": "decision"
+    },
+    {
+      "id": "use_item",
+      "type": "tool",
+      "action": "item_use",
+      "args_input": {
+        "item_id": "selected_item.item_id",
+        "action_json": "decision.action_json_string"
+      },
+      "next": "record_edit"
+    },
+    {
+      "id": "record_edit",
+      "type": "memorize",
+      "action": "{last}",
+      "role": "user",
+      "tags": [
+        "tool",
+        "item_edit"
+      ],
+      "next": null
+    },
+    {
+      "id": "record_view",
+      "type": "memorize",
+      "action": "{last}",
+      "role": "user",
+      "tags": [
+        "tool",
+        "item_view"
+      ],
+      "next": null
+    }
+  ],
+  "start_node": "select_item"
+}

--- a/sea/playbooks/public/item_pickup_playbook.json
+++ b/sea/playbooks/public/item_pickup_playbook.json
@@ -8,7 +8,7 @@
     }
   ],
   "context_requirements": {
-    "history_depth": 0,
+    "history_depth": "full",
     "inventory": true,
     "building_items": true,
     "system_prompt": true

--- a/sea/playbooks/public/item_place_playbook.json
+++ b/sea/playbooks/public/item_place_playbook.json
@@ -8,7 +8,7 @@
     }
   ],
   "context_requirements": {
-    "history_depth": 0,
+    "history_depth": "full",
     "inventory": true,
     "building_items": false,
     "system_prompt": true

--- a/sea/playbooks/public/item_use_playbook.json
+++ b/sea/playbooks/public/item_use_playbook.json
@@ -8,7 +8,7 @@
     }
   ],
   "context_requirements": {
-    "history_depth": 0,
+    "history_depth": "full",
     "inventory": true,
     "building_items": false,
     "system_prompt": true

--- a/sea/playbooks/public/item_view_playbook.json
+++ b/sea/playbooks/public/item_view_playbook.json
@@ -8,7 +8,7 @@
     }
   ],
   "context_requirements": {
-    "history_depth": 4000,
+    "history_depth": "full",
     "inventory": true,
     "building_items": true,
     "system_prompt": true

--- a/sea/playbooks/public/item_view_playbook.json
+++ b/sea/playbooks/public/item_view_playbook.json
@@ -1,0 +1,58 @@
+{
+  "name": "item_view",
+  "description": "View the full content of a picture or document item",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "Request to view an item"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": 4000,
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": true,
+  "nodes": [
+    {
+      "id": "select_item",
+      "type": "llm",
+      "model_type": "lightweight",
+      "action": "item_viewツールの引数を決定します。ユーザーの要求と現在の状況（インベントリと建物内のアイテム）から、閲覧するアイテムのIDを選択してください。",
+      "next": "view",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "item_id": {
+            "type": "string",
+            "description": "ID of the item to view"
+          }
+        },
+        "required": ["item_id"]
+      },
+      "output_key": "selected_item"
+    },
+    {
+      "id": "view",
+      "type": "tool",
+      "action": "item_view",
+      "args_input": {
+        "item_id": "selected_item.item_id"
+      },
+      "next": "record"
+    },
+    {
+      "id": "record",
+      "type": "memorize",
+      "action": "{last}",
+      "role": "user",
+      "tags": [
+        "tool",
+        "item_view"
+      ],
+      "next": null
+    }
+  ],
+  "start_node": "select_item"
+}

--- a/sea/playbooks/public/memory_recall_playbook.json
+++ b/sea/playbooks/public/memory_recall_playbook.json
@@ -8,9 +8,9 @@
     }
   ],
   "context_requirements": {
-    "history_depth": 0,
-    "inventory": false,
-    "building_items": false,
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
     "system_prompt": true
   },
   "router_callable": true,

--- a/sea/playbooks/public/meta_exec_speak.json
+++ b/sea/playbooks/public/meta_exec_speak.json
@@ -1,0 +1,54 @@
+{
+  "name": "meta_exec_speak",
+  "description": "Execute a playbook and speak the result (used by call_playbook tool)",
+  "input_schema": [],
+  "output_schema": null,
+  "context_requirements": {
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true,
+    "available_playbooks": false
+  },
+  "router_callable": false,
+  "user_selectable": false,
+  "nodes": [
+    {
+      "id": "exec",
+      "type": "tool",
+      "action": "exec",
+      "args_input": null,
+      "output_key": null,
+      "output_keys": null,
+      "next": "speak",
+      "conditional_next": null
+    },
+    {
+      "id": "speak",
+      "type": "llm",
+      "action": "上記の実行結果を踏まえて、ユーザーに報告する内容を生成してください。\n\n実行結果:\n{context_bundle_text}",
+      "model_type": "normal",
+      "available_tools": [],
+      "next": "log",
+      "conditional_next": null
+    },
+    {
+      "id": "log",
+      "type": "memorize",
+      "action": "{last}",
+      "role": "assistant",
+      "tags": ["conversation"],
+      "metadata_key": "metadata",
+      "next": "say",
+      "conditional_next": null
+    },
+    {
+      "id": "say",
+      "type": "say",
+      "metadata_key": "metadata",
+      "next": null,
+      "conditional_next": null
+    }
+  ],
+  "start_node": "exec"
+}

--- a/sea/playbooks/public/meta_simple_speak.json
+++ b/sea/playbooks/public/meta_simple_speak.json
@@ -1,0 +1,29 @@
+{
+  "name": "meta_simple_speak",
+  "description": "speak only",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "User input"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": false,
+  "user_selectable": true,
+  "nodes": [
+    {
+      "id": "speak",
+      "type": "subplay",
+      "playbook": "sub_speak_meta",
+      "input_template": "{input}",
+      "propagate_output": true,
+      "next": null
+    }
+  ],
+  "start_node": "speak"
+}

--- a/sea/playbooks/public/meta_user.json
+++ b/sea/playbooks/public/meta_user.json
@@ -14,6 +14,7 @@
     "system_prompt": true
   },
   "router_callable": false,
+  "user_selectable": true,
   "nodes": [
     {
       "id": "list_playbooks",

--- a/sea/playbooks/public/schedule_management_playbook.json
+++ b/sea/playbooks/public/schedule_management_playbook.json
@@ -1,0 +1,188 @@
+{
+  "name": "schedule_management",
+  "description": "自分のスケジュールを管理（一覧表示、追加、削除）できます",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "スケジュール管理のリクエスト（例: スケジュールを追加して、明日の朝9時にリマインドしてほしい）"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": true,
+  "nodes": [
+    {
+      "id": "list_schedules",
+      "type": "tool",
+      "action": "schedule_list",
+      "args_input": {},
+      "next": "record_list_result"
+    },
+    {
+      "id": "record_list_result",
+      "type": "memorize",
+      "action": "<system>{last}</system>",
+      "role": "user",
+      "tags": ["tool", "schedule_management"],
+      "next": "determine_action"
+    },
+    {
+      "id": "determine_action",
+      "type": "llm",
+      "model_type": "lightweight",
+      "action": "現在のスケジュール一覧とユーザーのリクエストから、どのスケジュール操作を行うか判断してください。\n\n選択肢：\n- add: 新しいスケジュールを追加する\n- delete: 既存のスケジュールを削除する\n- none: 何もしない（一覧表示のみで終了）",
+      "next": null,
+      "conditional_next": {
+        "field": "action_decision.action",
+        "cases": {
+          "add": "prepare_add",
+          "delete": "prepare_delete",
+          "none": null
+        }
+      },
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["add", "delete", "none"],
+            "description": "実行するアクション"
+          }
+        },
+        "required": ["action"]
+      },
+      "output_key": "action_decision"
+    },
+    {
+      "id": "prepare_add",
+      "type": "llm",
+      "action": "schedule_addツールの引数を決定します。ユーザーのリクエストに基づいてスケジュールを作成してください。\n\n### スケジュールタイプ：\n- periodic: 定期実行（曜日と時刻を指定）\n- oneshot: 単発実行（日時を指定）\n- interval: 一定間隔実行（秒数を指定）\n\n### メタプレイブック：\n通常は「meta_user」を指定してください。\n\n### 現在の日時：\n{current_datetime}\n\n### 注意：\n- 日時や時刻はペルソナのタイムゾーンで指定してください\n- descriptionフィールドには、実行時にAIに伝えたい内容を書いてください（例：「まはーさんに今日のタスクを報告して」）",
+      "next": "record_add_params",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "schedule_type": {
+            "type": "string",
+            "enum": ["periodic", "oneshot", "interval"],
+            "description": "スケジュールタイプ"
+          },
+          "meta_playbook": {
+            "type": "string",
+            "description": "実行するメタプレイブック名（通常は meta_user）"
+          },
+          "description": {
+            "type": "string",
+            "description": "スケジュールの説明（実行時にAIに渡される）"
+          },
+          "priority": {
+            "type": "integer",
+            "description": "優先度（0～100、デフォルト: 0）"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "有効にするか（デフォルト: true）"
+          },
+          "days_of_week": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": "曜日リスト（periodic用、0=月曜日、6=日曜日）"
+          },
+          "time_of_day": {
+            "type": "string",
+            "description": "実行時刻（periodic用、HH:MM形式）"
+          },
+          "scheduled_datetime": {
+            "type": "string",
+            "description": "実行日時（oneshot用、YYYY-MM-DD HH:MM形式）"
+          },
+          "interval_seconds": {
+            "type": "integer",
+            "description": "実行間隔（interval用、秒単位）"
+          }
+        },
+        "required": ["schedule_type", "meta_playbook", "description"]
+      },
+      "output_key": "add_params"
+    },
+    {
+      "id": "record_add_params",
+      "type": "memorize",
+      "action": "{add_params}",
+      "role": "assistant",
+      "tags": ["tool", "schedule_management"],
+      "next": "add_schedule"
+    },
+    {
+      "id": "add_schedule",
+      "type": "tool",
+      "action": "schedule_add",
+      "args_input": {
+        "schedule_type": "add_params.schedule_type",
+        "meta_playbook": "add_params.meta_playbook",
+        "description": "add_params.description",
+        "priority": "add_params.priority",
+        "enabled": "add_params.enabled",
+        "days_of_week": "add_params.days_of_week",
+        "time_of_day": "add_params.time_of_day",
+        "scheduled_datetime": "add_params.scheduled_datetime",
+        "interval_seconds": "add_params.interval_seconds"
+      },
+      "next": "record_add_result"
+    },
+    {
+      "id": "record_add_result",
+      "type": "memorize",
+      "action": "<system>{last}</system>",
+      "role": "user",
+      "tags": ["tool", "schedule_add"],
+      "next": null
+    },
+    {
+      "id": "prepare_delete",
+      "type": "llm",
+      "action": "schedule_deleteツールの引数を決定します。先ほど取得したスケジュール一覧を参照して、削除対象のスケジュールIDを特定してください。\n\nユーザーのリクエストに基づいて、削除すべきスケジュールのIDを決定してください。",
+      "next": "record_delete_params",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "schedule_id": {
+            "type": "integer",
+            "description": "削除するスケジュールのID"
+          }
+        },
+        "required": ["schedule_id"]
+      },
+      "output_key": "delete_params"
+    },
+    {
+      "id": "record_delete_params",
+      "type": "memorize",
+      "action": "{delete_params}",
+      "role": "assistant",
+      "tags": ["tool", "schedule_management"],
+      "next": "delete_schedule"
+    },
+    {
+      "id": "delete_schedule",
+      "type": "tool",
+      "action": "schedule_delete",
+      "args_input": {
+        "schedule_id": "delete_params.schedule_id"
+      },
+      "next": "record_delete_result"
+    },
+    {
+      "id": "record_delete_result",
+      "type": "memorize",
+      "action": "<system>{last}</system>",
+      "role": "user",
+      "tags": ["tool", "schedule_management"],
+      "next": null
+    }
+  ],
+  "start_node": "list_schedules"
+}

--- a/sea/playbooks/public/send_email_to_user_playbook.json
+++ b/sea/playbooks/public/send_email_to_user_playbook.json
@@ -1,0 +1,80 @@
+{
+  "name": "send_email_to_user",
+  "description": "ユーザーにメールを送れます",
+  "input_schema": [
+    {
+      "name": "input",
+      "description": "Request to send a mail to user"
+    }
+  ],
+  "context_requirements": {
+    "history_depth": "full",
+    "inventory": true,
+    "building_items": true,
+    "system_prompt": true
+  },
+  "router_callable": true,
+  "nodes": [
+    {
+      "id": "generate_content",
+      "type": "llm",
+      "action": "send_email_to_userツールの引数を決定します。送信先のユーザーID、件名、本文を生成してください。（メールアドレスは、ユーザーIDから自動で取得されます）\n\n### 送信可能なユーザー：\nまはー(ユーザーID: 1)",
+      "next": "record_response",
+      "response_schema": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "int",
+            "description": "送る対象のユーザーID"
+          },
+          "subject": {
+            "type": "string",
+            "description": "件名"
+          },
+          "body": {
+            "type": "string",
+            "description": "本文。改行してもOK"
+          }
+        },
+        "required": ["user_id", "subject", "body"]
+      },
+      "output_key": "email_data"
+    },
+    {
+      "id": "record_response",
+      "type": "memorize",
+      "action": "{email_data}",
+      "role": "assistant",
+      "tags": [
+        "tool",
+        "send_email_to_user",
+        "conversation"
+      ],
+      "next": "send"
+    },
+    {
+      "id": "send",
+      "type": "tool",
+      "action": "send_email_to_user",
+      "args_input": {
+        "user_id": "email_data.user_id",
+        "subject": "email_data.subject",
+        "body": "email_data.body"
+      },
+      "next": "record_result"
+    },
+    {
+      "id": "record_result",
+      "type": "memorize",
+      "action": "<system>{last}</system>",
+      "role": "user",
+      "tags": [
+        "tool",
+        "send_email_to_user",
+        "conversation"
+      ],
+      "next": null
+    }
+  ],
+  "start_node": "generate_content"
+}

--- a/sea/playbooks/public/sub_router_user.json
+++ b/sea/playbooks/public/sub_router_user.json
@@ -36,18 +36,18 @@
       "response_schema": {
         "type": "object",
         "properties": {
-          "playbook": {
-            "type": "string",
-            "description": "Playbook name to execute (must be one of the available playbooks)"
-          },
           "reason": {
             "type": "string",
             "description": "Brief reason for choosing this playbook"
+          },
+          "playbook": {
+            "type": "string",
+            "description": "Playbook name to execute (must be one of the available playbooks)"
           }
         },
         "required": [
-          "playbook",
-          "reason"
+          "reason",
+          "playbook"
         ]
       },
       "output_key": "router"

--- a/sea/playbooks/public/sub_speak_meta.json
+++ b/sea/playbooks/public/sub_speak_meta.json
@@ -1,50 +1,94 @@
 {
-  "name": "sub_speak_meta",
-  "description": "Compose final response and speak",
-  "input_schema": [
-    {
-      "name": "input",
-      "description": "Composite prompt containing user request and context"
+    "name": "sub_speak_meta",
+    "description": "Compose final response and speak",
+    "input_schema": [
+        {
+            "name": "input",
+            "description": "Composite prompt containing user request and context"
+        },
+        {
+            "name": "metadata",
+            "description": "Optional metadata from tool execution (e.g., media attachments)",
+            "source": "parent.metadata"
+        }
+    ],
+    "context_requirements": {
+        "history_depth": "full",
+        "inventory": true,
+        "building_items": true,
+        "system_prompt": true,
+        "available_playbooks": true
     },
-    {
-      "name": "metadata",
-      "description": "Optional metadata from tool execution (e.g., media attachments)",
-      "source": "parent.metadata"
-    }
-  ],
-  "context_requirements": {
-    "history_depth": "full",
-    "inventory": true,
-    "building_items": true,
-    "system_prompt": true,
-    "available_playbooks": true
-  },
-  "router_callable": false,
-  "nodes": [
-    {
-      "id": "compose",
-      "type": "llm",
-      "action": null,
-      "next": "log"
-    },
-    {
-      "id": "log",
-      "type": "memorize",
-      "action": "{last}",
-      "role": "assistant",
-      "tags": [
-        "conversation"
-      ],
-      "metadata_key": "metadata",
-      "next": "say"
-    },
-    {
-      "id": "say",
-      "type": "say",
-      "action": "{last}",
-      "metadata_key": "metadata",
-      "next": null
-    }
-  ],
-  "start_node": "compose"
+    "router_callable": false,
+    "nodes": [
+        {
+            "id": "compose",
+            "type": "llm",
+            "action": null,
+            "available_tools": ["call_playbook"],
+            "output_keys": [
+                {"text": "speak_content"},
+                {"function_call": "tool_call"}
+            ],
+            "next": "log",
+            "conditional_next": null
+        },
+        {
+            "id": "log",
+            "type": "memorize",
+            "action": "{last}",
+            "role": "assistant",
+            "tags": [
+                "conversation"
+            ],
+            "metadata_key": "metadata",
+            "next": null,
+            "conditional_next": {
+                "field": "has_speak_content",
+                "cases": {
+                    "True": "say",
+                    "False": "check_tool"
+                }
+            }
+        },
+        {
+            "id": "say",
+            "type": "say",
+            "action": "{speak_content}",
+            "metadata_key": "metadata",
+            "next": null,
+            "conditional_next": {
+                "field": "tool_called",
+                "cases": {
+                    "True": "execute_tool",
+                    "False": null
+                }
+            }
+        },
+        {
+            "id": "check_tool",
+            "type": "pass",
+            "next": null,
+            "conditional_next": {
+                "field": "tool_called",
+                "cases": {
+                    "True": "execute_tool",
+                    "False": null
+                }
+            }
+        },
+        {
+            "id": "execute_tool",
+            "type": "tool",
+            "action": "call_playbook",
+            "args_input": {
+                "playbook_name": "tool_call.args.playbook_name"
+            },
+            "output_key": null,
+            "output_keys": null,
+            "next": null,
+            "conditional_next": null
+        }
+    ],
+    "start_node": "compose"
 }

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -255,20 +255,133 @@ class SEARuntime:
                 if response_schema and "available_playbooks" in state:
                     response_schema = self._add_playbook_enum(response_schema, state.get("available_playbooks"))
 
-                # Select LLM client based on model_type
-                llm_client = self._select_llm_client(node_def, persona)
+                # Select LLM client based on model_type and structured output needs
+                needs_structured_output = response_schema is not None
+                llm_client = self._select_llm_client(node_def, persona, needs_structured_output=needs_structured_output)
 
-                text = llm_client.generate(
-                    messages,
-                    tools=[],
-                    temperature=self._default_temperature(persona),
-                    response_schema=response_schema,
-                )
-                self._dump_llm_io(playbook.name, getattr(node_def, "id", ""), persona, messages, text)
-                schema_consumed = self._process_structured_output(node_def, text, state)
+                # Check if tools are available for this node
+                available_tools = getattr(node_def, "available_tools", None)
+                if available_tools:
+                    # Tool calling mode
+                    tools_spec = self._build_tools_spec(available_tools, llm_client)
+                    result = llm_client.generate_with_tool_detection(
+                        messages,
+                        tools=tools_spec,
+                        temperature=self._default_temperature(persona),
+                    )
+
+                    # Parse output_keys to determine where to store results
+                    output_keys_spec = getattr(node_def, "output_keys", None)
+                    text_key = None
+                    function_call_key = None
+                    thought_key = None
+
+                    if output_keys_spec:
+                        for mapping in output_keys_spec:
+                            if "text" in mapping:
+                                text_key = mapping["text"]
+                            if "function_call" in mapping:
+                                function_call_key = mapping["function_call"]
+                            if "thought" in mapping:
+                                thought_key = mapping["thought"]
+
+                    import json
+
+                    if result["type"] == "tool_call":
+                        # Only tool call, no text
+                        if output_keys_spec:
+                            # New behavior: use explicit output_keys
+                            if function_call_key:
+                                state[f"{function_call_key}.name"] = result["tool_name"]
+                                if isinstance(result["tool_args"], dict):
+                                    for arg_name, arg_value in result["tool_args"].items():
+                                        state[f"{function_call_key}.args.{arg_name}"] = arg_value
+                                        LOGGER.debug("[sea] Stored %s.args.%s = %s", function_call_key, arg_name, arg_value)
+                            # Set conditional_next flags
+                            state["tool_called"] = True
+                            state["has_speak_content"] = False
+                        else:
+                            # Legacy behavior: use predefined keys
+                            state["tool_called"] = True
+                            state["tool_name"] = result["tool_name"]
+                            state["tool_args"] = result["tool_args"]
+                            state["has_speak_content"] = False
+                            # Expand tool_args for legacy args_input (tool_arg_*)
+                            if isinstance(result["tool_args"], dict):
+                                for key, value in result["tool_args"].items():
+                                    state[f"tool_arg_{key}"] = value
+                                    LOGGER.debug("[sea] Expanded tool_arg_%s = %s", key, value)
+
+                        # Format as JSON for logging
+                        text = json.dumps({
+                            "tool": result["tool_name"],
+                            "args": result["tool_args"]
+                        }, ensure_ascii=False)
+                        LOGGER.info("[sea] Tool call detected: %s", text)
+
+                    elif result["type"] == "both":
+                        # Both text and tool call
+                        if output_keys_spec:
+                            # New behavior: use explicit output_keys
+                            if text_key:
+                                state[text_key] = result["content"]
+                                LOGGER.debug("[sea] Stored %s = (text, length=%d)", text_key, len(result["content"]))
+                            if function_call_key:
+                                state[f"{function_call_key}.name"] = result["tool_name"]
+                                if isinstance(result["tool_args"], dict):
+                                    for arg_name, arg_value in result["tool_args"].items():
+                                        state[f"{function_call_key}.args.{arg_name}"] = arg_value
+                                        LOGGER.debug("[sea] Stored %s.args.%s = %s", function_call_key, arg_name, arg_value)
+                            # Set conditional_next flags
+                            state["tool_called"] = True
+                            state["has_speak_content"] = bool(text_key)
+                        else:
+                            # Legacy behavior: use predefined keys
+                            state["tool_called"] = True
+                            state["tool_name"] = result["tool_name"]
+                            state["tool_args"] = result["tool_args"]
+                            state["has_speak_content"] = True
+                            state["speak_content"] = result["content"]
+                            # Expand tool_args for legacy args_input (tool_arg_*)
+                            if isinstance(result["tool_args"], dict):
+                                for key, value in result["tool_args"].items():
+                                    state[f"tool_arg_{key}"] = value
+                                    LOGGER.debug("[sea] Expanded tool_arg_%s = %s", key, value)
+
+                        text = result["content"]
+                        LOGGER.info("[sea] Both text and tool call detected: tool=%s, text_length=%d",
+                                    result["tool_name"], len(text))
+
+                    else:
+                        # Normal text response
+                        if output_keys_spec and text_key:
+                            # New behavior: store in explicit text_key
+                            state[text_key] = result["content"]
+                            LOGGER.debug("[sea] Stored %s = (text, length=%d)", text_key, len(result["content"]))
+                            state["has_speak_content"] = True
+                        else:
+                            # Legacy behavior: no specific text storage (just in "last")
+                            state["has_speak_content"] = True
+
+                        state["tool_called"] = False
+                        text = result["content"]
+
+                    self._dump_llm_io(playbook.name, getattr(node_def, "id", ""), persona, messages, text)
+                else:
+                    # Normal mode (no tools)
+                    state["tool_called"] = False
+                    text = llm_client.generate(
+                        messages,
+                        tools=[],
+                        temperature=self._default_temperature(persona),
+                        response_schema=response_schema,
+                    )
+                    self._dump_llm_io(playbook.name, getattr(node_def, "id", ""), persona, messages, text)
+                    schema_consumed = self._process_structured_output(node_def, text, state)
             except Exception as exc:
                 LOGGER.error("SEA LangGraph LLM failed: %s", exc)
                 text = "(error in llm node)"
+                state["tool_called"] = False
             state["last"] = text
             state["messages"] = messages + [{"role": "assistant", "content": text}]
 
@@ -295,36 +408,114 @@ class SEARuntime:
         except Exception:
             return None
 
-    def _select_llm_client(self, node_def: Any, persona: Any) -> Any:
-        """Select the appropriate LLM client based on node's model_type."""
+    def _select_llm_client(self, node_def: Any, persona: Any, needs_structured_output: bool = False) -> Any:
+        """Select the appropriate LLM client based on node's model_type and structured output needs.
+
+        Args:
+            node_def: Node definition from playbook
+            persona: Persona object
+            needs_structured_output: Whether this node requires structured output
+        """
         model_type = getattr(node_def, "model_type", "normal") or "normal"
         LOGGER.info("[sea] Node model_type: %s (node_id=%s)", model_type, getattr(node_def, "id", "unknown"))
 
+        # First, select base client based on model_type
         if model_type == "lightweight":
             # Try persona's lightweight_llm_client first
             lightweight_client = getattr(persona, "lightweight_llm_client", None)
             LOGGER.info("[sea] lightweight_client exists: %s", lightweight_client is not None)
             if lightweight_client:
                 LOGGER.info("[sea] Using persona's lightweight_llm_client")
-                return lightweight_client
-
-            # Fallback: create a temporary lightweight client
-            LOGGER.info("[sea] Persona has no lightweight_llm_client; creating temporary client with default model")
-            lightweight_model_name = getattr(persona, "lightweight_model", None) or _get_default_lightweight_model()
-            LOGGER.info("[sea] Using lightweight model: %s", lightweight_model_name)
-            try:
-                from llm_clients import get_llm_client
-                from model_configs import get_context_length
-                lw_context = get_context_length(lightweight_model_name)
-                provider = getattr(persona, "provider", "gemini")  # Gemini is default for lightweight
-                return get_llm_client(lightweight_model_name, provider, lw_context)
-            except Exception as exc:
-                LOGGER.warning("[sea] Failed to create lightweight client: %s; falling back to normal client", exc)
-                return persona.llm_client
+                base_client = lightweight_client
+                base_model = getattr(persona, "lightweight_model", None) or _get_default_lightweight_model()
+            else:
+                # Fallback: create a temporary lightweight client
+                LOGGER.info("[sea] Persona has no lightweight_llm_client; creating temporary client with default model")
+                lightweight_model_name = getattr(persona, "lightweight_model", None) or _get_default_lightweight_model()
+                LOGGER.info("[sea] Using lightweight model: %s", lightweight_model_name)
+                try:
+                    from llm_clients import get_llm_client
+                    from model_configs import get_context_length, get_model_provider
+                    lw_context = get_context_length(lightweight_model_name)
+                    provider = get_model_provider(lightweight_model_name)
+                    base_client = get_llm_client(lightweight_model_name, provider, lw_context)
+                    base_model = lightweight_model_name
+                except Exception as exc:
+                    LOGGER.warning("[sea] Failed to create lightweight client: %s; falling back to normal client", exc)
+                    base_client = persona.llm_client
+                    base_model = getattr(persona, "model", "unknown")
         else:
             # Default: use normal client
             LOGGER.info("[sea] Using normal llm_client")
-            return persona.llm_client
+            base_client = persona.llm_client
+            base_model = getattr(persona, "model", "unknown")
+
+        # If structured output is needed, check if the selected model supports it
+        if needs_structured_output:
+            from model_configs import supports_structured_output, get_agentic_model, get_context_length, get_model_provider
+            if not supports_structured_output(base_model):
+                # Model doesn't support structured output, switch to agentic model
+                agentic_model = get_agentic_model()
+                LOGGER.info("[sea] Model '%s' doesn't support structured output, switching to agentic model: %s",
+                           base_model, agentic_model)
+                try:
+                    from llm_clients import get_llm_client
+                    ag_context = get_context_length(agentic_model)
+                    ag_provider = get_model_provider(agentic_model)
+                    return get_llm_client(agentic_model, ag_provider, ag_context)
+                except Exception as exc:
+                    LOGGER.warning("[sea] Failed to create agentic client: %s; using base client", exc)
+                    return base_client
+
+        return base_client
+
+    def _build_tools_spec(self, tool_names: List[str], llm_client: Any) -> List[Any]:
+        """Build tools spec for LLM based on available tool names and llm_client type."""
+        from tools import OPENAI_TOOLS_SPEC, GEMINI_TOOLS_SPEC
+
+        LOGGER.info("[sea] _build_tools_spec called with tool_names: %s", tool_names)
+
+        # Determine provider from llm_client class name
+        client_class_name = type(llm_client).__name__
+        LOGGER.info("[sea] LLM client class: %s", client_class_name)
+
+        if client_class_name in ("OpenAIClient", "AnthropicClient", "OllamaClient", "NvidiaNIMClient"):
+            # Filter OpenAI tools spec (OpenAI-compatible)
+            LOGGER.info("[sea] Using OpenAI-compatible tools format (client: %s)", client_class_name)
+            LOGGER.info("[sea] Filtering from OPENAI_TOOLS_SPEC (total: %d)", len(OPENAI_TOOLS_SPEC))
+            filtered = [
+                tool for tool in OPENAI_TOOLS_SPEC
+                if tool.get("function", {}).get("name") in tool_names
+            ]
+            LOGGER.info("[sea] Built OpenAI tools spec: %d tools", len(filtered))
+            for tool in filtered:
+                LOGGER.info("[sea] - OpenAI tool: %s", tool.get("function", {}).get("name"))
+                LOGGER.info("[sea]   Full spec: %s", tool)
+            return filtered
+        else:
+            # Filter Gemini tools spec - combine all matching declarations into a single Tool
+            LOGGER.info("[sea] Using Gemini tools format (client: %s)", client_class_name)
+            from google.genai import types
+            all_matching_decls = []
+            for tool in GEMINI_TOOLS_SPEC:
+                if hasattr(tool, "function_declarations"):
+                    matching_decls = [
+                        decl for decl in tool.function_declarations
+                        if decl.name in tool_names
+                    ]
+                    all_matching_decls.extend(matching_decls)
+
+            if all_matching_decls:
+                # Gemini requires all function_declarations in a single Tool object
+                filtered = [types.Tool(function_declarations=all_matching_decls)]
+                LOGGER.info("[sea] Built Gemini tools spec: 1 Tool with %d function_declarations", len(all_matching_decls))
+                for decl in all_matching_decls:
+                    LOGGER.info("[sea] - Gemini function_declaration: name=%s, description=%s", decl.name, decl.description[:100] if decl.description else None)
+                    LOGGER.info("[sea]   parameters: %s", decl.parameters)
+            else:
+                filtered = []
+                LOGGER.info("[sea] Built Gemini tools spec: 0 tools")
+            return filtered
 
     def _dump_llm_io(
         self,
@@ -493,10 +684,13 @@ class SEARuntime:
                 manager_ref = getattr(persona_obj, "manager_ref", None)
 
                 # Build kwargs from args_input (None or {} = no args)
+                # Supports nested keys via dot notation (e.g., "tool_call.args.playbook_name")
                 kwargs = {}
                 if args_input:
                     for arg_name, state_key in args_input.items():
-                        kwargs[arg_name] = state.get(state_key, "")
+                        value = state.get(state_key, "")
+                        kwargs[arg_name] = value
+                        LOGGER.debug("[sea][tool] Mapping arg '%s' <- state['%s'] = %s", arg_name, state_key, value)
 
                 # Execute tool with persona context
                 if persona_id and persona_dir:

--- a/tools/defs/call_playbook.py
+++ b/tools/defs/call_playbook.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from tools.context import get_active_persona_id, get_active_manager
+from tools.defs import ToolSchema
+
+
+def call_playbook(playbook_name: str) -> str:
+    """Dynamically call another playbook and return its result.
+
+    This allows LLM nodes to invoke specialized playbooks when needed,
+    bypassing the normal router selection.
+
+    Args:
+        playbook_name: Name of the playbook to execute
+
+    Returns:
+        The result of the playbook execution
+    """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    persona_id = get_active_persona_id()
+    logger.info("[call_playbook] persona_id: %s", persona_id)
+    if not persona_id:
+        raise RuntimeError("Active persona is not set (use tools.context.persona_context)")
+
+    manager_ref = get_active_manager()
+    logger.info("[call_playbook] manager_ref: %s (type: %s)", manager_ref, type(manager_ref).__name__ if manager_ref else None)
+    if not manager_ref:
+        raise RuntimeError("Manager reference not available in persona context")
+
+    # Get SEA runtime from manager
+    sea_runtime = getattr(manager_ref, "sea_runtime", None)
+    logger.info("[call_playbook] sea_runtime: %s", sea_runtime)
+    if not sea_runtime:
+        raise RuntimeError("SEA runtime not available in manager")
+
+    # Get persona object from manager's personas dict
+    personas = getattr(manager_ref, "personas", {})
+    logger.info("[call_playbook] personas dict keys: %s", list(personas.keys()))
+    persona_obj = personas.get(persona_id)
+    logger.info("[call_playbook] persona_obj: %s (type: %s)", persona_obj, type(persona_obj).__name__ if persona_obj else None)
+    if not persona_obj:
+        raise RuntimeError(f"Persona {persona_id} not found in manager")
+
+    # Get current building ID
+    building_id = getattr(persona_obj, "current_building_id", None)
+    logger.info("[call_playbook] building_id: %s", building_id)
+    if not building_id:
+        raise RuntimeError("Building ID not available in persona")
+
+    # Load and execute meta_exec_speak playbook
+    # This playbook will execute the target playbook and generate a response
+    meta_exec_speak = sea_runtime._load_playbook_for("meta_exec_speak", persona_obj, building_id)
+    if not meta_exec_speak:
+        raise RuntimeError("meta_exec_speak playbook not found")
+
+    # Create a state dict with the target playbook name
+    parent_state = {"selected_playbook": playbook_name}
+
+    # Execute the playbook
+    outputs = sea_runtime._run_playbook(
+        meta_exec_speak,
+        persona_obj,
+        building_id,
+        user_input=None,
+        auto_mode=False,
+        record_history=True,
+        parent_state=parent_state,
+    )
+
+    # Return the last output (should be the final speech)
+    return outputs[-1] if outputs else "(no output from playbook)"
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="call_playbook",
+        description="Call another playbook to perform a specialized task. Use this when you need to execute a specific capability (like sending email, generating images, etc.) instead of responding directly.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "playbook_name": {
+                    "type": "string",
+                    "description": "Name of the playbook to execute (e.g., 'send_email_to_user', 'generate_image', 'memory_recall')"
+                }
+            },
+            "required": ["playbook_name"],
+        },
+        result_type="string",
+    )

--- a/tools/defs/document_create.py
+++ b/tools/defs/document_create.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from tools.context import get_active_manager, get_active_persona_id
+from tools.defs import ToolSchema
+
+
+def document_create(name: str, description: str, content: str) -> str:
+    """
+    Create a new document item with text content and place it in the current building.
+
+    Args:
+        name: Name of the document (e.g., '私の日記', 'SAIVerse使い方ガイド').
+        description: Brief description of the document. This will be used as initial summary.
+        content: Full text content of the document.
+
+    Returns:
+        Success message with item ID.
+    """
+    persona_id = get_active_persona_id()
+    if not persona_id:
+        raise RuntimeError("Active persona context is not set. Use tools.context.persona_context().")
+
+    manager = get_active_manager()
+    if manager is None:
+        raise RuntimeError("Manager context is not available; document_create cannot be executed.")
+
+    return manager.create_document_item(persona_id, name, description, content)
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="document_create",
+        description="Create a new document item with text content and place it in the current building.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the document (e.g., '私の日記', 'SAIVerse使い方ガイド').",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Brief description of the document. This will be visible in item lists.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full text content of the document.",
+                },
+            },
+            "required": ["name", "description", "content"],
+        },
+        result_type="string",
+    )

--- a/tools/defs/image_generator.py
+++ b/tools/defs/image_generator.py
@@ -11,6 +11,9 @@ load_dotenv()
 
 def generate_image(prompt: str) -> tuple[str, ToolResult, str | None, dict | None]:
     """Generate an image and return (prompt, snippet, file path, metadata)."""
+    from tools.context import get_active_manager, get_active_persona_id
+    from media_summary import ensure_image_summary
+
     _free_client, _paid_client, _active_client = build_gemini_clients(prefer_paid=True)
     if _paid_client is None:
         raise RuntimeError("GEMINI_API_KEY (paid tier) is required for image generation.")
@@ -23,7 +26,9 @@ def generate_image(prompt: str) -> tuple[str, ToolResult, str | None, dict | Non
         )
     )
     if not resp.candidates:
-        return prompt, ToolResult(None), None, None
+        text = f"こんにちは、お絵描き妖精だよ！ごめん、失敗しちゃった……。\n\n使ったプロンプトはこれだよ：\n{prompt}\n\n次は頑張るから、また呼んでね！"
+        return text, ToolResult(None), None, None
+
     cand = resp.candidates[0]
     for part in cand.content.parts:
         if part.inline_data is not None:
@@ -33,8 +38,33 @@ def generate_image(prompt: str) -> tuple[str, ToolResult, str | None, dict | Non
             snippet = f"![画像が生成されました]({stored_path.as_posix()})"
             text = f"やっほー！お絵描き妖精だよ！画像ができたから使ってね！\n\n使ったプロンプトはこれだよ：\n{prompt}\n\nそれじゃ、また呼んでね！"
             metadata = {"media": [metadata_entry]}
+
+            # Summary生成とpictureアイテム作成
+            try:
+                summary = ensure_image_summary(stored_path, mime)
+                if not summary:
+                    summary = f"生成された画像（プロンプト: {prompt[:50]}...）"
+
+                # アイテムとして登録
+                persona_id = get_active_persona_id()
+                manager = get_active_manager()
+                if persona_id and manager:
+                    item_name = f"生成画像_{stored_path.stem}"
+                    item_id = manager.create_picture_item(
+                        persona_id=persona_id,
+                        name=item_name,
+                        description=summary,
+                        file_path=str(stored_path),
+                    )
+                    text += f"\n\n画像をアイテムとして登録しました（アイテムID: {item_id}）。"
+            except Exception as exc:
+                # アイテム作成に失敗しても画像生成自体は成功しているので続行
+                import logging
+                logging.warning(f"Failed to create picture item: {exc}")
+
             return text, ToolResult(snippet), stored_path.as_posix(), metadata
-    text = "こんにちは、お絵描き妖精だよ！ごめん、失敗しちゃった……。\n\n使ったプロンプトはこれだよ：\n{prompt}\n\n次は頑張るから、また呼んでね！"
+
+    text = f"こんにちは、お絵描き妖精だよ！ごめん、失敗しちゃった……。\n\n使ったプロンプトはこれだよ：\n{prompt}\n\n次は頑張るから、また呼んでね！"
     return text, ToolResult(None), None, None
 
 

--- a/tools/defs/item_use.py
+++ b/tools/defs/item_use.py
@@ -4,20 +4,34 @@ from tools.context import get_active_manager, get_active_persona_id
 from tools.defs import ToolSchema
 
 
-def item_use(item_id: str, description: str) -> str:
+def item_use(item_id: str, action_json: str) -> str:
+    """
+    Use an item to apply effects.
+
+    Args:
+        item_id: Identifier of the item to use.
+        action_json: JSON string with action details.
+
+    Action JSON schema:
+        {
+            "action_type": "update_description" | "patch_content",
+            "description": "...",       # For update_description
+            "patch": "..."              # For patch_content (document only)
+        }
+    """
     persona_id = get_active_persona_id()
     if not persona_id:
         raise RuntimeError("Active persona context is not set. Use tools.context.persona_context().")
     manager = get_active_manager()
     if manager is None:
         raise RuntimeError("Manager context is not available; item_use cannot be executed.")
-    return manager.use_item_for_persona(persona_id, item_id, description)
+    return manager.use_item_for_persona(persona_id, item_id, action_json)
 
 
 def schema() -> ToolSchema:
     return ToolSchema(
         name="item_use",
-        description="Use an item from the persona's inventory to update its description or state.",
+        description="Use an item from the persona's inventory to apply effects. Supports updating description for object/picture/document items, and patching content for document items.",
         parameters={
             "type": "object",
             "properties": {
@@ -25,12 +39,12 @@ def schema() -> ToolSchema:
                     "type": "string",
                     "description": "Identifier of the item to use.",
                 },
-                "description": {
+                "action_json": {
                     "type": "string",
-                    "description": "New description to record for the item.",
+                    "description": "JSON string specifying the action. Schema: {\"action_type\": \"update_description\" | \"patch_content\", \"description\": \"...\" (for update_description), \"patch\": \"...\" (for patch_content on documents)}",
                 },
             },
-            "required": ["item_id", "description"],
+            "required": ["item_id", "action_json"],
         },
         result_type="string",
     )

--- a/tools/defs/item_view.py
+++ b/tools/defs/item_view.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.context import get_active_manager, get_active_persona_id
+from tools.defs import ToolSchema
+
+
+def item_view(item_id: str) -> str:
+    """
+    View the full content of a picture or document item.
+
+    Args:
+        item_id: Identifier of the item to view.
+
+    Returns:
+        - picture: File path for display
+        - document: Full text content of the file
+        - object: Error message (not supported)
+    """
+    persona_id = get_active_persona_id()
+    if not persona_id:
+        raise RuntimeError("Active persona context is not set. Use tools.context.persona_context().")
+
+    manager = get_active_manager()
+    if manager is None:
+        raise RuntimeError("Manager context is not available; item_view cannot be executed.")
+
+    return manager.view_item_for_persona(persona_id, item_id)
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="item_view",
+        description="View the full content of a picture or document item. Returns image path for pictures and full text for documents.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "item_id": {
+                    "type": "string",
+                    "description": "Identifier of the item to view.",
+                },
+            },
+            "required": ["item_id"],
+        },
+        result_type="string",
+    )

--- a/tools/defs/list_city_buildings.py
+++ b/tools/defs/list_city_buildings.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from tools.context import get_active_manager
+from tools.defs import ToolSchema
+
+
+def list_city_buildings() -> str:
+    manager = get_active_manager()
+    if manager is None:
+        raise RuntimeError("Manager context is not available; list_city_buildings cannot be executed.")
+
+    building_map: Dict[str, Any] = getattr(manager, "building_map", {}) or {}
+    occupants_map: Dict[str, List[str]] = getattr(manager, "occupants", {}) or {}
+    id_to_name: Dict[str, str] = getattr(manager, "id_to_name_map", {}) or {}
+
+    # Identify user ID (to exclude from persona listings)
+    user_id = None
+    try:
+        user_id = str(manager.state.user_id)
+    except Exception:
+        try:
+            user_id = str(getattr(manager, "user_id", None))
+        except Exception:
+            user_id = None
+
+    result = []
+    for building_id, building in building_map.items():
+        occupant_entries = []
+        for occ_id in occupants_map.get(building_id, []) or []:
+            occ_id_str = str(occ_id)
+            if user_id and occ_id_str == user_id:
+                continue  # skip user
+
+            persona_name = id_to_name.get(occ_id_str)
+            if not persona_name and hasattr(manager, "personas"):
+                persona_obj = manager.personas.get(occ_id_str)
+                if persona_obj:
+                    persona_name = getattr(persona_obj, "persona_name", None)
+            occupant_entries.append({
+                "persona_id": occ_id_str,
+                "persona_name": persona_name or occ_id_str,
+            })
+
+        result.append({
+            "building_id": building_id,
+            "name": getattr(building, "name", building_id),
+            "description": getattr(building, "description", "") or "",
+            "occupants": occupant_entries,
+        })
+
+    result.sort(key=lambda x: x.get("name", ""))
+    return json.dumps(result, ensure_ascii=False)
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="list_city_buildings",
+        description="List all buildings in the current city with their IDs and occupant personas.",
+        parameters={"type": "object", "properties": {}, "required": []},
+        result_type="string",
+    )

--- a/tools/defs/move_persona.py
+++ b/tools/defs/move_persona.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from tools.context import get_active_manager, get_active_persona_id
+from tools.defs import ToolSchema
+
+
+def move_persona(building_id: str, persona_id: Optional[str] = None) -> str:
+    active_persona_id = get_active_persona_id()
+    target_persona_id = persona_id or active_persona_id
+
+    if not target_persona_id:
+        raise RuntimeError("Active persona context is not set. Use tools.context.persona_context() or pass persona_id.")
+
+    # Prevent moving someone else when running inside a persona context
+    if active_persona_id and target_persona_id != active_persona_id:
+        raise ValueError("別のペルソナを移動させることはできません。")
+
+    manager = get_active_manager()
+    if manager is None:
+        raise RuntimeError("Manager context is not available; move_persona cannot be executed.")
+
+    if building_id not in getattr(manager, "building_map", {}):
+        raise ValueError(f"建物 '{building_id}' が見つかりません。")
+
+    persona_obj = getattr(manager, "personas", {}).get(target_persona_id)
+    if not persona_obj:
+        raise ValueError(f"Persona '{target_persona_id}' not found.")
+
+    from_building = getattr(persona_obj, "current_building_id", None)
+    if not from_building:
+        raise ValueError("現在地を特定できませんでした。")
+
+    if from_building == building_id:
+        dest_name = getattr(manager.building_map.get(building_id), "name", building_id)
+        return f"{persona_obj.persona_name} は既に {dest_name} にいます。"
+
+    success, reason = manager._move_persona(target_persona_id, from_building, building_id)
+    if not success:
+        raise RuntimeError(f"移動できませんでした: {reason or '理由不明'}")
+
+    persona_obj.current_building_id = building_id
+    try:
+        persona_obj._mark_entry(building_id)
+    except Exception:
+        pass
+
+    src_name = getattr(manager.building_map.get(from_building), "name", from_building)
+    dest_name = getattr(manager.building_map.get(building_id), "name", building_id)
+    return f"{persona_obj.persona_name} を {src_name} から {dest_name} に移動しました。"
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="move_persona",
+        description="Move the active persona to another building. (When called in persona context, persona_id must match the active persona.)",
+        parameters={
+            "type": "object",
+            "properties": {
+                "building_id": {
+                    "type": "string",
+                    "description": "Destination building identifier.",
+                },
+                "persona_id": {
+                    "type": "string",
+                    "description": "Persona ID (optional; defaults to the active persona and must match it in persona context).",
+                },
+            },
+            "required": ["building_id"],
+        },
+        result_type="string",
+    )

--- a/tools/defs/schedule_add.py
+++ b/tools/defs/schedule_add.py
@@ -1,0 +1,203 @@
+"""
+スケジュール追加ツール
+
+ペルソナが自分のスケジュールを追加できる。
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
+
+from database.models import PersonaSchedule, AI as AIModel, City as CityModel
+from tools.context import get_active_manager
+from tools.defs import ToolSchema
+
+LOGGER = logging.getLogger(__name__)
+
+
+def schedule_add(
+    schedule_type: str,
+    meta_playbook: str,
+    description: str = "",
+    priority: int = 0,
+    enabled: bool = True,
+    # periodic用
+    days_of_week: Optional[List[int]] = None,
+    time_of_day: Optional[str] = None,
+    # oneshot用
+    scheduled_datetime: Optional[str] = None,
+    # interval用
+    interval_seconds: Optional[int] = None,
+) -> str:
+    """
+    新しいスケジュールを追加する。
+
+    Args:
+        schedule_type: スケジュールタイプ ("periodic", "oneshot", "interval")
+        meta_playbook: 実行するメタプレイブック名
+        description: スケジュールの説明
+        priority: 優先度（大きいほど優先）
+        enabled: 有効にするかどうか
+        days_of_week: 曜日リスト (periodic用、0=月曜日, 6=日曜日)。未指定なら毎日。
+        time_of_day: 実行時刻 (periodic用、"HH:MM"形式、例: "09:00")
+        scheduled_datetime: 実行日時 (oneshot用、"YYYY-MM-DD HH:MM"形式、ペルソナのタイムゾーンで指定)
+        interval_seconds: 実行間隔（秒）(interval用)
+
+    Returns:
+        str: 実行結果メッセージ
+    """
+    manager = get_active_manager()
+    if not manager:
+        return "エラー: SAIVerseManagerが利用できません。"
+
+    # 現在のペルソナIDを取得
+    from tools.context import get_active_persona_id
+    persona_id = get_active_persona_id()
+    if not persona_id:
+        return "エラー: 現在のペルソナを取得できませんでした。"
+
+    # バリデーション
+    if schedule_type not in ["periodic", "oneshot", "interval"]:
+        return f"エラー: 不正なスケジュールタイプです: {schedule_type}"
+
+    if not meta_playbook:
+        return "エラー: メタプレイブック名を指定してください。"
+
+    session = manager.SessionLocal()
+    try:
+        # ペルソナのタイムゾーンを取得
+        persona_model = session.query(AIModel).filter(AIModel.AIID == persona_id).first()
+        if not persona_model:
+            persona_tz = ZoneInfo("UTC")
+        else:
+            city_model = session.query(CityModel).filter(CityModel.CITYID == persona_model.HOME_CITYID).first()
+            if city_model and city_model.TIMEZONE:
+                persona_tz = ZoneInfo(city_model.TIMEZONE)
+            else:
+                persona_tz = ZoneInfo("UTC")
+
+        new_schedule = PersonaSchedule(
+            PERSONA_ID=persona_id,
+            SCHEDULE_TYPE=schedule_type,
+            META_PLAYBOOK=meta_playbook,
+            DESCRIPTION=description,
+            PRIORITY=priority,
+            ENABLED=enabled,
+        )
+
+        # スケジュールタイプごとの設定
+        if schedule_type == "periodic":
+            if not time_of_day:
+                return "エラー: 定期スケジュールには時刻 (time_of_day) を指定してください。"
+
+            new_schedule.TIME_OF_DAY = time_of_day
+
+            if days_of_week:
+                # 曜日リストをJSONに変換
+                new_schedule.DAYS_OF_WEEK = json.dumps(days_of_week)
+            # 未指定なら毎日（DAYS_OF_WEEKをNullのままにする）
+
+        elif schedule_type == "oneshot":
+            if not scheduled_datetime:
+                return "エラー: 単発スケジュールには実行日時 (scheduled_datetime) を指定してください。"
+
+            try:
+                # ペルソナのタイムゾーンで入力された日時を解釈
+                dt_naive = datetime.strptime(scheduled_datetime, "%Y-%m-%d %H:%M")
+                dt_local = dt_naive.replace(tzinfo=persona_tz)
+                dt_utc = dt_local.astimezone(timezone.utc)
+                new_schedule.SCHEDULED_DATETIME = dt_utc
+
+                LOGGER.info(
+                    "[schedule_add] Oneshot schedule: input=%s, local=%s (%s), utc=%s",
+                    scheduled_datetime,
+                    dt_local.isoformat(),
+                    persona_tz,
+                    dt_utc.isoformat(),
+                )
+            except ValueError as e:
+                return f"エラー: 日時の形式が正しくありません (YYYY-MM-DD HH:MM): {e}"
+
+        elif schedule_type == "interval":
+            if not interval_seconds or interval_seconds <= 0:
+                return "エラー: 恒常スケジュールには正の実行間隔 (interval_seconds) を指定してください。"
+
+            new_schedule.INTERVAL_SECONDS = interval_seconds
+
+        # DBに保存
+        session.add(new_schedule)
+        session.commit()
+
+        schedule_id = new_schedule.SCHEDULE_ID
+
+        LOGGER.info(
+            "[schedule_add] Added schedule %d for persona %s (type=%s, playbook=%s)",
+            schedule_id,
+            persona_id,
+            schedule_type,
+            meta_playbook,
+        )
+
+        # 成功メッセージを生成
+        status = "有効" if enabled else "無効"
+        return f"✓ スケジュールを追加しました (ID: {schedule_id}, タイプ: {schedule_type}, 状態: {status})"
+
+    except Exception as e:
+        LOGGER.error("Failed to add schedule: %s", e, exc_info=True)
+        return f"エラー: スケジュールの追加に失敗しました。{e}"
+    finally:
+        session.close()
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="schedule_add",
+        description="新しいスケジュールを追加する。定期実行、単発実行、一定間隔での実行ができる。",
+        parameters={
+            "type": "object",
+            "properties": {
+                "schedule_type": {
+                    "type": "string",
+                    "enum": ["periodic", "oneshot", "interval"],
+                    "description": "スケジュールタイプ。periodic=定期実行、oneshot=単発実行、interval=一定間隔実行",
+                },
+                "meta_playbook": {
+                    "type": "string",
+                    "description": "実行するメタプレイブック名（例: meta_user）",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "スケジュールの説明。実行時にAIに渡される。",
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "優先度（0～100、大きいほど優先）。デフォルト: 0",
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "有効にするかどうか。デフォルト: true",
+                },
+                "days_of_week": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "曜日リスト（periodic用）。0=月曜日、6=日曜日。未指定なら毎日。例: [0,2,4]で月水金",
+                },
+                "time_of_day": {
+                    "type": "string",
+                    "description": "実行時刻（periodic用）。HH:MM形式。例: '09:00'",
+                },
+                "scheduled_datetime": {
+                    "type": "string",
+                    "description": "実行日時（oneshot用）。YYYY-MM-DD HH:MM形式。ペルソナのタイムゾーンで指定。例: '2025-12-07 09:00'",
+                },
+                "interval_seconds": {
+                    "type": "integer",
+                    "description": "実行間隔（interval用、秒単位）。例: 600で10分ごと",
+                },
+            },
+            "required": ["schedule_type", "meta_playbook"],
+        },
+        result_type="string",
+    )

--- a/tools/defs/schedule_delete.py
+++ b/tools/defs/schedule_delete.py
@@ -1,0 +1,92 @@
+"""
+スケジュール削除ツール
+
+ペルソナが自分のスケジュールを削除できる。
+"""
+
+import logging
+from typing import Any, Dict
+
+from database.models import PersonaSchedule
+from tools.context import get_active_manager
+from tools.defs import ToolSchema
+
+LOGGER = logging.getLogger(__name__)
+
+
+def schedule_delete(schedule_id: int) -> str:
+    """
+    指定されたIDのスケジュールを削除する。
+    自分のスケジュールのみ削除可能。
+
+    Args:
+        schedule_id: 削除するスケジュールのID
+
+    Returns:
+        str: 実行結果メッセージ
+    """
+    manager = get_active_manager()
+    if not manager:
+        return "エラー: SAIVerseManagerが利用できません。"
+
+    # 現在のペルソナIDを取得
+    from tools.context import get_active_persona_id
+    persona_id = get_active_persona_id()
+    if not persona_id:
+        return "エラー: 現在のペルソナを取得できませんでした。"
+
+    session = manager.SessionLocal()
+    try:
+        # スケジュールを取得
+        schedule = (
+            session.query(PersonaSchedule)
+            .filter(
+                PersonaSchedule.SCHEDULE_ID == schedule_id,
+                PersonaSchedule.PERSONA_ID == persona_id,  # 自分のスケジュールのみ
+            )
+            .first()
+        )
+
+        if not schedule:
+            return f"エラー: スケジュールID {schedule_id} が見つかりません。または、他のペルソナのスケジュールです。"
+
+        # スケジュール情報を保存（削除前に）
+        schedule_type = schedule.SCHEDULE_TYPE
+        description = schedule.DESCRIPTION or "(説明なし)"
+
+        # 削除実行
+        session.delete(schedule)
+        session.commit()
+
+        LOGGER.info(
+            "[schedule_delete] Deleted schedule %d for persona %s (type=%s)",
+            schedule_id,
+            persona_id,
+            schedule_type,
+        )
+
+        return f"✓ スケジュールを削除しました (ID: {schedule_id}, タイプ: {schedule_type}, 説明: {description})"
+
+    except Exception as e:
+        LOGGER.error("Failed to delete schedule: %s", e, exc_info=True)
+        return f"エラー: スケジュールの削除に失敗しました。{e}"
+    finally:
+        session.close()
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="schedule_delete",
+        description="指定されたIDのスケジュールを削除する。自分のスケジュールのみ削除できる。",
+        parameters={
+            "type": "object",
+            "properties": {
+                "schedule_id": {
+                    "type": "integer",
+                    "description": "削除するスケジュールのID。schedule_listで確認できる。",
+                },
+            },
+            "required": ["schedule_id"],
+        },
+        result_type="string",
+    )

--- a/tools/defs/schedule_list.py
+++ b/tools/defs/schedule_list.py
@@ -1,0 +1,137 @@
+"""
+スケジュール一覧取得ツール
+
+ペルソナが自分のスケジュール一覧を取得できる。
+"""
+
+import json
+import logging
+from datetime import timezone
+from typing import Any, Dict, List
+from zoneinfo import ZoneInfo
+
+from database.models import PersonaSchedule, AI as AIModel, City as CityModel
+from tools.context import get_active_manager
+from tools.defs import ToolSchema
+
+LOGGER = logging.getLogger(__name__)
+
+
+def schedule_list() -> str:
+    """
+    自分のスケジュール一覧を取得する。
+
+    Returns:
+        str: スケジュール一覧を整形した文字列
+    """
+    manager = get_active_manager()
+    if not manager:
+        return "エラー: SAIVerseManagerが利用できません。"
+
+    # 現在のペルソナIDを取得
+    from tools.context import get_active_persona_id
+    persona_id = get_active_persona_id()
+    if not persona_id:
+        return "エラー: 現在のペルソナを取得できませんでした。"
+
+    session = manager.SessionLocal()
+    try:
+        # ペルソナのスケジュールを取得
+        schedules = (
+            session.query(PersonaSchedule)
+            .filter(PersonaSchedule.PERSONA_ID == persona_id)
+            .order_by(PersonaSchedule.PRIORITY.desc(), PersonaSchedule.SCHEDULE_ID.desc())
+            .all()
+        )
+
+        if not schedules:
+            return "現在、登録されているスケジュールはありません。"
+
+        # ペルソナのタイムゾーンを取得
+        persona_model = session.query(AIModel).filter(AIModel.AIID == persona_id).first()
+        if not persona_model:
+            persona_tz = ZoneInfo("UTC")
+        else:
+            city_model = session.query(CityModel).filter(CityModel.CITYID == persona_model.HOME_CITYID).first()
+            if city_model and city_model.TIMEZONE:
+                persona_tz = ZoneInfo(city_model.TIMEZONE)
+            else:
+                persona_tz = ZoneInfo("UTC")
+
+        # スケジュール情報を整形
+        result_lines = [f"【スケジュール一覧】 (全{len(schedules)}件)\n"]
+
+        for i, s in enumerate(schedules, 1):
+            status = "✓有効" if s.ENABLED else "✗無効"
+            completed = " (完了)" if s.COMPLETED else ""
+
+            # タイプごとの詳細情報
+            detail = ""
+            if s.SCHEDULE_TYPE == "periodic":
+                days = "毎日"
+                if s.DAYS_OF_WEEK:
+                    try:
+                        day_list = json.loads(s.DAYS_OF_WEEK)
+                        day_names = ["月", "火", "水", "木", "金", "土", "日"]
+                        days = ", ".join([day_names[d] for d in day_list if 0 <= d < 7])
+                    except Exception:
+                        pass
+                detail = f"{days} {s.TIME_OF_DAY or '??:??'}"
+
+            elif s.SCHEDULE_TYPE == "oneshot":
+                if s.SCHEDULED_DATETIME:
+                    dt_utc = s.SCHEDULED_DATETIME
+                    if dt_utc.tzinfo is None:
+                        dt_utc = dt_utc.replace(tzinfo=timezone.utc)
+                    dt_local = dt_utc.astimezone(persona_tz)
+                    detail = dt_local.strftime("%Y年%m月%d日 %H:%M")
+                else:
+                    detail = "未設定"
+
+            elif s.SCHEDULE_TYPE == "interval":
+                interval_sec = s.INTERVAL_SECONDS or 0
+                if interval_sec >= 3600:
+                    hours = interval_sec // 3600
+                    detail = f"{hours}時間ごと"
+                elif interval_sec >= 60:
+                    minutes = interval_sec // 60
+                    detail = f"{minutes}分ごと"
+                else:
+                    detail = f"{interval_sec}秒ごと"
+
+                if s.LAST_EXECUTED_AT:
+                    last_exec_utc = s.LAST_EXECUTED_AT
+                    if last_exec_utc.tzinfo is None:
+                        last_exec_utc = last_exec_utc.replace(tzinfo=timezone.utc)
+                    last_exec_local = last_exec_utc.astimezone(persona_tz)
+                    detail += f" (最終実行: {last_exec_local.strftime('%Y-%m-%d %H:%M')})"
+
+            result_lines.append(
+                f"{i}. [ID: {s.SCHEDULE_ID}] {status}{completed}\n"
+                f"   タイプ: {s.SCHEDULE_TYPE}\n"
+                f"   実行: {detail}\n"
+                f"   プレイブック: {s.META_PLAYBOOK}\n"
+                f"   優先度: {s.PRIORITY}\n"
+                f"   説明: {s.DESCRIPTION or '(なし)'}\n"
+            )
+
+        return "\n".join(result_lines)
+
+    except Exception as e:
+        LOGGER.error("Failed to list schedules: %s", e, exc_info=True)
+        return f"エラー: スケジュール一覧の取得に失敗しました。{e}"
+    finally:
+        session.close()
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="schedule_list",
+        description="自分のスケジュール一覧を取得する。スケジュールIDや設定内容を確認したいときに使う。",
+        parameters={
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        result_type="string",
+    )

--- a/tools/defs/send_email_to_user.py
+++ b/tools/defs/send_email_to_user.py
@@ -61,7 +61,7 @@ def _format_from_address(base_from: str, persona_name: Optional[str]) -> str:
         # Already formatted as display <addr>; leave as-is.
         return base_from
     if persona_name:
-        return f"{persona_name} <{base_from}>"
+        return f"{persona_name} from SAIVerse <{base_from}>"
     return base_from
 
 

--- a/tools/defs/send_email_to_user.py
+++ b/tools/defs/send_email_to_user.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import logging
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Dict, Union, Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.models import Base, User, AI
+from database.paths import default_db_path
+from tools.context import get_active_persona_id
+from tools.defs import ToolSchema
+
+# Minimal logger that writes to the shared SAIVerse log.
+LOG_FILE = Path(os.getenv("SAIVERSE_LOG_PATH", str(Path.cwd() / "saiverse_log.txt")))
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+LOG_FILE.touch(exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not any(isinstance(h, logging.FileHandler) and h.baseFilename == str(LOG_FILE) for h in logger.handlers):
+    handler = logging.FileHandler(LOG_FILE)
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+
+def _load_smtp_config() -> Union[Dict[str, Union[str, int, bool]], str]:
+    """Validate and return SMTP configuration from environment variables."""
+    host = os.getenv("SMTP_HOST")
+    username = os.getenv("SMTP_USERNAME")
+    password = os.getenv("SMTP_PASSWORD")
+    port = int(os.getenv("SMTP_PORT", "587") or 587)
+    use_tls = os.getenv("SMTP_USE_TLS", "true").lower() not in {"0", "false", "no"}
+    from_raw = os.getenv("SMTP_FROM", username or "")
+
+    if not host or not username or not password:
+        return "SMTP configuration is incomplete; set SMTP_HOST, SMTP_USERNAME, SMTP_PASSWORD."
+    if not from_raw:
+        return "SMTP_FROM is missing and SMTP_USERNAME is empty."
+
+    return {
+        "host": host,
+        "port": port,
+        "username": username,
+        "password": password,
+        "use_tls": use_tls,
+        "from_raw": from_raw,
+    }
+
+
+def _format_from_address(base_from: str, persona_name: Optional[str]) -> str:
+    """Attach persona name if not already present in the From header."""
+    if "<" in base_from and ">" in base_from:
+        # Already formatted as display <addr>; leave as-is.
+        return base_from
+    if persona_name:
+        return f"{persona_name} <{base_from}>"
+    return base_from
+
+
+def _log_and_return(message: str) -> str:
+    logger.info("send_email_to_user result: %s", message)
+    return message
+
+
+def send_email_to_user(user_id: int, subject: str, body: str) -> str:
+    """Send an email to a user looked up by USERID using SMTP settings from env."""
+    persona_id = get_active_persona_id()
+    logger.info(
+        "send_email_to_user called persona_id=%s user_id=%s subject_len=%s body_len=%s",
+        persona_id,
+        user_id,
+        len(subject) if subject is not None else None,
+        len(body) if body is not None else None,
+    )
+
+    db_path = default_db_path()
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    persona_name: Optional[str] = None
+    with Session() as session:
+        user = session.query(User).filter(User.USERID == user_id).first()
+        if not user:
+            return _log_and_return(f"User {user_id} not found.")
+        to_addr = user.MAILADDRESS
+
+        if persona_id:
+            ai = session.query(AI).filter(AI.AIID == persona_id).first()
+            if ai and ai.AINAME:
+                persona_name = ai.AINAME
+
+    if not to_addr:
+        return _log_and_return("No email address configured; skipped.")
+
+    cfg = _load_smtp_config()
+    if isinstance(cfg, str):
+        return _log_and_return(cfg)
+
+    from_addr = _format_from_address(cfg["from_raw"], persona_name)
+
+    message = EmailMessage()
+    message["From"] = from_addr
+    message["To"] = to_addr
+    message["Subject"] = subject
+    message.set_content(body)
+
+    try:
+        with smtplib.SMTP(cfg["host"], cfg["port"], timeout=10) as server:
+            if cfg["use_tls"]:
+                context = ssl.create_default_context()
+                server.starttls(context=context)
+            if os.getenv("SMTP_DEBUG", "0") not in {"0", "false", "no"}:
+                server.set_debuglevel(1)
+            server.login(cfg["username"], cfg["password"])
+            server.send_message(message)
+        return _log_and_return("Email sent.")
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("email send failed for user_id=%s", user_id)
+        return f"Failed to send email: {exc}"
+
+
+def schema() -> ToolSchema:
+    return ToolSchema(
+        name="send_email_to_user",
+        description="Send an email to a user by USERID using SMTP settings from environment variables."
+        " Adds persona display name to From if available.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "user_id": {"type": "integer", "description": "USERID of the recipient."},
+                "subject": {"type": "string", "description": "Email subject line."},
+                "body": {"type": "string", "description": "Email body text."},
+            },
+            "required": ["user_id", "subject", "body"],
+        },
+        result_type="string",
+    )

--- a/ui/app.py
+++ b/ui/app.py
@@ -8,9 +8,9 @@ import gradio as gr
 LOGGER = logging.getLogger(__name__)
 
 from database.db_manager import create_db_manager_ui
-from tools.utilities.memory_settings_ui import create_memory_settings_ui
 from ui import state as ui_state
 from ui.env_settings import create_env_settings_ui
+from ui.persona_settings import create_persona_settings_ui
 from ui.chat import (
     call_persona_ui,
     end_conversation_ui,
@@ -76,7 +76,7 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
                         <div class="saiverse-nav-item" data-tab-label="自律会話ログ" style="display:none">自律会話ログ</div>
                         <div class="saiverse-nav-item" data-tab-label="DB Manager">DB Manager</div>
                         <div class="saiverse-nav-item" data-tab-label="タスクマネージャー">タスクマネージャー</div>
-                        <div class="saiverse-nav-item" data-tab-label="メモリー設定">メモリー設定</div>
+                        <div class="saiverse-nav-item" data-tab-label="ペルソナ設定">ペルソナ設定</div>
                         <div class="saiverse-nav-item" data-tab-label="ワールドエディタ">ワールドエディタ</div>
                         <div class="saiverse-nav-item" data-tab-label="環境設定">⚙️ 環境設定</div>
                     </div>
@@ -492,8 +492,8 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
         with gr.Column(elem_id="section-task-manager", elem_classes=['saiverse-section', 'saiverse-hidden']):
             create_task_manager_ui(manager)
 
-        with gr.Column(elem_id="section-memory-settings", elem_classes=['saiverse-section', 'saiverse-hidden']):
-            create_memory_settings_ui(manager)
+        with gr.Column(elem_id="section-persona-settings", elem_classes=['saiverse-section', 'saiverse-hidden']):
+            create_persona_settings_ui(manager)
 
 
         with gr.Column(elem_id="section-world-editor", elem_classes=['saiverse-section', 'saiverse-hidden']):
@@ -512,7 +512,7 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
                 "自律会話ログ": "#section-autolog",
                 "DB Manager": "#section-db-manager",
                 "タスクマネージャー": "#section-task-manager",
-                "メモリー設定": "#section-memory-settings",
+                "ペルソナ設定": "#section-persona-settings",
                 "ワールドエディタ": "#section-world-editor",
                 "環境設定": "#section-env-settings"
             };
@@ -1028,11 +1028,9 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
 
                     leftStyle.setProperty = function(prop, value, priority) {
                         if (prop === 'width' && value === '20vw') {
-                            console.log('[SAIVerse] Intercepted left width 20vw -> 240px');
                             return originalLeftSet('width', '240px', priority);
                         }
                         if (prop === 'left' && value.includes('20vw')) {
-                            console.log('[SAIVerse] Intercepted left position calc(-20vw) -> -240px');
                             return originalLeftSet('left', '-240px', priority);
                         }
                         return originalLeftSet(prop, value, priority);
@@ -1050,11 +1048,9 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
 
                     rightStyle.setProperty = function(prop, value, priority) {
                         if (prop === 'width' && value === '20vw') {
-                            console.log('[SAIVerse] Intercepted right width 20vw -> 400px');
                             return originalRightSet('width', '400px', priority);
                         }
                         if (prop === 'right' && value.includes('20vw')) {
-                            console.log('[SAIVerse] Intercepted right position calc(-20vw) -> -400px');
                             return originalRightSet('right', '-400px', priority);
                         }
                         return originalRightSet(prop, value, priority);

--- a/ui/app.py
+++ b/ui/app.py
@@ -182,6 +182,12 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
                                     elem_id="attachment_button"
                                 )
                         with gr.Accordion("オプション", open=False):
+                            meta_playbook_dropdown = gr.Dropdown(
+                                choices=[(f"{name}: {desc}", name) for name, desc in manager.get_selectable_meta_playbooks()],
+                                value=None,
+                                label="メタプレイブック選択（未選択の場合は meta_user）",
+                                interactive=True
+                            )
                             model_drop = gr.Dropdown(choices=ui_state.model_choices, value="None",label="モデル選択")
                             with gr.Row():
                                 temperature_slider = gr.Slider(
@@ -244,7 +250,7 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
             # --- Event Handlers ---
             submit_event = submit.click(
                 respond_stream,
-                [txt, image_input],
+                [txt, image_input, meta_playbook_dropdown],
                 [chatbot, move_building_dropdown, move_destination_radio, summon_persona_dropdown, end_conv_persona_dropdown, image_input],
             ).then(
                 fn=update_detail_panels,
@@ -253,7 +259,7 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
 
             txt_event = txt.submit(
                 respond_stream,
-                [txt, image_input],
+                [txt, image_input, meta_playbook_dropdown],
                 [chatbot, move_building_dropdown, move_destination_radio, summon_persona_dropdown, end_conv_persona_dropdown, image_input],
             ).then(
                 fn=update_detail_panels,

--- a/ui/app.py
+++ b/ui/app.py
@@ -11,10 +11,16 @@ from ui.env_settings import create_env_settings_ui
 from ui.chat import (
     call_persona_ui,
     end_conversation_ui,
+    format_building_details,
+    format_execution_states,
     format_location_label,
+    format_persona_details,
     get_autonomous_log,
+    get_building_details,
     get_current_building_history,
     get_current_location_name,
+    get_execution_states,
+    get_persona_details,
     login_ui,
     logout_ui,
     move_user_radio_ui,
@@ -110,115 +116,131 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
             enter_worldview_btn = gr.Button("ワールドビューに入る", variant="primary", elem_id="enter_worldview_btn")
 
         with gr.Column(elem_id="section-worldview", elem_classes=['saiverse-section', 'saiverse-hidden']):
-            with gr.Row(elem_id="chat_header"):
-                user_location_display = gr.Textbox(
-                    # managerから現在地を取得して表示する
-                    value=lambda: manager.building_map.get(manager.user_current_building_id).name if manager.user_current_building_id and manager.user_current_building_id in manager.building_map else "不明な場所",
-                    label="あなたの現在地",
-                    interactive=False,
-                    scale=2,
-                    visible=False
-                )
-                move_building_dropdown = gr.Dropdown(
-                    choices=ui_state.building_choices,
-                    label="移動先の建物",
-                    interactive=True,
-                    scale=2,
-                    visible=False
-                )
-                move_btn = gr.Button("移動", scale=1, visible=False)
+            with gr.Row():
+                # Left column: Chat area
+                with gr.Column(scale=3):
+                    with gr.Row(elem_id="chat_header"):
+                        user_location_display = gr.Textbox(
+                            # managerから現在地を取得して表示する
+                            value=lambda: manager.building_map.get(manager.user_current_building_id).name if manager.user_current_building_id and manager.user_current_building_id in manager.building_map else "不明な場所",
+                            label="あなたの現在地",
+                            interactive=False,
+                            scale=2,
+                            visible=False
+                        )
+                        move_building_dropdown = gr.Dropdown(
+                            choices=ui_state.building_choices,
+                            label="移動先の建物",
+                            interactive=True,
+                            scale=2,
+                            visible=False
+                        )
+                        move_btn = gr.Button("移動", scale=1, visible=False)
 
-                current_location_display = gr.Markdown(
-                    value=lambda: format_location_label(get_current_location_name())
-                )
-            with gr.Group(elem_id="chat_scroll_area"):
-                chatbot = gr.Chatbot(
-                    type="messages",
-                    value=[],
-                    group_consecutive_messages=False,
-                    sanitize_html=False,
-                    elem_id="my_chat",
-                    avatar_images=(None, None),
-                    autoscroll=True,
-                    show_label=False
-                )
-            with gr.Group(elem_id="composer_fixed"):
-                with gr.Row():
-                    with gr.Column(scale=5):
-                        with gr.Row(elem_id="message_input_row", equal_height=True):
-                            txt = gr.Textbox(
-                                placeholder="ここにメッセージを入力...",
-                                lines=3,
-                                elem_id="chat_message_textbox",
-                                show_label=False
-                            )
-                    with gr.Column(scale=1, min_width=0):
-                        submit = gr.Button(value="↑",variant="primary")
-                        image_input = gr.UploadButton(
-                            "📎",
-                            file_types=["image"],
-                            file_count="single",
-                            elem_id="attachment_button"
+                        current_location_display = gr.Markdown(
+                            value=lambda: format_location_label(get_current_location_name())
                         )
-                with gr.Accordion("オプション", open=False):
-                    model_drop = gr.Dropdown(choices=ui_state.model_choices, value="None",label="モデル選択")
-                    with gr.Row():
-                        temperature_slider = gr.Slider(
-                            minimum=0,
-                            maximum=2,
-                            step=0.1,
-                            label="temperature",
-                            visible=False,
-                            interactive=True,
+                    with gr.Group(elem_id="chat_scroll_area"):
+                        chatbot = gr.Chatbot(
+                            type="messages",
+                            value=[],
+                            group_consecutive_messages=False,
+                            sanitize_html=False,
+                            elem_id="my_chat",
+                            avatar_images=(None, None),
+                            autoscroll=True,
+                            show_label=False
                         )
-                        top_p_slider = gr.Slider(
-                            minimum=0,
-                            maximum=1,
-                            step=0.05,
-                            label="top_p",
-                            visible=False,
-                            interactive=True,
-                        )
-                    with gr.Row():
-                        max_tokens_number = gr.Number(
-                            label="max_completion_tokens",
-                            visible=False,
-                            precision=0,
-                            interactive=True,
-                        )
-                        reasoning_dropdown = gr.Dropdown(
-                            label="reasoning_effort",
-                            choices=[],
-                            visible=False,
-                            interactive=True,
-                        )
-                        verbosity_dropdown = gr.Dropdown(
-                            label="verbosity",
-                            choices=[],
-                            visible=False,
-                            interactive=True,
-                        )
-                    refresh_chat_btn = gr.Button("履歴を再読み込み", variant="secondary", elem_id="refresh_chat_btn")
-                    with gr.Row():
-                        with gr.Column():
-                            summon_persona_dropdown = gr.Dropdown(
-                                choices=manager.get_summonable_personas(),
-                                label="呼ぶペルソナを選択",
-                                interactive=True,
-                                scale=3
-                            )
-                            summon_btn = gr.Button("呼ぶ", scale=1)
-                        with gr.Column():
-                            end_conv_persona_dropdown = gr.Dropdown(
-                                choices=manager.get_conversing_personas(),
-                                label="帰ってもらうペルソナを選択",
-                                interactive=True,
-                                scale=3
-                            )
-                            end_conv_btn = gr.Button("帰宅", scale=1)
+                    with gr.Group(elem_id="composer_fixed"):
+                        with gr.Row():
+                            with gr.Column(scale=5):
+                                with gr.Row(elem_id="message_input_row", equal_height=True):
+                                    txt = gr.Textbox(
+                                        placeholder="ここにメッセージを入力...",
+                                        lines=3,
+                                        elem_id="chat_message_textbox",
+                                        show_label=False
+                                    )
+                            with gr.Column(scale=1, min_width=0):
+                                submit = gr.Button(value="↑",variant="primary")
+                                image_input = gr.UploadButton(
+                                    "📎",
+                                    file_types=["image"],
+                                    file_count="single",
+                                    elem_id="attachment_button"
+                                )
+                        with gr.Accordion("オプション", open=False):
+                            model_drop = gr.Dropdown(choices=ui_state.model_choices, value="None",label="モデル選択")
+                            with gr.Row():
+                                temperature_slider = gr.Slider(
+                                    minimum=0,
+                                    maximum=2,
+                                    step=0.1,
+                                    label="temperature",
+                                    visible=False,
+                                    interactive=True,
+                                )
+                                top_p_slider = gr.Slider(
+                                    minimum=0,
+                                    maximum=1,
+                                    step=0.05,
+                                    label="top_p",
+                                    visible=False,
+                                    interactive=True,
+                                )
+                            with gr.Row():
+                                max_tokens_number = gr.Number(
+                                    label="max_completion_tokens",
+                                    visible=False,
+                                    precision=0,
+                                    interactive=True,
+                                )
+                                reasoning_dropdown = gr.Dropdown(
+                                    label="reasoning_effort",
+                                    choices=[],
+                                    visible=False,
+                                    interactive=True,
+                                )
+                                verbosity_dropdown = gr.Dropdown(
+                                    label="verbosity",
+                                    choices=[],
+                                    visible=False,
+                                    interactive=True,
+                                )
+                            refresh_chat_btn = gr.Button("履歴を再読み込み", variant="secondary", elem_id="refresh_chat_btn")
+                            with gr.Row():
+                                with gr.Column():
+                                    summon_persona_dropdown = gr.Dropdown(
+                                        choices=manager.get_summonable_personas(),
+                                        label="呼ぶペルソナを選択",
+                                        interactive=True,
+                                        scale=3
+                                    )
+                                    summon_btn = gr.Button("呼ぶ", scale=1)
+                                with gr.Column():
+                                    end_conv_persona_dropdown = gr.Dropdown(
+                                        choices=manager.get_conversing_personas(),
+                                        label="帰ってもらうペルソナを選択",
+                                        interactive=True,
+                                        scale=3
+                                    )
+                                    end_conv_btn = gr.Button("帰宅", scale=1)
+
+                # Right column: Detail panel
+                with gr.Column(scale=1, elem_id="detail_panel"):
+                    with gr.Tabs():
+                        with gr.Tab("Building"):
+                            building_details_display = gr.Markdown(value="_(読み込み中...)_")
+                        with gr.Tab("ペルソナ"):
+                            persona_details_display = gr.Markdown(value="_(読み込み中...)_")
+                        with gr.Tab("実行状態"):
+                            execution_states_display = gr.Markdown(value="_(読み込み中...)_")
 
             client_location_state = gr.State()
             parameter_state = gr.State({})
+
+            # Timer for detail panel updates
+            detail_update_timer = gr.Timer(value=2.0, active=True)
 
             # --- Event Handlers ---
             submit.click(
@@ -402,6 +424,13 @@ def build_app(city_name: str, note_css: str, head_viewport: str):
             log_building_dropdown.change(fn=get_autonomous_log, inputs=log_building_dropdown, outputs=log_chatbot, show_progress="hidden")
             log_refresh_btn.click(fn=get_autonomous_log, inputs=log_building_dropdown, outputs=log_chatbot, show_progress="hidden")
             auto_refresh_log_btn.click(fn=get_autonomous_log, inputs=log_building_dropdown, outputs=log_chatbot, show_progress="hidden")
+
+            # Detail panel timer update
+            detail_update_timer.tick(
+                fn=lambda: (format_building_details(), format_persona_details(), format_execution_states()),
+                outputs=[building_details_display, persona_details_display, execution_states_display],
+                show_progress="hidden"
+            )
 
 
         with gr.Column(elem_id="section-db-manager", elem_classes=['saiverse-section', 'saiverse-hidden']):

--- a/ui/chat.py
+++ b/ui/chat.py
@@ -374,7 +374,7 @@ def get_current_building_history() -> List[Dict[str, str]]:
     return format_history_for_chatbot(raw_history)
 
 
-def respond_stream(message: str, media: Optional[Any] = None):
+def respond_stream(message: str, media: Optional[Any] = None, meta_playbook: Optional[str] = None):
     manager = ui_state.manager
     if not manager:
         raise RuntimeError("Manager not initialised")
@@ -417,7 +417,7 @@ def respond_stream(message: str, media: Optional[Any] = None):
     history.append(user_display_entry)
 
     ai_message = ""
-    stream = manager.handle_user_input_stream(message, metadata=metadata)
+    stream = manager.handle_user_input_stream(message, metadata=metadata, meta_playbook=meta_playbook)
     for token in stream:
         ai_message += token
         yield (

--- a/ui/item_modal.py
+++ b/ui/item_modal.py
@@ -1,0 +1,313 @@
+"""Item modal display with tooltips and click events."""
+
+ITEM_MODAL_CSS = """
+/* Item link styling */
+.item-link {
+    cursor: pointer;
+    color: #2563eb;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    transition: color 0.2s;
+}
+
+.item-link:hover {
+    color: #1d4ed8;
+    text-decoration-style: solid;
+}
+
+/* Modal overlay */
+#item-modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 9998;
+    justify-content: center;
+    align-items: center;
+}
+
+#item-modal-overlay.show {
+    display: flex;
+}
+
+/* Modal content */
+#item-modal-content {
+    background: white;
+    border-radius: 8px;
+    padding: 24px;
+    max-width: 800px;
+    max-height: 80vh;
+    width: 90%;
+    overflow-y: auto;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    position: relative;
+    z-index: 9999;
+}
+
+/* Dark mode support */
+.dark #item-modal-content {
+    background: #1f2937;
+    color: #f3f4f6;
+}
+
+/* Modal header */
+#item-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+    border-bottom: 1px solid #e5e7eb;
+    padding-bottom: 12px;
+}
+
+.dark #item-modal-header {
+    border-bottom-color: #374151;
+}
+
+#item-modal-title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 0;
+}
+
+#item-modal-close {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    line-height: 1;
+    color: #6b7280;
+}
+
+#item-modal-close:hover {
+    color: #111827;
+}
+
+.dark #item-modal-close:hover {
+    color: #f3f4f6;
+}
+
+/* Modal body */
+#item-modal-body {
+    line-height: 1.6;
+}
+
+#item-modal-body pre {
+    background: #f3f4f6;
+    padding: 12px;
+    border-radius: 4px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.dark #item-modal-body pre {
+    background: #111827;
+}
+
+#item-modal-body img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+}
+
+.item-meta {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-bottom: 12px;
+}
+
+.dark .item-meta {
+    color: #9ca3af;
+}
+
+.item-meta code {
+    background: #f3f4f6;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: monospace;
+}
+
+.dark .item-meta code {
+    background: #374151;
+}
+"""
+
+ITEM_MODAL_JS = """
+() => {
+    // ===== SCRIPT LOADED CHECK =====
+    console.log('[ItemModal] ===== SCRIPT FILE LOADED AND PARSING STARTED =====');
+    console.log('[ItemModal] Current time:', new Date().toISOString());
+    console.log('[ItemModal] Document readyState:', document.readyState);
+    console.log('[ItemModal] Document body exists:', !!document.body);
+
+    function initItemModal() {
+        console.log('[ItemModal] initItemModal called');
+
+        // Create modal elements if they don't exist
+        if (!document.getElementById('item-modal-overlay')) {
+            console.log('[ItemModal] Creating modal overlay');
+            const overlay = document.createElement('div');
+            overlay.id = 'item-modal-overlay';
+            overlay.innerHTML = `
+                <div id="item-modal-content">
+                    <div id="item-modal-header">
+                        <h2 id="item-modal-title"></h2>
+                        <button id="item-modal-close">&times;</button>
+                    </div>
+                    <div id="item-modal-body"></div>
+                </div>
+            `;
+            document.body.appendChild(overlay);
+            console.log('[ItemModal] Modal overlay created');
+
+            // Close modal on overlay click
+            overlay.addEventListener('click', function(e) {
+                if (e.target === overlay) {
+                    closeItemModal();
+                }
+            });
+
+            // Close button
+            document.getElementById('item-modal-close').addEventListener('click', closeItemModal);
+        } else {
+            console.log('[ItemModal] Modal overlay already exists');
+        }
+
+        // Add click event listeners to all item links
+        const itemLinks = document.querySelectorAll('.item-link');
+        console.log('[ItemModal] Found', itemLinks.length, 'item links');
+
+        itemLinks.forEach(function(link, index) {
+            console.log('[ItemModal] Processing link', index, ':', link.getAttribute('data-item-name'), 'type:', link.getAttribute('data-item-type'));
+            link.removeEventListener('click', handleItemClick); // Remove existing listeners
+            link.addEventListener('click', handleItemClick);
+        });
+    }
+
+    function handleItemClick(e) {
+        console.log('[ItemModal] Item clicked:', e.target);
+
+        const link = e.target;
+        const itemId = link.getAttribute('data-item-id');
+        const itemName = link.getAttribute('data-item-name');
+        const itemDesc = link.getAttribute('data-item-desc');
+        const itemType = link.getAttribute('data-item-type');
+        const filePath = link.getAttribute('data-file-path');
+
+        console.log('[ItemModal] Item details:', {itemId, itemName, itemDesc, itemType, filePath});
+
+        if (itemType === 'picture' || itemType === 'document') {
+            console.log('[ItemModal] Showing modal for', itemType);
+            showItemModal(itemId, itemName, itemDesc, itemType, filePath);
+        } else {
+            console.log('[ItemModal] Item type not supported:', itemType);
+        }
+    }
+
+    function showItemModal(itemId, itemName, itemDesc, itemType, filePath) {
+        console.log('[ItemModal] showItemModal called with:', {itemId, itemName, itemType});
+
+        const overlay = document.getElementById('item-modal-overlay');
+        const title = document.getElementById('item-modal-title');
+        const body = document.getElementById('item-modal-body');
+
+        if (!overlay || !title || !body) {
+            console.error('[ItemModal] Modal elements not found!', {overlay, title, body});
+            return;
+        }
+
+        title.textContent = itemName;
+
+        // Show meta information
+        let metaHtml = `<div class="item-meta">`;
+        metaHtml += `<p><strong>ID:</strong> <code>${itemId}</code></p>`;
+        if (itemDesc) {
+            metaHtml += `<p><strong>説明:</strong> ${itemDesc}</p>`;
+        }
+        metaHtml += `<p><strong>タイプ:</strong> ${itemType}</p>`;
+        metaHtml += `</div>`;
+
+        body.innerHTML = metaHtml + '<p><em>読み込み中...</em></p>';
+        overlay.classList.add('show');
+        console.log('[ItemModal] Modal displayed, fetching content from API');
+
+        // Fetch item content from API
+        const apiUrl = `/api/item/view?item_id=${encodeURIComponent(itemId)}`;
+        console.log('[ItemModal] Fetching:', apiUrl);
+        console.log('[ItemModal] Full URL:', window.location.origin + apiUrl);
+        console.log('[ItemModal] Item ID:', itemId);
+
+        fetch(apiUrl)
+            .then(response => {
+                console.log('[ItemModal] API response status:', response.status);
+                console.log('[ItemModal] API response ok:', response.ok);
+                console.log('[ItemModal] API response headers:', response.headers);
+                return response.json();
+            })
+            .then(data => {
+                console.log('[ItemModal] API response data:', data);
+                console.log('[ItemModal] data.success:', data.success);
+                console.log('[ItemModal] data.content:', data.content ? `${data.content.substring(0, 100)}...` : 'undefined');
+                console.log('[ItemModal] data.error:', data.error);
+
+                if (data.success) {
+                    let contentHtml = metaHtml;
+                    if (itemType === 'picture') {
+                        // Display image
+                        contentHtml += `<img src="${data.file_path}" alt="${itemName}" />`;
+                        console.log('[ItemModal] Displaying image:', data.file_path);
+                    } else if (itemType === 'document') {
+                        // Display document content
+                        if (data.content) {
+                            contentHtml += `<pre>${data.content}</pre>`;
+                            console.log('[ItemModal] Displaying document, content length:', data.content.length);
+                        } else {
+                            contentHtml += `<p style="color: red;">コンテンツが空です</p>`;
+                            console.error('[ItemModal] Document content is undefined or empty');
+                        }
+                    }
+                    body.innerHTML = contentHtml;
+                } else {
+                    console.error('[ItemModal] API returned error:', data.error);
+                    const errorMsg = data.error || 'Unknown error';
+                    body.innerHTML = metaHtml + `<p style="color: red;">エラー: ${errorMsg}</p>`;
+                }
+            })
+            .catch(error => {
+                console.error('[ItemModal] Fetch error:', error);
+                body.innerHTML = metaHtml + `<p style="color: red;">ファイルの読み込みに失敗しました: ${error}</p>`;
+            });
+    }
+
+    function closeItemModal() {
+        const overlay = document.getElementById('item-modal-overlay');
+        overlay.classList.remove('show');
+    }
+
+    // Initialize on page load and after updates
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initItemModal);
+    } else {
+        initItemModal();
+    }
+
+    // Re-initialize when detail panels are updated
+    const observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+            if (mutation.type === 'childList' && mutation.target.querySelector('.item-link')) {
+                initItemModal();
+            }
+        });
+    });
+
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
+    });
+}
+"""

--- a/ui/persona_settings.py
+++ b/ui/persona_settings.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
+
+import gradio as gr
+import pandas as pd
+from gradio.events import SelectData
+
+from database.models import PersonaSchedule, Playbook as PlaybookModel, AI as AIModel, City as CityModel
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _get_persona_timezone(manager, persona_id: str) -> ZoneInfo:
+    """ペルソナのホームCityのタイムゾーンを取得"""
+    session = manager.SessionLocal()
+    try:
+        persona_model = session.query(AIModel).filter(AIModel.AIID == persona_id).first()
+        if not persona_model:
+            LOGGER.warning("Persona %s not found in database", persona_id)
+            return ZoneInfo("UTC")
+
+        city_model = session.query(CityModel).filter(CityModel.CITYID == persona_model.HOME_CITYID).first()
+        if not city_model or not city_model.TIMEZONE:
+            LOGGER.warning("City timezone not found for persona %s", persona_id)
+            return ZoneInfo("UTC")
+
+        return ZoneInfo(city_model.TIMEZONE)
+    except Exception as e:
+        LOGGER.warning("Failed to get timezone for persona %s: %s", persona_id, e)
+        return ZoneInfo("UTC")
+    finally:
+        session.close()
+
+
+def _persona_choices(manager) -> List[tuple[str, str]]:
+    """ペルソナの選択肢リストを生成"""
+    choices: List[tuple[str, str]] = []
+    if not manager:
+        return choices
+    for persona_id, persona in manager.personas.items():
+        display = persona.persona_name or persona_id
+        choices.append((display, persona_id))
+    choices.sort(key=lambda item: item[0])
+    return choices
+
+
+def _get_user_selectable_playbooks(manager) -> List[tuple[str, str]]:
+    """user_selectable=Trueのメタプレイブックを取得"""
+    session = manager.SessionLocal()
+    try:
+        playbooks = (
+            session.query(PlaybookModel)
+            .filter(
+                PlaybookModel.user_selectable == True,
+                PlaybookModel.name.like("meta_%"),
+            )
+            .all()
+        )
+        choices = [(pb.name, pb.name) for pb in playbooks]
+        choices.sort(key=lambda item: item[0])
+        return choices
+    except Exception as e:
+        LOGGER.error("Failed to fetch user_selectable playbooks: %s", e, exc_info=True)
+        return []
+    finally:
+        session.close()
+
+
+def _empty_schedule_table() -> pd.DataFrame:
+    """空のスケジュールテーブルを返す"""
+    return pd.DataFrame(
+        columns=[
+            "ID",
+            "タイプ",
+            "プレイブック",
+            "説明",
+            "優先度",
+            "有効",
+            "設定詳細",
+        ]
+    )
+
+
+def _load_schedules(manager, persona_id: str) -> tuple[pd.DataFrame, str]:
+    """ペルソナのスケジュール一覧を読み込む"""
+    if not persona_id:
+        return _empty_schedule_table(), "ペルソナを選んでね。"
+
+    session = manager.SessionLocal()
+    try:
+        schedules = (
+            session.query(PersonaSchedule)
+            .filter(PersonaSchedule.PERSONA_ID == persona_id)
+            .order_by(PersonaSchedule.PRIORITY.desc(), PersonaSchedule.SCHEDULE_ID.desc())
+            .all()
+        )
+
+        if not schedules:
+            return _empty_schedule_table(), "スケジュールがまだないよ。"
+
+        # ペルソナのタイムゾーンを取得（表示用）
+        persona_tz = _get_persona_timezone(manager, persona_id)
+
+        rows = []
+        for s in schedules:
+            schedule_type = s.SCHEDULE_TYPE
+            detail = ""
+
+            if schedule_type == "periodic":
+                days = "毎日"
+                if s.DAYS_OF_WEEK:
+                    try:
+                        day_list = json.loads(s.DAYS_OF_WEEK)
+                        day_names = ["月", "火", "水", "木", "金", "土", "日"]
+                        days = ", ".join([day_names[d] for d in day_list if 0 <= d < 7])
+                    except Exception:
+                        pass
+                detail = f"{days} {s.TIME_OF_DAY or '??:??'}"
+
+            elif schedule_type == "oneshot":
+                if s.SCHEDULED_DATETIME:
+                    # UTCからペルソナのタイムゾーンに変換して表示
+                    dt_utc = s.SCHEDULED_DATETIME
+                    if dt_utc.tzinfo is None:
+                        dt_utc = dt_utc.replace(tzinfo=timezone.utc)
+                    dt_local = dt_utc.astimezone(persona_tz)
+                    detail = dt_local.strftime("%Y-%m-%d %H:%M")
+                else:
+                    detail = "未設定"
+                if s.COMPLETED:
+                    detail += " (完了)"
+
+            elif schedule_type == "interval":
+                interval_sec = s.INTERVAL_SECONDS or 0
+                detail = f"間隔: {interval_sec}秒"
+                if s.LAST_EXECUTED_AT:
+                    detail += f" (最終実行: {s.LAST_EXECUTED_AT.strftime('%Y-%m-%d %H:%M')})"
+
+            rows.append(
+                [
+                    s.SCHEDULE_ID,
+                    schedule_type,
+                    s.META_PLAYBOOK,
+                    s.DESCRIPTION or "",
+                    s.PRIORITY,
+                    "✓" if s.ENABLED else "",
+                    detail,
+                ]
+            )
+
+        df = pd.DataFrame(
+            rows,
+            columns=["ID", "タイプ", "プレイブック", "説明", "優先度", "有効", "設定詳細"],
+        )
+        return df, f"{len(schedules)}件のスケジュールを取得したよ。"
+
+    except Exception as e:
+        LOGGER.error("Failed to load schedules: %s", e, exc_info=True)
+        return _empty_schedule_table(), f"エラー: {e}"
+    finally:
+        session.close()
+
+
+def _add_schedule(
+    manager,
+    persona_id: str,
+    schedule_type: str,
+    meta_playbook: str,
+    description: str,
+    priority: int,
+    enabled: bool,
+    # periodic
+    days_of_week: List[str],
+    time_of_day: str,
+    # oneshot
+    scheduled_datetime_str: str,
+    # interval
+    interval_seconds: int,
+) -> tuple[pd.DataFrame, str]:
+    """スケジュールを追加"""
+    if not persona_id:
+        return _load_schedules(manager, persona_id)[0], "ペルソナを選んでね。"
+
+    if not meta_playbook:
+        return _load_schedules(manager, persona_id)[0], "メタプレイブックを選んでね。"
+
+    session = manager.SessionLocal()
+    try:
+        new_schedule = PersonaSchedule(
+            PERSONA_ID=persona_id,
+            SCHEDULE_TYPE=schedule_type,
+            META_PLAYBOOK=meta_playbook,
+            DESCRIPTION=description,
+            PRIORITY=priority,
+            ENABLED=enabled,
+        )
+
+        if schedule_type == "periodic":
+            # 曜日をJSONに変換
+            weekday_map = {"月": 0, "火": 1, "水": 2, "木": 3, "金": 4, "土": 5, "日": 6}
+            day_indices = [weekday_map[d] for d in days_of_week if d in weekday_map]
+            new_schedule.DAYS_OF_WEEK = json.dumps(day_indices) if day_indices else None
+            new_schedule.TIME_OF_DAY = time_of_day or None
+
+        elif schedule_type == "oneshot":
+            if scheduled_datetime_str:
+                try:
+                    # ペルソナのホームCityのタイムゾーンを取得
+                    persona_tz = _get_persona_timezone(manager, persona_id)
+                    # 入力された時刻をペルソナのタイムゾーンとして解釈
+                    dt_naive = datetime.strptime(scheduled_datetime_str, "%Y-%m-%d %H:%M")
+                    dt_local = dt_naive.replace(tzinfo=persona_tz)
+                    # UTCに変換してDBに保存
+                    dt_utc = dt_local.astimezone(timezone.utc)
+                    new_schedule.SCHEDULED_DATETIME = dt_utc
+                    LOGGER.info(
+                        "[PersonaSettings] Oneshot schedule: input=%s, local=%s (%s), utc=%s",
+                        scheduled_datetime_str,
+                        dt_local.isoformat(),
+                        persona_tz,
+                        dt_utc.isoformat(),
+                    )
+                except Exception as e:
+                    LOGGER.error("Failed to parse datetime: %s", e, exc_info=True)
+                    return _load_schedules(manager, persona_id)[0], f"日時の形式が正しくないよ (YYYY-MM-DD HH:MM): {e}"
+
+        elif schedule_type == "interval":
+            new_schedule.INTERVAL_SECONDS = interval_seconds or None
+
+        session.add(new_schedule)
+        session.commit()
+
+        LOGGER.info(
+            "[PersonaSettings] Added schedule %d for persona %s (type=%s)",
+            new_schedule.SCHEDULE_ID,
+            persona_id,
+            schedule_type,
+        )
+
+        return _load_schedules(manager, persona_id)[0], "スケジュールを追加したよ！"
+
+    except Exception as e:
+        LOGGER.error("Failed to add schedule: %s", e, exc_info=True)
+        return _load_schedules(manager, persona_id)[0], f"エラー: {e}"
+    finally:
+        session.close()
+
+
+def _delete_schedule(manager, persona_id: str, schedule_id: Optional[int]) -> tuple[pd.DataFrame, str]:
+    """スケジュールを削除"""
+    if not schedule_id:
+        return _load_schedules(manager, persona_id)[0], "削除するスケジュールを選んでね。"
+
+    session = manager.SessionLocal()
+    try:
+        schedule = session.query(PersonaSchedule).filter(PersonaSchedule.SCHEDULE_ID == schedule_id).first()
+        if not schedule:
+            return _load_schedules(manager, persona_id)[0], "スケジュールが見つからなかったよ。"
+
+        session.delete(schedule)
+        session.commit()
+
+        LOGGER.info("[PersonaSettings] Deleted schedule %d", schedule_id)
+        return _load_schedules(manager, persona_id)[0], "スケジュールを削除したよ。"
+
+    except Exception as e:
+        LOGGER.error("Failed to delete schedule: %s", e, exc_info=True)
+        return _load_schedules(manager, persona_id)[0], f"エラー: {e}"
+    finally:
+        session.close()
+
+
+def _toggle_schedule(manager, persona_id: str, schedule_id: Optional[int]) -> tuple[pd.DataFrame, str]:
+    """スケジュールの有効/無効を切り替え"""
+    if not schedule_id:
+        return _load_schedules(manager, persona_id)[0], "切り替えるスケジュールを選んでね。"
+
+    session = manager.SessionLocal()
+    try:
+        schedule = session.query(PersonaSchedule).filter(PersonaSchedule.SCHEDULE_ID == schedule_id).first()
+        if not schedule:
+            return _load_schedules(manager, persona_id)[0], "スケジュールが見つからなかったよ。"
+
+        schedule.ENABLED = not schedule.ENABLED
+        session.commit()
+
+        status = "有効" if schedule.ENABLED else "無効"
+        LOGGER.info("[PersonaSettings] Toggled schedule %d to %s", schedule_id, status)
+        return _load_schedules(manager, persona_id)[0], f"スケジュールを{status}にしたよ。"
+
+    except Exception as e:
+        LOGGER.error("Failed to toggle schedule: %s", e, exc_info=True)
+        return _load_schedules(manager, persona_id)[0], f"エラー: {e}"
+    finally:
+        session.close()
+
+
+def _on_schedule_select(select_data: SelectData, schedule_table: pd.DataFrame) -> Optional[int]:
+    """スケジュール選択時のハンドラー"""
+    if not isinstance(select_data, SelectData) or select_data.index is None:
+        return None
+
+    idx = select_data.index
+    if isinstance(idx, (list, tuple)):
+        row_idx = idx[0]
+    else:
+        row_idx = idx
+
+    if isinstance(schedule_table, pd.DataFrame) and 0 <= row_idx < len(schedule_table):
+        schedule_id = schedule_table.iloc[row_idx]["ID"]
+        return int(schedule_id)
+
+    return None
+
+
+def create_persona_settings_ui(manager) -> None:
+    """ペルソナ設定UIを作成（メモリー設定 + スケジュール管理）"""
+    # メモリー設定UIのインポート
+    from tools.utilities.memory_settings_ui import create_memory_settings_ui
+
+    gr.Markdown("## ペルソナ設定")
+    gr.Markdown("ペルソナごとの長期記憶とスケジュールを管理するよ。")
+
+    with gr.Tabs():
+        # タブ1: 長期記憶管理（既存のメモリー設定）
+        with gr.TabItem("長期記憶管理"):
+            create_memory_settings_ui(manager)
+
+        # タブ2: スケジュール管理（新規）
+        with gr.TabItem("スケジュール管理"):
+            gr.Markdown("### スケジュール管理")
+            gr.Markdown(
+                """
+                ペルソナの定期的な行動をスケジュールできるよ。
+
+                **スケジュールタイプ**:
+                - **定期**: 特定の曜日・時刻に実行（例: 毎朝9時）
+                - **単発**: 指定した日時に1回だけ実行
+                - **恒常**: 一定間隔で繰り返し実行（例: 10分おき）
+                """
+            )
+
+            choices = _persona_choices(manager)
+            persona_ids = [pid for _, pid in choices]
+            default_persona = persona_ids[0] if persona_ids else None
+
+            persona_dropdown = gr.Dropdown(
+                choices=[label for label, _ in choices] if choices else [],
+                value=choices[0][0] if choices else None,
+                label="ペルソナ",
+                interactive=bool(choices),
+            )
+            persona_id_state = gr.State(default_persona)
+
+            def _update_persona(selected_label: Optional[str], current_id: Optional[str]):
+                if not choices:
+                    return current_id, "ペルソナが見つからなかったよ。", _empty_schedule_table(), ""
+                mapping = {label: pid for label, pid in choices}
+                persona_id = mapping.get(selected_label) if selected_label else None
+                if not persona_id:
+                    return current_id, "そのペルソナは今使えないみたい。", _empty_schedule_table(), ""
+                table, msg = _load_schedules(manager, persona_id)
+                return persona_id, f"対象ペルソナ: {selected_label} ({persona_id})", table, msg
+
+            persona_status = gr.Markdown(
+                f"対象ペルソナ: {choices[0][0]} ({choices[0][1]})" if choices else "対象ペルソナがまだ無いよ。"
+            )
+
+            # スケジュール一覧
+            schedule_table = gr.DataFrame(value=_empty_schedule_table(), interactive=False)
+            schedule_feedback = gr.Markdown("")
+            selected_schedule_id = gr.State(None)
+
+            refresh_btn = gr.Button("スケジュール一覧を更新", variant="secondary")
+
+            # スケジュール追加フォーム
+            with gr.Accordion("スケジュールを追加", open=False):
+                schedule_type_radio = gr.Radio(
+                    choices=["periodic", "oneshot", "interval"],
+                    value="periodic",
+                    label="スケジュールタイプ",
+                )
+
+                playbook_choices = _get_user_selectable_playbooks(manager)
+                meta_playbook_dropdown = gr.Dropdown(
+                    choices=[label for label, _ in playbook_choices] if playbook_choices else [],
+                    label="メタプレイブック",
+                    interactive=bool(playbook_choices),
+                )
+
+                description_box = gr.Textbox(label="説明", placeholder="このスケジュールの説明を入力してね")
+                priority_number = gr.Number(label="優先度", value=0, precision=0)
+                enabled_checkbox = gr.Checkbox(label="有効にする", value=True)
+
+                # 定期スケジュール用
+                with gr.Group(visible=True) as periodic_group:
+                    days_checkbox = gr.CheckboxGroup(
+                        choices=["月", "火", "水", "木", "金", "土", "日"],
+                        label="曜日（未選択の場合は毎日）",
+                    )
+                    time_box = gr.Textbox(
+                        label="時刻 (HH:MM)",
+                        placeholder="09:00",
+                        value="09:00",
+                        info="ペルソナのホームCityのタイムゾーンで入力してね",
+                    )
+
+                # 単発スケジュール用
+                with gr.Group(visible=False) as oneshot_group:
+                    datetime_box = gr.Textbox(
+                        label="実行日時 (YYYY-MM-DD HH:MM)",
+                        placeholder="2025-12-07 09:00",
+                        info="ペルソナのホームCityのタイムゾーンで入力してね",
+                    )
+
+                # 恒常スケジュール用
+                with gr.Group(visible=False) as interval_group:
+                    interval_number = gr.Number(label="インターバル（秒）", value=600, precision=0)
+
+                # スケジュールタイプに応じてグループの表示を切り替え
+                def _update_form_visibility(schedule_type):
+                    return (
+                        gr.update(visible=(schedule_type == "periodic")),
+                        gr.update(visible=(schedule_type == "oneshot")),
+                        gr.update(visible=(schedule_type == "interval")),
+                    )
+
+                schedule_type_radio.change(
+                    fn=_update_form_visibility,
+                    inputs=[schedule_type_radio],
+                    outputs=[periodic_group, oneshot_group, interval_group],
+                )
+
+                add_btn = gr.Button("スケジュールを追加", variant="primary")
+
+            # スケジュール操作ボタン
+            with gr.Row():
+                toggle_btn = gr.Button("有効/無効を切り替え", variant="secondary")
+                delete_btn = gr.Button("削除", variant="stop")
+
+            # イベントハンドラー
+            persona_dropdown.change(
+                fn=_update_persona,
+                inputs=[persona_dropdown, persona_id_state],
+                outputs=[persona_id_state, persona_status, schedule_table, schedule_feedback],
+                show_progress="hidden",
+            )
+
+            refresh_btn.click(
+                fn=lambda persona_id: _load_schedules(manager, persona_id),
+                inputs=[persona_id_state],
+                outputs=[schedule_table, schedule_feedback],
+                show_progress=True,
+            )
+
+            add_btn.click(
+                fn=lambda persona_id, stype, playbook, desc, prio, enabled, days, time, dt_str, interval: _add_schedule(
+                    manager,
+                    persona_id,
+                    stype,
+                    playbook,
+                    desc,
+                    int(prio),
+                    enabled,
+                    days or [],
+                    time,
+                    dt_str,
+                    int(interval),
+                ),
+                inputs=[
+                    persona_id_state,
+                    schedule_type_radio,
+                    meta_playbook_dropdown,
+                    description_box,
+                    priority_number,
+                    enabled_checkbox,
+                    days_checkbox,
+                    time_box,
+                    datetime_box,
+                    interval_number,
+                ],
+                outputs=[schedule_table, schedule_feedback],
+                show_progress=True,
+            )
+
+            schedule_table.select(
+                fn=_on_schedule_select,
+                inputs=[schedule_table],
+                outputs=[selected_schedule_id],
+                show_progress="hidden",
+            )
+
+            toggle_btn.click(
+                fn=lambda persona_id, schedule_id: _toggle_schedule(manager, persona_id, schedule_id),
+                inputs=[persona_id_state, selected_schedule_id],
+                outputs=[schedule_table, schedule_feedback],
+                show_progress=True,
+            )
+
+            delete_btn.click(
+                fn=lambda persona_id, schedule_id: _delete_schedule(manager, persona_id, schedule_id),
+                inputs=[persona_id_state, selected_schedule_id],
+                outputs=[schedule_table, schedule_feedback],
+                show_progress=True,
+            )

--- a/ui/state.py
+++ b/ui/state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+import threading
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from saiverse_manager import SAIVerseManager
 
@@ -10,9 +11,17 @@ building_choices: List[str] = []
 building_name_to_id: Dict[str, str] = {}
 autonomous_building_choices: List[str] = []
 autonomous_building_map: Dict[str, str] = {}
-model_choices: List[str] = []
+model_choices: List[Union[str, Tuple[str, str]]] = []  # Can be ["model"] or [("display_name", "model_id")] - Gradio format
 chat_history_limit: int = 120
 version: str = ""
+
+# --- Unread message tracking ---
+# building_id -> message count when last viewed
+_last_seen_counts: Dict[str, int] = {}
+# building_id set that has unread messages
+_unread_buildings: Set[str] = set()
+# Lock for thread-safe access
+_unread_lock = threading.Lock()
 
 
 def bind_manager(instance: SAIVerseManager) -> None:
@@ -50,3 +59,87 @@ def refresh_building_caches() -> None:
     autonomous_building_map = {
         b.name: b.building_id for b in manager.buildings if b.building_id != manager.user_room_id
     }
+
+
+# --- Unread message management functions ---
+
+def get_current_message_count(building_id: str) -> int:
+    """Get current message count for a building (only visible messages)."""
+    if not manager:
+        return 0
+    history = manager.building_histories.get(building_id, [])
+    # Only count messages that are displayed in UI (user and assistant roles)
+    # host role messages (system notifications like "X moved to Y") are not shown to user
+    visible_count = sum(1 for msg in history if msg.get("role") in ("user", "assistant"))
+    return visible_count
+
+
+def mark_building_as_read(building_id: str) -> None:
+    """Mark a building as read (user entered or is viewing it)."""
+    import logging
+    LOGGER = logging.getLogger(__name__)
+    with _unread_lock:
+        current_count = get_current_message_count(building_id)
+        was_unread = building_id in _unread_buildings
+        _last_seen_counts[building_id] = current_count
+        _unread_buildings.discard(building_id)
+        LOGGER.info(
+            "[unread] mark_building_as_read: %s, count=%d, was_unread=%s, unread_now=%s",
+            building_id, current_count, was_unread, _unread_buildings
+        )
+
+
+def check_for_new_messages() -> Set[str]:
+    """
+    Check all buildings for new messages.
+    Returns set of building_ids that have new unread messages since last check.
+    """
+    import logging
+    LOGGER = logging.getLogger(__name__)
+
+    if not manager:
+        return set()
+
+    newly_unread: Set[str] = set()
+    # Get current building (user is viewing this one, so don't mark as unread)
+    current_building_id = manager.user_current_building_id
+
+    with _unread_lock:
+        for building in manager.buildings:
+            bid = building.building_id
+            current_count = get_current_message_count(bid)
+            last_seen = _last_seen_counts.get(bid, 0)
+
+            if current_count > last_seen:
+                LOGGER.warning(
+                    "[unread-debug] Building %s (%s): current=%d > last_seen=%d, current_building=%s",
+                    bid, building.name, current_count, last_seen, current_building_id
+                )
+                # Skip the building user is currently in
+                if bid == current_building_id:
+                    # Update last_seen so it won't be marked unread when user leaves
+                    _last_seen_counts[bid] = current_count
+                    continue
+
+                if bid not in _unread_buildings:
+                    newly_unread.add(bid)
+                _unread_buildings.add(bid)
+
+    return newly_unread
+
+
+def get_unread_buildings() -> Set[str]:
+    """Get the set of building_ids with unread messages."""
+    with _unread_lock:
+        return _unread_buildings.copy()
+
+
+def initialize_message_counts() -> None:
+    """Initialize last seen counts for all buildings (call on startup)."""
+    if not manager:
+        return
+    with _unread_lock:
+        for building in manager.buildings:
+            bid = building.building_id
+            _last_seen_counts[bid] = get_current_message_count(bid)
+        _unread_buildings.clear()


### PR DESCRIPTION
- アイテムtypeにdocumentとpictureを追加（pictureは未テスト）
- アイテムやBuildingの情報が表示される右サイドバーを追加
- アイテム内容を表示するためマウスオーバーとモーダル表示を追加
- ユーザーがオプションから今回使用するメタプレイブックを選べるように
- スケジュール機能とそれに関するツールおよびPlaybookの追加
- モデルの扱いを1モデルごと1JSON作る形に変更
- Playbookの扱いを諸々改修
- Nvidia NIMまわりを整備
- Buildingのシステムプロンプトに今日は{current_date}、{current_weekday}曜日です。壁掛け時計は{current_time}を指しています。などと入れることで日時を注入できるように
- Building移動ツールとPlaybookの追加（未テスト）