### PR TITLE
Improve Memopedia context relevance and depth

### DIFF
--- a/api/routes/people/memopedia.py
+++ b/api/routes/people/memopedia.py
@@ -129,6 +129,7 @@ def update_memopedia_page(
             summary=request.summary,
             content=request.content,
             keywords=request.keywords,
+            vividness=request.vividness,
             edit_source="manual_ui",
         )
         if not updated:
@@ -141,6 +142,7 @@ def update_memopedia_page(
                 "summary": updated.summary,
                 "content": updated.content,
                 "keywords": updated.keywords,
+                "vividness": updated.vividness,
             }
         }
     except HTTPException:

--- a/api/routes/people/models.py
+++ b/api/routes/people/models.py
@@ -161,6 +161,7 @@ class UpdateMemopediaPageRequest(BaseModel):
     summary: Optional[str] = None
     content: Optional[str] = None
     keywords: Optional[List[str]] = None
+    vividness: Optional[str] = None
 
 
 # -----------------------------------------------------------------------------

--- a/frontend/src/components/memory/MemopediaViewer.module.css
+++ b/frontend/src/components/memory/MemopediaViewer.module.css
@@ -610,3 +610,23 @@
     opacity: 0.5;
     cursor: not-allowed;
 }
+
+/* Vividness Styles */
+.pageVividVivid {
+    font-weight: 700;
+    color: #fff;
+}
+
+.pageVividRough {
+    /* Default - no extra styles needed */
+}
+
+.pageVividFaint {
+    color: #666;
+}
+
+.pageVividBuried {
+    color: #444;
+    font-style: italic;
+    opacity: 0.7;
+}

--- a/frontend/src/components/memory/MemopediaViewer.tsx
+++ b/frontend/src/components/memory/MemopediaViewer.tsx
@@ -330,28 +330,27 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
             if (!hasChildren) setShowList(false); // Mobile: go to content if leaf
         };
 
-        // Style based on vividness
-        const getVividnessStyle = () => {
+        // CSS class based on vividness
+        const getVividnessClass = () => {
             switch (page.vividness) {
                 case 'vivid':
-                    return { fontWeight: 'bold' as const, color: '#000' };
+                    return styles.pageVividVivid;
                 case 'rough':
-                    return {}; // Default style
+                    return styles.pageVividRough;
                 case 'faint':
-                    return { color: '#999' };
+                    return styles.pageVividFaint;
                 case 'buried':
-                    return { color: '#ccc', fontStyle: 'italic' as const };
+                    return styles.pageVividBuried;
                 default:
-                    return {};
+                    return '';
             }
         };
 
         return (
             <div>
                 <div
-                    className={`${styles.pageItem} ${selectedPageId === page.id ? styles.active : ''}`}
+                    className={`${styles.pageItem} ${selectedPageId === page.id ? styles.active : ''} ${getVividnessClass()}`}
                     onClick={handlePageClick}
-                    style={getVividnessStyle()}
                 >
                     {hasChildren ? (
                         <span

--- a/frontend/src/components/memory/MemopediaViewer.tsx
+++ b/frontend/src/components/memory/MemopediaViewer.tsx
@@ -202,6 +202,27 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
         setIsEditing(false);
     };
 
+    const handleVividnessChange = async (newVividness: string) => {
+        if (!selectedPageId) return;
+        try {
+            const res = await fetch(`/api/people/${personaId}/memopedia/pages/${selectedPageId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ vividness: newVividness }),
+            });
+
+            if (res.ok) {
+                await loadTree(); // Refresh tree to show updated vividness
+            } else {
+                const err = await res.json();
+                alert(`鮮明度の更新に失敗しました: ${err.detail || 'Unknown error'}`);
+            }
+        } catch (error) {
+            console.error('Failed to update vividness', error);
+            alert('鮮明度の更新に失敗しました');
+        }
+    };
+
     const saveEdit = async () => {
         if (!selectedPageId) return;
         setIsSaving(true);
@@ -586,8 +607,28 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
                                         </div>
                                     </div>
                                 )}
-                                <div style={{ marginBottom: '1rem', fontSize: '0.9em', color: '#666' }}>
-                                    <strong>鮮明度:</strong> {getVividnessLabel(selectedVividness)}
+                                <div style={{ marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                                    <label style={{ fontSize: '0.9em', fontWeight: 'bold', color: '#666' }}>鮮明度:</label>
+                                    <select
+                                        value={selectedVividness}
+                                        onChange={e => handleVividnessChange(e.target.value)}
+                                        style={{
+                                            padding: '4px 8px',
+                                            fontSize: '0.9em',
+                                            borderRadius: '4px',
+                                            border: '1px solid #ccc',
+                                            backgroundColor: '#fff',
+                                            cursor: 'pointer'
+                                        }}
+                                    >
+                                        <option value="vivid">鮮明（全内容）</option>
+                                        <option value="rough">概要（デフォルト）</option>
+                                        <option value="faint">淡い（タイトルのみ）</option>
+                                        <option value="buried">埋没（非表示）</option>
+                                    </select>
+                                    <small style={{ color: '#888' }}>
+                                        コンテキストに含める情報量
+                                    </small>
                                 </div>
                                 <div className={styles.markdown}>
                                     <ReactMarkdown>{pageContent}</ReactMarkdown>

--- a/frontend/src/components/memory/MemopediaViewer.tsx
+++ b/frontend/src/components/memory/MemopediaViewer.tsx
@@ -330,11 +330,28 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
             if (!hasChildren) setShowList(false); // Mobile: go to content if leaf
         };
 
+        // Style based on vividness
+        const getVividnessStyle = () => {
+            switch (page.vividness) {
+                case 'vivid':
+                    return { fontWeight: 'bold' as const, color: '#000' };
+                case 'rough':
+                    return {}; // Default style
+                case 'faint':
+                    return { color: '#999' };
+                case 'buried':
+                    return { color: '#ccc', fontStyle: 'italic' as const };
+                default:
+                    return {};
+            }
+        };
+
         return (
             <div>
                 <div
                     className={`${styles.pageItem} ${selectedPageId === page.id ? styles.active : ''}`}
                     onClick={handlePageClick}
+                    style={getVividnessStyle()}
                 >
                     {hasChildren ? (
                         <span

--- a/frontend/src/components/memory/MemopediaViewer.tsx
+++ b/frontend/src/components/memory/MemopediaViewer.tsx
@@ -8,6 +8,7 @@ interface MemopediaPage {
     title: string;
     summary: string;
     keywords: string[];
+    vividness: string;
     children: MemopediaPage[];
 }
 
@@ -67,6 +68,7 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
     const [editSummary, setEditSummary] = useState("");
     const [editContent, setEditContent] = useState("");
     const [editKeywords, setEditKeywords] = useState("");
+    const [editVividness, setEditVividness] = useState("rough");
     const [isSaving, setIsSaving] = useState(false);
 
     // Delete confirmation state
@@ -191,6 +193,7 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
         setEditSummary(summary);
         setEditContent(content);
         setEditKeywords(page.keywords?.join(', ') || '');
+        setEditVividness(page.vividness || 'rough');
         setIsEditing(true);
         setShowHistory(false);
     };
@@ -216,6 +219,7 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
                     summary: editSummary,
                     content: editContent,
                     keywords,
+                    vividness: editVividness,
                 }),
             });
 
@@ -348,7 +352,34 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
         return page?.keywords || [];
     };
 
+    // Helper to find selected page and get its vividness
+    const getSelectedPageVividness = (): string => {
+        if (!tree || !selectedPageId) return 'rough';
+        const allPages = [...tree.people, ...tree.terms, ...tree.plans];
+        const findPage = (pages: MemopediaPage[]): MemopediaPage | null => {
+            for (const p of pages) {
+                if (p.id === selectedPageId) return p;
+                const found = findPage(p.children);
+                if (found) return found;
+            }
+            return null;
+        };
+        const page = findPage(allPages);
+        return page?.vividness || 'rough';
+    };
+
     const selectedKeywords = getSelectedPageKeywords();
+    const selectedVividness = getSelectedPageVividness();
+
+    const getVividnessLabel = (vividness: string) => {
+        switch (vividness) {
+            case 'vivid': return '鮮明（全内容）';
+            case 'rough': return '概要';
+            case 'faint': return '淡い（タイトルのみ）';
+            case 'buried': return '埋没（非表示）';
+            default: return vividness;
+        }
+    };
 
     if (!tree) return <div className={styles.emptyState}>Loading knowledge base...</div>;
 
@@ -495,6 +526,22 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
                             />
                         </div>
                         <div className={styles.formGroup}>
+                            <label>鮮明度</label>
+                            <select
+                                value={editVividness}
+                                onChange={e => setEditVividness(e.target.value)}
+                                className={styles.formInput}
+                            >
+                                <option value="vivid">鮮明（全内容）</option>
+                                <option value="rough">概要（デフォルト）</option>
+                                <option value="faint">淡い（タイトルのみ）</option>
+                                <option value="buried">埋没（非表示）</option>
+                            </select>
+                            <small style={{ color: '#888', display: 'block', marginTop: '4px' }}>
+                                コンテキストに含める情報量を制御します
+                            </small>
+                        </div>
+                        <div className={styles.formGroup}>
                             <label>本文</label>
                             <textarea
                                 value={editContent}
@@ -539,6 +586,9 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
                                         </div>
                                     </div>
                                 )}
+                                <div style={{ marginBottom: '1rem', fontSize: '0.9em', color: '#666' }}>
+                                    <strong>鮮明度:</strong> {getVividnessLabel(selectedVividness)}
+                                </div>
                                 <div className={styles.markdown}>
                                     <ReactMarkdown>{pageContent}</ReactMarkdown>
                                 </div>

--- a/sai_memory/memopedia/core.py
+++ b/sai_memory/memopedia/core.py
@@ -83,6 +83,8 @@ class Memopedia:
                 "title": page.title,
                 "summary": page.summary,
                 "keywords": page.keywords,
+                "vividness": page.vividness,
+                "content": page.content,  # Include content for vivid pages
                 "is_open": states.get(page.id, False),
                 "children": [_annotate(c) for c in page.children],
             }
@@ -161,6 +163,7 @@ class Memopedia:
         summary: str = "",
         content: str = "",
         keywords: Optional[List[str]] = None,
+        vividness: str = "rough",
         ref_start_message_id: Optional[str] = None,
         ref_end_message_id: Optional[str] = None,
         edit_source: Optional[str] = None,
@@ -176,6 +179,7 @@ class Memopedia:
             summary: Page summary
             content: Page content
             keywords: List of keywords
+            vividness: Vividness level (vivid/rough/faint/buried), default: rough
             ref_start_message_id: Start of message reference range
             ref_end_message_id: End of message reference range
             edit_source: Source of this edit (e.g., 'ai_conversation', 'manual')
@@ -192,6 +196,7 @@ class Memopedia:
                 content=content,
                 category=parent.category,
                 keywords=keywords,
+                vividness=vividness,
             )
             # Record edit history for create
             full_content = f"title: {title}\nsummary: {summary}\ncontent:\n{content}"
@@ -215,11 +220,12 @@ class Memopedia:
         summary: Optional[str] = None,
         content: Optional[str] = None,
         keywords: Optional[List[str]] = None,
+        vividness: Optional[str] = None,
         ref_start_message_id: Optional[str] = None,
         ref_end_message_id: Optional[str] = None,
         edit_source: Optional[str] = None,
     ) -> Optional[MemopediaPage]:
-        """Update a page's title, summary, content, or keywords."""
+        """Update a page's title, summary, content, keywords, or vividness."""
         with self._lock:
             # Get old page for diff
             old_page = get_page(self.conn, page_id)
@@ -234,6 +240,7 @@ class Memopedia:
                 summary=summary,
                 content=content,
                 keywords=keywords,
+                vividness=vividness,
             )
 
             if result:


### PR DESCRIPTION
Memopediaの各ページにvividness（鮮明度）パラメータを追加し、
コンテキストに含める情報量を制御できるようにしました。

**4つの鮮明度レベル:**
- vivid（鮮明）: ページ名+概要+キーワード+内容全体
- rough（概要、デフォルト）: ページ名+概要+キーワード
- faint（淡い）: ページ名のみ
- buried（埋没）: コンテキストに含めない

**変更内容:**
- sai_memory/memopedia/storage.py: vividnessカラムの追加、マイグレーション、CRUD処理の更新
- sai_memory/memopedia/core.py: create_page/update_pageにvividnessパラメータ追加、get_treeにcontent含める
- tools/defs/get_memory_weave_context.py: vividnessに応じてコンテキスト生成を変更
- ui/memopedia.py: ページ一覧にvividnessカラム追加、vividness変更UIの実装

**動作:**
- 既存のページはデフォルトでrough（概要）に設定される
- UI上で各ページのvividnessを変更可能
- 古い記憶をburiedにしてコンテキスト圧迫を解消
- 重要な情報をvividにして詳細を常に参照可能