### PR TITLE
Fix duplicate summary text in Memopedia editor

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/memory/MemopediaViewer.tsx
+++ b/frontend/src/components/memory/MemopediaViewer.tsx
@@ -169,7 +169,7 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
         if (!page) return;
 
         // Parse the markdown content to extract title, summary, content
-        // The pageContent from API is markdown: "# Title\n*summary*\ncontent"
+        // The pageContent from API is markdown: "# Title\n\n*summary*\n\ncontent"
         const lines = pageContent.split('\n');
         let title = page.title;
         let summary = page.summary;
@@ -177,17 +177,33 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
 
         // Try to extract from markdown
         let contentStartIdx = 0;
+
+        // Extract title
         if (lines[0]?.startsWith('# ')) {
             title = lines[0].substring(2);
             contentStartIdx = 1;
         }
-        if (lines[contentStartIdx]?.startsWith('*') && lines[contentStartIdx]?.endsWith('*')) {
+
+        // Skip empty lines after title
+        while (contentStartIdx < lines.length && lines[contentStartIdx] === '') {
+            contentStartIdx++;
+        }
+
+        // Extract summary
+        if (contentStartIdx < lines.length &&
+            lines[contentStartIdx]?.startsWith('*') &&
+            lines[contentStartIdx]?.endsWith('*')) {
             summary = lines[contentStartIdx].slice(1, -1);
             contentStartIdx++;
         }
-        // Skip empty line after summary
-        if (lines[contentStartIdx] === '') contentStartIdx++;
-        content = lines.slice(contentStartIdx).join('\n');
+
+        // Skip empty lines after summary
+        while (contentStartIdx < lines.length && lines[contentStartIdx] === '') {
+            contentStartIdx++;
+        }
+
+        // Extract content (remaining lines)
+        content = lines.slice(contentStartIdx).join('\n').trim();
 
         setEditTitle(title);
         setEditSummary(summary);

--- a/frontend/src/components/memory/MemopediaViewer.tsx
+++ b/frontend/src/components/memory/MemopediaViewer.tsx
@@ -203,7 +203,8 @@ export default function MemopediaViewer({ personaId }: MemopediaViewerProps) {
         }
 
         // Extract content (remaining lines)
-        content = lines.slice(contentStartIdx).join('\n').trim();
+        // Use trimEnd() to preserve leading whitespace (important for code blocks and indentation)
+        content = lines.slice(contentStartIdx).join('\n').trimEnd();
 
         setEditTitle(title);
         setEditSummary(summary);


### PR DESCRIPTION
修正内容:
- Memopediaの編集フォームで本文テキストボックスに概要が含まれていた問題を修正
- Markdownパース処理を改善し、タイトル、概要、本文の間の空行を正しく処理するように変更
- 概要が本文に重複して表示されないよう、抽出ロジックを修正

変更ファイル:
- frontend/src/components/memory/MemopediaViewer.tsx: startEditing関数のMarkdown解析ロジックを改善