### PR TITLE
Fix parentheses syntax error in setup.bat

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -25,7 +25,7 @@ echo.
 echo [SETUP] Node.js not found. Attempting auto-install...
 where winget >nul 2>nul
 if %errorlevel% neq 0 (
-    echo [ERROR] Could not auto-install Node.js (winget not available).
+    echo [ERROR] Could not auto-install Node.js. winget is not available.
     echo   Please install manually from https://nodejs.org/
     pause
     exit /b 1


### PR DESCRIPTION
## Summary
- setup.bat の if ブロック内の echo に含まれる `(winget not available)` の `)` が if ブロックの閉じ括弧として誤解釈されていた
- 括弧を使わない表現に変更

## Test plan
- [ ] winget がない環境で setup.bat を実行し、エラーメッセージが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)