### PR TITLE
Fix hydration mismatch warning on /usage page

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({
                     })();
                 `}} />
             </head>
-            <body>{children}</body>
+            <body suppressHydrationWarning>{children}</body>
         </html>
     );
 }


### PR DESCRIPTION
## Summary
- ブラウザ拡張機能（ColorZilla等）が `<body>` に属性を注入することで発生するhydration mismatch警告を修正
- `<body>` タグに `suppressHydrationWarning` を追加（`<html>` には既に設定済みだった）

## Test plan
- [ ] `/usage` ページをColorZilla等の拡張機能がインストールされた状態で開き、コンソールにhydration warningが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)