### PR TITLE
Fix seed.py creating database at legacy path

### DIFF
--- a/database/seed.py
+++ b/database/seed.py
@@ -1,8 +1,15 @@
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 from datetime import datetime
+
+# Ensure project root is on sys.path so saiverse package is importable
+# (when run as `python database/seed.py`, sys.path[0] is database/ not project root)
+_project_root = str(Path(__file__).resolve().parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/setup.bat
+++ b/setup.bat
@@ -134,7 +134,8 @@ echo [OK] Frontend packages installed
 
 REM --- 7. Database seed (only if not exists) ---
 set SAIVERSE_DB=%USERPROFILE%\.saiverse\user_data\database\saiverse.db
-if not exist "%SAIVERSE_DB%" (
+set SAIVERSE_DB_LEGACY=database\data\saiverse.db
+if not exist "%SAIVERSE_DB%" if not exist "%SAIVERSE_DB_LEGACY%" (
     echo.
     echo [SETUP] Initializing database...
     python database\seed.py --force


### PR DESCRIPTION
## Summary
- `python database/seed.py` 実行時に `saiverse.data_paths` が import できず、DB が旧パス `database/data/` に作られていた
  - 原因: `sys.path[0]` が `database/` になり、プロジェクトルートが含まれないため
  - 修正: seed.py の先頭でプロジェクトルートを `sys.path` に追加
- setup.bat の DB 存在チェックに旧パスのフォールバックを追加（既に旧パスに DB がある場合の再 seed 防止）

## Impact
- setup.bat を複数回実行すると毎回 DB が再作成されてデータが消えるバグを修正
- 新規セットアップでは DB が正しく `~/.saiverse/user_data/database/` に作られるようになる

## Test plan
- [ ] 新規環境で setup.bat を実行し、DB が `~/.saiverse/user_data/database/saiverse.db` に作られること
- [ ] setup.bat を2回実行しても DB が再作成されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)