### PR TITLE
Show backend/frontend windows visibly on start

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -19,7 +19,7 @@ if exist ".node\node.exe" set "PATH=%CD%\.node;%PATH%"
 
 REM Start Backend
 echo [INFO] Starting backend...
-start "SAIVerse Backend" /min cmd /c "call .venv\Scripts\activate.bat && python main.py city_a"
+start "SAIVerse Backend" cmd /c "title SAIVerse Backend && call .venv\Scripts\activate.bat && python main.py city_a"
 
 REM Wait for backend to initialize
 echo [INFO] Waiting for backend to initialize...
@@ -27,7 +27,7 @@ timeout /t 5 /nobreak >nul
 
 REM Start Frontend
 echo [INFO] Starting frontend...
-start "SAIVerse Frontend" /min cmd /c "cd frontend && npm run dev"
+start "SAIVerse Frontend" cmd /c "title SAIVerse Frontend && cd frontend && npm run dev"
 
 REM Wait for frontend to initialize
 timeout /t 5 /nobreak >nul
@@ -43,8 +43,13 @@ echo ========================================
 echo.
 echo   Web UI: http://localhost:3000
 echo.
+echo   Two additional windows should be open:
+echo     [SAIVerse Backend]  - Python server
+echo     [SAIVerse Frontend] - Next.js dev server
+echo   Do NOT close them while SAIVerse is running.
+echo.
 echo   To stop: close all the command prompt windows.
 echo.
-echo   You can close this window.
+echo   You can close THIS window.
 echo.
 pause


### PR DESCRIPTION
## Summary
- start.bat の `/min` を削除し、バックエンド・フロントエンドのウィンドウを見える状態で起動
- 子プロセス内で `title` コマンドを実行してウィンドウタイトルを確実に設定
- 終了メッセージに「Backend と Frontend の2つのウィンドウを閉じないでください」と明記

## Test plan
- [ ] start.bat 実行後に「SAIVerse Backend」「SAIVerse Frontend」の2ウィンドウが見える状態で開くこと
- [ ] 各ウィンドウのタイトルバーにタイトルが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)