### PR TITLE
Fix setup.bat creating .venv in System32 after winget install

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -88,6 +88,9 @@ echo [OK] Node.js %NODE_VERSION%
 
 :node_done
 
+REM Restore working directory (winget/MSI install can change CWD to System32)
+cd /d "%~dp0"
+
 REM --- 3. Create venv if not exists ---
 if not exist ".venv" (
     echo.


### PR DESCRIPTION
## Summary
- winget による Node.js インストール時、MSI の UAC 昇格でカレントディレクトリが `C:\Windows\System32` にリセットされる問題を修正
- `:node_done` ラベル後に `cd /d "%~dp0"` を追加し、以降の処理（venv作成等）が正しいディレクトリで実行されるようにした

## 再現条件
- Node.js 未インストールの環境で `setup.bat` をダブルクリック実行
- winget が MSI 経由で Node.js をインストール → UAC 昇格が発生
- その後の `python -m venv .venv` が `C:\Windows\System32\.venv` に作成しようとして `WinError 5`（アクセス拒否）

## Test plan
- [ ] Node.js 未インストール環境で setup.bat を実行し、.venv がSAIVerseディレクトリに作成されることを確認
- [ ] Node.js インストール済み環境で setup.bat を実行し、既存動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)