### PR TITLE
Add backend disconnected banner in frontend

### DIFF
--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -40,6 +40,25 @@
     flex-shrink: 0;
 }
 
+.backendErrorBanner {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.6rem 1rem;
+    background: #fee2e2;
+    border-bottom: 1px solid #ef4444;
+    color: #991b1b;
+    font-size: 0.82rem;
+    line-height: 1.4;
+    flex-shrink: 0;
+}
+
+.backendErrorContent {
+    flex: 1;
+    min-width: 0;
+    word-break: break-word;
+}
+
 .startupWarningBanner {
     display: flex;
     align-items: flex-start;
@@ -644,6 +663,12 @@
 :global([data-theme="dark"]) .header {
     background: rgba(10, 10, 10, 0.8);
     border-color: rgba(255, 255, 255, 0.1);
+}
+
+:global([data-theme="dark"]) .backendErrorBanner {
+    background: #450a0a;
+    border-color: #dc2626;
+    color: #fca5a5;
 }
 
 :global([data-theme="dark"]) .startupWarningBanner {


### PR DESCRIPTION
## Summary
- バックエンドが起動していない/停止している場合に、ブラウザ上部に赤いエラーバナーを表示
- 検出: `/api/user/status` と `/api/chat/history` の fetch 失敗（network error + 500）
- 10秒間隔で自動リトライし、復帰したらバナーを自動非表示＋データ再取得
- ダークモード対応

## UI
バックエンド停止時:
```
⚠ Backend server is not running.
  Please make sure the "SAIVerse Backend" window is open.
  This page will reconnect automatically.
```

## Test plan
- [ ] バックエンドを停止した状態でブラウザを開き、赤バナーが表示されること
- [ ] バックエンドを起動すると、10秒以内にバナーが自動で消えること
- [ ] 通常時にはバナーが表示されないこと
- [ ] ダークモードでバナーが正しい色で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)