### PR TITLE
Refresh sidebar buildings on backend reconnect

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1096,6 +1096,7 @@ export default function Home() {
             onTouchMove={handleTouchMove}
         >
             <Sidebar
+                refreshTrigger={backendConnected}
                 onMove={(buildingId?: string) => {
                     if (!buildingId) return;
                     setCurrentBuildingId(buildingId);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -27,9 +27,10 @@ interface SidebarProps {
     isOpen: boolean;
     onOpen: () => void;
     onClose: () => void;
+    refreshTrigger?: boolean;
 }
 
-export default function Sidebar({ onMove, isOpen, onOpen, onClose }: SidebarProps) {
+export default function Sidebar({ onMove, isOpen, onOpen, onClose, refreshTrigger }: SidebarProps) {
     const [status, setStatus] = useState<UserStatus | null>(null);
     const [buildings, setBuildings] = useState<Building[]>([]);
     const [cityId, setCityId] = useState<number | null>(null);
@@ -69,10 +70,10 @@ export default function Sidebar({ onMove, isOpen, onOpen, onClose }: SidebarProp
         }
     };
 
-    // Fetch data only once on mount
+    // Fetch data on mount and when refreshTrigger changes (e.g. backend reconnect)
     useEffect(() => {
         refreshData();
-    }, []);
+    }, [refreshTrigger]);
 
     // Global Touch Handlers for swipe-to-open (separate effect to avoid re-fetching on onOpen change)
     useEffect(() => {


### PR DESCRIPTION
## Summary
- バックエンド復帰時にサイドバーのBuilding一覧とユーザーステータスが再取得されるように修正
- `backendConnected` を `refreshTrigger` prop として Sidebar に渡し、変化時に `refreshData()` を再実行

## Background
PR #105 でバックエンド未接続バナーを追加したが、バックエンド復帰後もサイドバーのBuilding一覧が空のままになる問題が残っていた。

## Test plan
- [ ] バックエンドを停止→起動後、サイドバーのBuilding一覧が自動で復帰すること
- [ ] 通常動作（Building移動等）に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)