### PR TITLE
Fix setup.sh checking wrong path for existing database

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,7 +52,9 @@ echo "[SETUP] フロントエンドパッケージをインストール中..."
 echo "[OK] フロントエンドパッケージのインストール完了"
 
 # --- 7. Database seed (only if not exists) ---
-if [ ! -f "user_data/database/saiverse.db" ]; then
+SAIVERSE_DB="$HOME/.saiverse/user_data/database/saiverse.db"
+SAIVERSE_DB_LEGACY="database/data/saiverse.db"
+if [ ! -f "$SAIVERSE_DB" ] && [ ! -f "$SAIVERSE_DB_LEGACY" ]; then
     echo ""
     echo "[SETUP] データベースを初期化中..."
     python database/seed.py --force


### PR DESCRIPTION
## Summary
- `setup.sh` was checking the legacy in-repo path (`user_data/database/saiverse.db`) instead of the current `~/.saiverse/user_data/database/saiverse.db` location
- On a fresh clone with existing user data in `~/.saiverse/`, this would cause `seed.py --force` to run and **overwrite the database**
- Now checks both `~/.saiverse/user_data/database/saiverse.db` and legacy `database/data/saiverse.db`, matching `setup.bat` behavior

## Test plan
- [ ] Verify `setup.sh` skips DB seed when `~/.saiverse/user_data/database/saiverse.db` exists
- [ ] Verify `setup.sh` runs DB seed when neither path exists (fresh install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)