### PR TITLE
Fix tutorial city name save and error handling

### DIFF
--- a/builtin_data/cities.json
+++ b/builtin_data/cities.json
@@ -3,10 +3,5 @@
     "db_file": "city_A.db",
     "ui_port": 8000,
     "api_port": 8001
-  },
-  "city_b": {
-    "db_file": "city_B.db",
-    "ui_port": 9000,
-    "api_port": 9001
   }
 }

--- a/frontend/src/components/settings/WorldEditor.tsx
+++ b/frontend/src/components/settings/WorldEditor.tsx
@@ -326,7 +326,7 @@ export default function WorldEditor() {
                         </div>
                         <div className={styles.form}>
                             <h3>{selectedCity ? `City を編集` : '新しい City'}</h3>
-                            <Field label="名前"><Input value={formData.name || ''} onChange={(e: any) => setFormData({ ...formData, name: e.target.value })} /></Field>
+                            <Field label="名前（英数字・アンダースコアのみ）"><Input value={formData.name || ''} onChange={(e: any) => setFormData({ ...formData, name: e.target.value.replace(/[^a-zA-Z0-9_]/g, '') })} /></Field>
                             <Field label="説明"><TextArea value={formData.description || ''} onChange={(e: any) => setFormData({ ...formData, description: e.target.value })} /></Field>
                             <div className={styles.row}>
                                 <Field label="UI ポート"><NumInput value={formData.ui_port || ''} onChange={(e: any) => setFormData({ ...formData, ui_port: parseInt(e.target.value) })} /></Field>

--- a/frontend/src/components/tutorial/steps/StepCityName.tsx
+++ b/frontend/src/components/tutorial/steps/StepCityName.tsx
@@ -21,12 +21,12 @@ export default function StepCityName({ value, onChange }: StepCityNameProps) {
                 <input
                     type="text"
                     value={value}
-                    onChange={(e) => onChange(e.target.value)}
-                    placeholder="例: マイシティ"
+                    onChange={(e) => onChange(e.target.value.replace(/[^a-zA-Z0-9_]/g, ''))}
+                    placeholder="例: my_city"
                     autoFocus
                 />
                 <p className={styles.fieldHint}>
-                    スキップした場合は「city_a」になります
+                    英数字とアンダースコアのみ使用できます。スキップした場合は「city_a」になります
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- **City名保存の修正**: チュートリアルの `saveCityName()` が PUT に必須フィールドを送っておらず、422エラーで静かに失敗していた。現在の City データから全フィールドを含めて送るように修正
- **City名のASCIIバリデーション**: City名がペルソナIDやファイルパスに使われるため、英数字+アンダースコアのみに制限。フロントエンド（入力フィルタ）とバックエンド（`_validate_city_name()`）の二重ガード
- **city_b の削除**: `cities.json` から city_b を削除（`seed_data.json` からは既に削除済みだったが、`cities.json` に残っていたため seed 時に空の city_b が作成されていた）
- **City削除保護の改善**: ハードコードされた `city_a`/`city_b` 名前チェックを、「最後の1つは削除不可」のカウントベースチェックに変更
- **チュートリアル全save関数のエラーハンドリング修正**: 内部 try/catch でのエラー握り潰し、レスポンス未チェックを修正。失敗時にユーザーにエラーメッセージを表示するように

## Test plan
- [ ] チュートリアルでCity名を変更し、ペルソナ作成ステップで反映されることを確認
- [ ] City名に日本語を入力しても弾かれることを確認（フロントエンド）
- [ ] WorldEditor でも City名に非ASCII文字が入力できないことを確認
- [ ] 新規 seed 実行時に city_b が作成されないことを確認
- [ ] City が1つしかない状態で削除しようとするとエラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)