### PR TITLE
Fix tutorial not showing on first launch

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -194,28 +194,6 @@ export default function Home() {
         return () => window.removeEventListener('resize', checkMobile);
     }, []);
 
-    // Check tutorial status on mount
-    useEffect(() => {
-        const checkTutorial = async () => {
-            try {
-                const res = await fetch('/api/tutorial/status');
-                if (res.ok) {
-                    const data = await res.json();
-                    // Show tutorial if not completed or if initial setup is needed
-                    if (!data.tutorial_completed || data.needs_initial_setup) {
-                        setShowTutorial(true);
-                    }
-                }
-            } catch (e) {
-                console.error('Failed to check tutorial status', e);
-            } finally {
-                setTutorialChecked(true);
-            }
-        };
-
-        checkTutorial();
-    }, []);
-
     // Auto-resize textarea based on content (max 10 lines)
     const adjustTextareaHeight = useCallback(() => {
         const textarea = textareaRef.current;
@@ -263,6 +241,31 @@ export default function Home() {
 
     // Backend connection status
     const [backendConnected, setBackendConnected] = useState(true);
+
+    // Check tutorial status on mount and when backend reconnects
+    useEffect(() => {
+        // Skip if tutorial is already showing
+        if (showTutorial) return;
+
+        const checkTutorial = async () => {
+            try {
+                const res = await fetch('/api/tutorial/status');
+                if (res.ok) {
+                    const data = await res.json();
+                    // Show tutorial if not completed or if initial setup is needed
+                    if (!data.tutorial_completed || data.needs_initial_setup) {
+                        setShowTutorial(true);
+                    }
+                }
+            } catch (e) {
+                console.error('Failed to check tutorial status', e);
+            } finally {
+                setTutorialChecked(true);
+            }
+        };
+
+        checkTutorial();
+    }, [backendConnected]);
 
     // Startup warnings
     const [startupWarnings, setStartupWarnings] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- 初回起動時、フロントエンドが先に立ち上がりバックエンドが後から起動するため、チュートリアルチェックが失敗して表示されない問題を修正
- チュートリアルチェックの依存配列に `backendConnected` を追加し、バックエンド再接続時に再チェックするように変更
- 既にチュートリアル表示中の場合は再チェックをスキップ

## Test plan
- [ ] バックエンドを停止した状態でフロントエンドを開き、後からバックエンドを起動 → チュートリアルが自動表示されることを確認
- [ ] 通常起動（バックエンド起動済み）でもチュートリアルが正常に表示されることを確認
- [ ] チュートリアル完了済みの場合、再接続時にチュートリアルが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)