### PR TITLE
Fix tutorial overwriting city internal ID, show display names

### DIFF
--- a/frontend/src/components/BuildingSettingsModal.tsx
+++ b/frontend/src/components/BuildingSettingsModal.tsx
@@ -12,6 +12,7 @@ interface Tool {
 interface City {
     CITYID: number;
     CITYNAME: string;
+    DESCRIPTION?: string;
 }
 
 interface BuildingSettingsModalProps {
@@ -216,7 +217,7 @@ export default function BuildingSettingsModal({ isOpen, onClose, buildingId, onS
                             <label>都市</label>
                             <select value={cityId} onChange={e => setCityId(parseInt(e.target.value))}>
                                 {cities.map(c => (
-                                    <option key={c.CITYID} value={c.CITYID}>{c.CITYNAME}</option>
+                                    <option key={c.CITYID} value={c.CITYID}>{c.DESCRIPTION || c.CITYNAME}</option>
                                 ))}
                             </select>
                         </div>

--- a/frontend/src/components/PersonaWizard.tsx
+++ b/frontend/src/components/PersonaWizard.tsx
@@ -17,6 +17,7 @@ interface PersonaWizardProps {
 interface City {
     CITYID: number;
     CITYNAME: string;
+    DESCRIPTION?: string;
 }
 
 type Step = 1 | 2 | 3;
@@ -210,7 +211,7 @@ export default function PersonaWizard({ isOpen, onClose, onComplete, embedded }:
                         onChange={(e) => handleCityChange(parseInt(e.target.value))}
                     >
                         {cities.map(c => (
-                            <option key={c.CITYID} value={c.CITYID}>{c.CITYNAME}</option>
+                            <option key={c.CITYID} value={c.CITYID}>{c.DESCRIPTION || c.CITYNAME}</option>
                         ))}
                     </select>
                 </div>

--- a/frontend/src/components/settings/WorldEditor.tsx
+++ b/frontend/src/components/settings/WorldEditor.tsx
@@ -321,7 +321,7 @@ export default function WorldEditor() {
                     <div className={styles.pane}>
                         <div className={styles.list}>
                             <h3>City 一覧</h3>
-                            {cities.map(c => <div key={c.CITYID} className={`${styles.item} ${selectedCity?.CITYID === c.CITYID ? styles.selected : ''}`} onClick={() => handleCitySelect(c)}>{c.CITYNAME}</div>)}
+                            {cities.map(c => <div key={c.CITYID} className={`${styles.item} ${selectedCity?.CITYID === c.CITYID ? styles.selected : ''}`} onClick={() => handleCitySelect(c)}>{c.DESCRIPTION || c.CITYNAME}</div>)}
                             <button className={styles.newBtn} onClick={() => { setSelectedCity(null); setFormData({}); }}>+ 新規作成</button>
                         </div>
                         <div className={styles.form}>
@@ -354,7 +354,7 @@ export default function WorldEditor() {
                                 : <Field label="ID（任意）"><Input value={formData.building_id || ''} placeholder="空欄で自動生成" onChange={(e: any) => setFormData({ ...formData, building_id: e.target.value })} /></Field>
                             }
                             <Field label="都市"><Select value={formData.city_id || ''} onChange={(e: any) => setFormData({ ...formData, city_id: parseInt(e.target.value) })}>
-                                <option value="">City を選択...</option>{cities.map(c => <option key={c.CITYID} value={c.CITYID}>{c.CITYNAME}</option>)}
+                                <option value="">City を選択...</option>{cities.map(c => <option key={c.CITYID} value={c.CITYID}>{c.DESCRIPTION || c.CITYNAME}</option>)}
                             </Select></Field>
                             <div className={styles.row}>
                                 <Field label="定員"><NumInput value={formData.capacity || 1} onChange={(e: any) => setFormData({ ...formData, capacity: parseInt(e.target.value) })} /></Field>
@@ -425,7 +425,7 @@ export default function WorldEditor() {
                             <h3>{selectedAI ? `ペルソナを編集` : '新しいペルソナ'}</h3>
                             <Field label="名前"><Input value={formData.name || ''} onChange={(e: any) => setFormData({ ...formData, name: e.target.value })} /></Field>
                             <Field label="ホーム都市"><Select value={formData.home_city_id || ''} onChange={(e: any) => setFormData({ ...formData, home_city_id: parseInt(e.target.value) })}>
-                                <option value="">City を選択...</option>{cities.map(c => <option key={c.CITYID} value={c.CITYID}>{c.CITYNAME}</option>)}
+                                <option value="">City を選択...</option>{cities.map(c => <option key={c.CITYID} value={c.CITYID}>{c.DESCRIPTION || c.CITYNAME}</option>)}
                             </Select></Field>
                             {selectedAI && <>
                                 <Field label="デフォルトモデル"><Select value={formData.default_model || ''} onChange={(e: any) => setFormData({ ...formData, default_model: e.target.value })}>
@@ -488,7 +488,7 @@ export default function WorldEditor() {
                             <Field label="名前"><Input value={formData.name || ''} onChange={(e: any) => setFormData({ ...formData, name: e.target.value })} /></Field>
                             <Field label="タイプ"><Input value={formData.entity_type || 'ai'} onChange={(e: any) => setFormData({ ...formData, entity_type: e.target.value })} /></Field>
                             <Field label="都市"><Select value={formData.city_id || ''} onChange={(e: any) => setFormData({ ...formData, city_id: parseInt(e.target.value) })}>
-                                <option value="">City を選択...</option>{cities.map(c => <option key={c.CITYID} value={c.CITYID}>{c.CITYNAME}</option>)}
+                                <option value="">City を選択...</option>{cities.map(c => <option key={c.CITYID} value={c.CITYID}>{c.DESCRIPTION || c.CITYNAME}</option>)}
                             </Select></Field>
                             <Field label="システムプロンプト"><TextArea style={{ minHeight: 200 }} value={formData.system_prompt || ''} onChange={(e: any) => setFormData({ ...formData, system_prompt: e.target.value })} /></Field>
                             <Field label="説明"><TextArea value={formData.description || ''} onChange={(e: any) => setFormData({ ...formData, description: e.target.value })} /></Field>

--- a/frontend/src/components/tutorial/TutorialWizard.tsx
+++ b/frontend/src/components/tutorial/TutorialWizard.tsx
@@ -159,8 +159,9 @@ export default function TutorialWizard({
             }
             if (citiesRes.ok) {
                 const cities = await citiesRes.json();
-                if (cities.length > 0 && cities[0].CITYNAME) {
-                    updates.cityName = cities[0].CITYNAME;
+                if (cities.length > 0) {
+                    // Use DESCRIPTION (display name) if available, else CITYNAME
+                    updates.cityName = cities[0].DESCRIPTION || cities[0].CITYNAME || '';
                 }
             }
             if (Object.keys(updates).length > 0) {
@@ -284,13 +285,14 @@ export default function TutorialWizard({
         }
 
         const city = cities[0];
-        // PUT requires all fields, so send current values with updated name
+        // PUT requires all fields. Keep CITYNAME (internal ID) unchanged,
+        // save user-entered display name to DESCRIPTION.
         const updateRes = await fetch(`/api/world/cities/${city.CITYID}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                name,
-                description: city.DESCRIPTION || '',
+                name: city.CITYNAME,
+                description: name,
                 online_mode: city.START_IN_ONLINE_MODE ?? false,
                 ui_port: city.UI_PORT ?? 8000,
                 api_port: city.API_PORT ?? 8001,


### PR DESCRIPTION
## Summary
- チュートリアルの都市名保存が CITYNAME（内部識別子）を上書きしていたバグを修正。日本語名等を入力すると `main.py city_a` の起動時ルックアップが失敗してバックエンドが起動不能になっていた
- ユーザー入力は DESCRIPTION（表示名）に保存し、CITYNAME は変更しないように修正
- 全 City 選択ドロップダウン・一覧で `DESCRIPTION || CITYNAME` を表示するように統一

## Affected files
- `TutorialWizard.tsx` — saveCityName() の保存先を name→description に変更、初期値ロードも DESCRIPTION 優先に
- `BuildingSettingsModal.tsx` — City 選択で DESCRIPTION 表示
- `PersonaWizard.tsx` — City 選択で DESCRIPTION 表示
- `WorldEditor.tsx` — City 一覧 + 3箇所のドロップダウンで DESCRIPTION 表示

## DB recovery (affected users)
既にこのバグでCITYNAMEが壊れている場合、以下のSQLで復旧できます:
```sql
UPDATE city SET CITYNAME = 'city_a' WHERE CITYID = 1;
```

## Test plan
- [ ] チュートリアルで日本語の都市名を入力→保存後、バックエンド再起動が正常に行えることを確認
- [ ] チュートリアル再表示時に DESCRIPTION（表示名）が初期値として表示されることを確認
- [ ] ペルソナ作成ウィザードで City ドロップダウンに表示名が出ることを確認
- [ ] WorldEditor の City 一覧・Building/AI/Blueprint の City 選択で表示名が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)