### PR TITLE
Auto-advance tutorial after persona creation

### DIFF
--- a/frontend/src/components/tutorial/TutorialWizard.tsx
+++ b/frontend/src/components/tutorial/TutorialWizard.tsx
@@ -405,7 +405,10 @@ export default function TutorialWizard({
                     <StepPersonaChoice
                         choice={state.personaChoice}
                         onChange={(v) => updateState({ personaChoice: v })}
-                        onPersonaCreated={(id, roomId) => updateState({ createdPersonaId: id, createdRoomId: roomId })}
+                        onPersonaCreated={(id, roomId) => {
+                            updateState({ createdPersonaId: id, createdRoomId: roomId });
+                            setStep(5);
+                        }}
                     />
                 );
             case 5:


### PR DESCRIPTION
## Summary
- ペルソナ作成完了後、ステップ4（ペルソナ選択画面）に戻る代わりにステップ5（APIキー設定）へ自動遷移するように変更
- 「セットアップに戻る」ボタンを押す手間がなくなり、フローが直感的に

## Test plan
- [ ] チュートリアルでペルソナ作成完了後、自動的にAPIキー設定ステップに進むことを確認
- [ ] 戻るボタンでステップ4に戻れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)