### PR TITLE
Add auto-release workflow for ZIP distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create ZIP archive
+        run: git archive --format=zip --prefix=SAIVerse/ -o SAIVerse.zip HEAD
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            SAIVerse.zip \
+            --title "SAIVerse ${{ github.ref_name }}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -130,10 +130,16 @@ SAIVerseは、AIと人が共に生きる世界を目指すプロジェクトで�
 git clone https://github.com/maha0525/SAIVerse.git
 ```
 **Git非導入の場合：**<br>
-このGithubページからzipをダウンロード・任意の場所に解凍してください
+[**最新版をダウンロード（ZIP）**](https://github.com/maha0525/SAIVerse/releases/latest/download/SAIVerse.zip)して任意の場所に解凍してください
+
+<details>
+<summary>上記リンクが使えない場合</summary>
+
+このGithubページのCodeボタンからもダウンロードできます（ただしリリース版ではなく開発中の最新版になります）
 <p align="center">
   <img src="assets/image/guide/quickstart_download_zip.png" alt="Codeボタンをクリック、出てきたDownload ZIPをクリックしてダウンロード" width="400">
 </p>
+</details>
 
 #### インストール
 
@@ -187,10 +193,17 @@ chmod +x setup.sh start.sh
 ```
 
 **Git非導入の場合：**<br>
-このGithubページからzipをダウンロード・任意の場所に解凍してください
+[**最新版をダウンロード（ZIP）**](https://github.com/maha0525/SAIVerse/releases/latest/download/SAIVerse.zip)して任意の場所に解凍してください
+
+<details>
+<summary>上記リンクが使えない場合</summary>
+
+このGithubページのCodeボタンからもダウンロードできます（ただしリリース版ではなく開発中の最新版になります）
 <p align="center">
   <img src="assets/image/guide/quickstart_download_zip.png" alt="Codeボタンをクリック、出てきたDownload ZIPをクリックしてダウンロード" width="400">
 </p>
+</details>
+
 初回起動時にチュートリアルが表示され、ユーザー名やAPIキーの設定を案内します。
 
 `SAIVerse` フォルダ内の **`setup.sh`** をダブルクリック


### PR DESCRIPTION
## Summary
- タグpush (`v*`) 時にGitHub Actionsで自動的にリリースを作成し、`SAIVerse.zip` アセットを添付するワークフローを追加
- READMEのダウンロード案内を、リリースZIPの直リンク (`releases/latest/download/SAIVerse.zip`) に更新。従来のCode→Download ZIP案内は折りたたみ内にフォールバックとして残存

## Test plan
- [ ] マージ後にタグを作成してpush (`git tag v0.1.12 && git push --tags`)
- [ ] GitHub Actionsでワークフローが正常に実行されることを確認
- [ ] リリースページに `SAIVerse.zip` アセットが添付されていることを確認
- [ ] READMEの直リンクからZIPがダウンロードできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)