### PR TITLE
Add community links, About tab, and funding info

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: maha0525
+custom:
+  - https://note.com/maha0525

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
   <img src="assets/image/SAIVerse_logo.jpg" alt="SAIVerse仮ロゴ" width="400">
 </p>
 
+<p align="center">
+  <a href="https://discord.gg/sqDKjtZV"><img src="https://img.shields.io/badge/Discord-%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/maha0525/SAIVerse/releases/latest"><img src="https://img.shields.io/github/v/release/maha0525/SAIVerse?label=%E6%9C%80%E6%96%B0%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3" alt="Latest Release"></a>
+  <a href="https://github.com/maha0525/SAIVerse/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License"></a>
+</p>
+
 **あなたのAIパートナーと自由に話そう！**
 
 SAIVerseは、AIと人が共に生きる世界を目指すプロジェクトです。<br>
@@ -342,6 +348,17 @@ python test_fixtures/test_api.py --quick   # クイックテスト（LLM除く�
 - 各種ツールの改良。
 - Playbookを視覚的に閲覧・作成できるインターフェースの作成。
 - ツールをたくさん増やす。Webカメラとの連携、Switchbot連携、X API連携など。
+
+## コミュニティ・サポート
+
+- [Discord コミュニティ](https://discord.gg/sqDKjtZV) - 質問・雑談・バグ報告などお気軽にどうぞ
+- [GitHub Issues](https://github.com/maha0525/SAIVerse/issues) - バグ報告・機能リクエスト
+
+### 支援について
+SAIVerseはフリーソフトウェアとして開発を続けています。応援していただける方は以下からサポートをお願いします。
+
+- **GitHub Sponsors**: 準備中です
+- **Note**: [開発記録ページ](https://note.com/maha0525/n/n5a63f572be8f)からチップ（サポート）を送ることができます
 
 ## コントリビューション
 現在プレリリース中のため、受け付ける余裕がありません……もうしばらくお待ちください。

--- a/frontend/src/components/GlobalSettingsModal.module.css
+++ b/frontend/src/components/GlobalSettingsModal.module.css
@@ -907,3 +907,217 @@
         min-width: 0;
     }
 }
+
+/* ── About Tab ── */
+.aboutContainer {
+    max-width: 600px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.aboutCard {
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.aboutVersion {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #60a5fa;
+    font-family: monospace;
+}
+
+.aboutUpdateNotice {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: #fbbf24;
+}
+
+.aboutCardTitle {
+    font-weight: 600;
+    color: #94a3b8;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+}
+
+.aboutDeveloper {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: #f1f5f9;
+    font-weight: 500;
+}
+
+.aboutLink {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: #60a5fa;
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.aboutLink:hover {
+    color: #93c5fd;
+    text-decoration: underline;
+}
+
+.aboutLinks {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.aboutLinkItem {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 6px;
+    color: #f1f5f9;
+    text-decoration: none;
+    transition: background 0.15s;
+}
+
+.aboutLinkItem:hover {
+    background: #1e293b;
+}
+
+.aboutLinkIcon {
+    font-size: 1.25rem;
+    width: 2rem;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.aboutLinkName {
+    font-weight: 500;
+    font-size: 0.9rem;
+}
+
+.aboutLinkDesc {
+    font-size: 0.8rem;
+    color: #94a3b8;
+}
+
+.aboutLinkArrow {
+    margin-left: auto;
+    color: #475569;
+    flex-shrink: 0;
+}
+
+.aboutSupportText {
+    color: #cbd5e1;
+    font-size: 0.9rem;
+    margin-bottom: 0.75rem;
+}
+
+.aboutSupportItems {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.aboutSupportItem {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    color: #cbd5e1;
+    font-size: 0.9rem;
+    text-decoration: none;
+    transition: background 0.15s;
+}
+
+.aboutSupportItem:hover {
+    background: #1e293b;
+}
+
+.aboutSupportBadge {
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: #475569;
+    color: #94a3b8;
+    flex-shrink: 0;
+}
+
+.aboutSupportBadge.active {
+    background: #166534;
+    color: #86efac;
+}
+
+/* ── Light Mode: About ── */
+:global([data-theme="light"]) .aboutCard {
+    background: #f8fafc;
+    border-color: #e2e8f0;
+}
+
+:global([data-theme="light"]) .aboutVersion {
+    color: #2563eb;
+}
+
+:global([data-theme="light"]) .aboutUpdateNotice {
+    color: #d97706;
+}
+
+:global([data-theme="light"]) .aboutCardTitle {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .aboutDeveloper {
+    color: #1f2937;
+}
+
+:global([data-theme="light"]) .aboutLink {
+    color: #2563eb;
+}
+
+:global([data-theme="light"]) .aboutLink:hover {
+    color: #1d4ed8;
+}
+
+:global([data-theme="light"]) .aboutLinkItem {
+    color: #1f2937;
+}
+
+:global([data-theme="light"]) .aboutLinkItem:hover {
+    background: #f1f5f9;
+}
+
+:global([data-theme="light"]) .aboutLinkDesc {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .aboutLinkArrow {
+    color: #cbd5e1;
+}
+
+:global([data-theme="light"]) .aboutSupportText {
+    color: #475569;
+}
+
+:global([data-theme="light"]) .aboutSupportItem {
+    color: #475569;
+}
+
+:global([data-theme="light"]) .aboutSupportItem:hover {
+    background: #f1f5f9;
+}
+
+:global([data-theme="light"]) .aboutSupportBadge {
+    background: #e2e8f0;
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .aboutSupportBadge.active {
+    background: #dcfce7;
+    color: #166534;
+}

--- a/frontend/src/components/GlobalSettingsModal.tsx
+++ b/frontend/src/components/GlobalSettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { X, Settings, Database, Globe, Layers, Save, RefreshCw, Power, Play, Pause, Monitor, Sun, Moon, Cpu, ChevronDown } from 'lucide-react';
+import { X, Settings, Database, Globe, Layers, Save, RefreshCw, Power, Play, Pause, Monitor, Sun, Moon, Cpu, ChevronDown, Info, ExternalLink } from 'lucide-react';
 import styles from './GlobalSettingsModal.module.css';
 import WorldEditor from './settings/WorldEditor';
 import ModalOverlay from './common/ModalOverlay';
@@ -42,7 +42,7 @@ interface ModelInfo {
     is_available: boolean;
 }
 
-type TabId = 'env' | 'world' | 'db' | 'models';
+type TabId = 'env' | 'world' | 'db' | 'models' | 'about';
 
 export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProps) {
     const [activeTab, setActiveTab] = useState<TabId>('env');
@@ -66,6 +66,9 @@ export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsM
     // Theme
     const [theme, setTheme] = useState<'system' | 'light' | 'dark'>('system');
 
+    // About
+    const [versionInfo, setVersionInfo] = useState<{ version: string; latest_version?: string; update_available?: boolean } | null>(null);
+
     // Model Roles
     const [modelRoles, setModelRoles] = useState<Record<string, ModelRoleInfo>>({});
     const [modelPresets, setModelPresets] = useState<PresetInfo[]>([]);
@@ -87,6 +90,9 @@ export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsM
         }
         if (isOpen && activeTab === 'models') {
             loadModelRoles();
+        }
+        if (isOpen && activeTab === 'about') {
+            loadVersionInfo();
         }
     }, [isOpen, activeTab]);
 
@@ -239,6 +245,18 @@ export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsM
         }
     };
 
+    // --- About ---
+    const loadVersionInfo = async () => {
+        try {
+            const res = await fetch('/api/version');
+            if (res.ok) {
+                setVersionInfo(await res.json());
+            }
+        } catch (e) {
+            console.error('Failed to load version info', e);
+        }
+    };
+
     // --- Model Roles ---
     const loadModelRoles = async () => {
         setModelRolesLoading(true);
@@ -335,6 +353,12 @@ export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsM
                             onClick={() => setActiveTab('models')}
                         >
                             <Cpu size={18} /> モデルロール
+                        </div>
+                        <div
+                            className={`${styles.navItem} ${activeTab === 'about' ? styles.active : ''}`}
+                            onClick={() => setActiveTab('about')}
+                        >
+                            <Info size={18} /> 情報
                         </div>
                     </div>
 
@@ -582,6 +606,89 @@ export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsM
                                         </div>
                                     </>
                                 )}
+                            </div>
+                        )}
+
+                        {activeTab === 'about' && (
+                            <div className={styles.aboutContainer}>
+                                <div className={styles.sectionHeader}>
+                                    <h3>SAIVerseについて</h3>
+                                </div>
+
+                                {/* Version */}
+                                {versionInfo && (
+                                    <div className={styles.aboutCard}>
+                                        <div className={styles.aboutVersion}>
+                                            v{versionInfo.version}
+                                        </div>
+                                        {versionInfo.update_available && (
+                                            <div className={styles.aboutUpdateNotice}>
+                                                新しいバージョン v{versionInfo.latest_version} が利用可能です
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Developer */}
+                                <div className={styles.aboutCard}>
+                                    <div className={styles.aboutCardTitle}>開発者</div>
+                                    <div className={styles.aboutDeveloper}>
+                                        <span>まはー</span>
+                                        <a href="https://x.com/Lize_san_suki" target="_blank" rel="noopener noreferrer" className={styles.aboutLink}>
+                                            <ExternalLink size={14} /> @Lize_san_suki
+                                        </a>
+                                    </div>
+                                </div>
+
+                                {/* Links */}
+                                <div className={styles.aboutCard}>
+                                    <div className={styles.aboutCardTitle}>リンク</div>
+                                    <div className={styles.aboutLinks}>
+                                        <a href="https://discord.gg/sqDKjtZV" target="_blank" rel="noopener noreferrer" className={styles.aboutLinkItem}>
+                                            <span className={styles.aboutLinkIcon}>💬</span>
+                                            <div>
+                                                <div className={styles.aboutLinkName}>Discord コミュニティ</div>
+                                                <div className={styles.aboutLinkDesc}>質問・雑談・バグ報告など</div>
+                                            </div>
+                                            <ExternalLink size={14} className={styles.aboutLinkArrow} />
+                                        </a>
+                                        <a href="https://github.com/maha0525/SAIVerse" target="_blank" rel="noopener noreferrer" className={styles.aboutLinkItem}>
+                                            <span className={styles.aboutLinkIcon}>📦</span>
+                                            <div>
+                                                <div className={styles.aboutLinkName}>GitHub</div>
+                                                <div className={styles.aboutLinkDesc}>ソースコード・Issues</div>
+                                            </div>
+                                            <ExternalLink size={14} className={styles.aboutLinkArrow} />
+                                        </a>
+                                        <a href="https://note.com/maha0525/n/n5a63f572be8f" target="_blank" rel="noopener noreferrer" className={styles.aboutLinkItem}>
+                                            <span className={styles.aboutLinkIcon}>📝</span>
+                                            <div>
+                                                <div className={styles.aboutLinkName}>Note</div>
+                                                <div className={styles.aboutLinkDesc}>開発記録・サポート（チップ）</div>
+                                            </div>
+                                            <ExternalLink size={14} className={styles.aboutLinkArrow} />
+                                        </a>
+                                    </div>
+                                </div>
+
+                                {/* Support */}
+                                <div className={styles.aboutCard}>
+                                    <div className={styles.aboutCardTitle}>支援について</div>
+                                    <div className={styles.aboutSupportText}>
+                                        SAIVerseはフリーソフトウェアとして開発を続けています。
+                                    </div>
+                                    <div className={styles.aboutSupportItems}>
+                                        <div className={styles.aboutSupportItem}>
+                                            <span className={styles.aboutSupportBadge}>準備中</span>
+                                            GitHub Sponsors
+                                        </div>
+                                        <a href="https://note.com/maha0525/n/n5a63f572be8f" target="_blank" rel="noopener noreferrer" className={styles.aboutSupportItem} style={{ cursor: 'pointer' }}>
+                                            <span className={`${styles.aboutSupportBadge} ${styles.active}`}>受付中</span>
+                                            Noteからチップを送る
+                                            <ExternalLink size={14} className={styles.aboutLinkArrow} />
+                                        </a>
+                                    </div>
+                                </div>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary
- README上部にDiscord / 最新バージョン / ライセンスのバッジを追加
- READMEに「コミュニティ・サポート」セクションを追加（Discord、GitHub Sponsors準備中、Noteチップ）
- `.github/FUNDING.yml` を作成し、リポジトリにSponsorボタンを表示
- グローバル設定に「情報」タブを追加（バージョン表示、開発者クレジット、Discord/GitHub/Noteリンク、支援情報）

## Test plan
- [ ] READMEのバッジが正しく表示されることを確認
- [ ] GitHubリポジトリページにSponsorボタンが表示されることを確認
- [ ] グローバル設定 → 情報タブの表示確認（ダークモード・ライトモード両方）
- [ ] 各外部リンクが正しいURLで新しいタブに開くことを確認
- [ ] バージョン情報がAPIから正しく取得・表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)