### PR TITLE
Fix dev_only playbooks accessible without developer mode

### DIFF
--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -178,6 +178,7 @@ def get_playbook_params(name: str, manager=Depends(get_manager)):
             city_id=getattr(manager, 'city_id', None),
             building_id=getattr(manager.state, 'current_building_id', None) if hasattr(manager, 'state') else None,
             persona_id=getattr(manager.state, 'current_persona_id', None) if hasattr(manager, 'state') else None,
+            developer_mode=getattr(manager.state, 'developer_mode', False) if hasattr(manager, 'state') else False,
         )
 
         # Filter to user_configurable and resolve enum_source

--- a/api/utils/enum_resolver.py
+++ b/api/utils/enum_resolver.py
@@ -22,10 +22,12 @@ class EnumResolverContext:
         city_id: Optional[int] = None,
         building_id: Optional[str] = None,
         persona_id: Optional[str] = None,
+        developer_mode: bool = False,
     ):
         self.city_id = city_id
         self.building_id = building_id
         self.persona_id = persona_id
+        self.developer_mode = developer_mode
 
 
 def resolve_enum_source(
@@ -81,6 +83,10 @@ def _resolve_playbooks(scope: str, context: EnumResolverContext) -> List[Dict[st
             pass  # No filter
         else:
             raise ValueError(f"Unknown playbooks scope: {scope}")
+
+        # Filter out dev_only playbooks when developer mode is off
+        if not context.developer_mode:
+            query = query.filter(Playbook.dev_only == False)
 
         playbooks = query.all()
         return [

--- a/builtin_data/tools/list_available_playbooks.py
+++ b/builtin_data/tools/list_available_playbooks.py
@@ -40,9 +40,17 @@ def list_available_playbooks(persona_id: Optional[str] = None, building_id: Opti
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
 
+    # Check developer mode
+    developer_mode = False
+    manager = get_active_manager()
+    if manager and hasattr(manager, "state"):
+        developer_mode = getattr(manager.state, "developer_mode", False)
+
     with Session() as session:
         # Get all router_callable playbooks
         query = session.query(Playbook).filter(Playbook.router_callable == True)
+        if not developer_mode:
+            query = query.filter(Playbook.dev_only == False)
         all_playbooks = query.all()
 
         available = []


### PR DESCRIPTION
## Summary
- `agentic_chat`（`dev_only: true`）が開発者モードOFFでもLLMルーターの選択肢やUIドロップダウンに表示されていた問題を修正
- `list_available_playbooks` ツール、`enum_resolver`、API呼び出し側の3箇所に `dev_only` フィルタを追加
- runtime側の既存チェック（`_load_playbook_from_db`）と合わせて多層防御に

## Test plan
- [ ] 開発者モードOFFで `meta_user` / `meta_agentic` 使用時、ルーターが `agentic_chat` を選択肢に含めないことを確認
- [ ] 開発者モードOFFで `meta_user_manual` のドロップダウンに `agentic_chat` が表示されないことを確認
- [ ] 開発者モードONでは `agentic_chat` が正常に表示・実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)