### PR TITLE
Fix seed.py missing playbook flags and add startup auto-sync

### DIFF
--- a/database/seed.py
+++ b/database/seed.py
@@ -52,7 +52,10 @@ def import_initial_playbooks() -> None:
                     continue
 
                 description = data.get("description", "")
+                display_name = data.get("display_name")
                 router_callable = data.get("router_callable", False)
+                user_selectable = data.get("user_selectable", False)
+                dev_only = data.get("dev_only", False)
                 schema_payload = {
                     "name": name,
                     "description": description,
@@ -65,12 +68,15 @@ def import_initial_playbooks() -> None:
                 record = Playbook(
                     name=name,
                     description=description,
+                    display_name=display_name,
                     scope="public",
                     created_by_persona_id=None,
                     building_id=None,
                     schema_json=schema_json,
                     nodes_json=nodes_json,
                     router_callable=router_callable,
+                    user_selectable=user_selectable,
+                    dev_only=dev_only,
                 )
                 session.add(record)
                 imported_count += 1


### PR DESCRIPTION
## Summary
- **Root cause**: `seed.py:import_initial_playbooks()` was not reading `user_selectable`, `dev_only`, `display_name` from playbook JSON files — all playbooks got `user_selectable=False`, making the dropdown empty for new users
- Fix `seed.py` to read and set all flag fields (matching `import_all_playbooks.py`)
- Add `_sync_builtin_playbook_flags()` at startup in `main.py` that auto-repairs flag mismatches for existing users (compares DB against builtin JSON, updates flags only)

## Test plan
- [ ] Fresh install: `seed.py --force` → verify `user_selectable=True` on 4 meta playbooks
- [ ] Existing install with broken flags: restart server → verify flags auto-repaired (check log for "Synced N builtin playbook flag(s)")
- [ ] ChatOptions playbook dropdown shows selectable playbooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)