### PR TITLE
Fix chatgpt-4o-latest structured output errors

### DIFF
--- a/api/routes/tutorial.py
+++ b/api/routes/tutorial.py
@@ -42,6 +42,7 @@ class ModelAvailability(BaseModel):
     display_name: str
     provider: str
     is_available: bool
+    supports_structured_output: bool = True
 
 
 class AvailableModelsResponse(BaseModel):
@@ -237,7 +238,8 @@ def get_available_models():
     from saiverse.model_configs import (
         get_model_choices_with_display_names,
         get_model_config,
-        get_model_provider
+        get_model_provider,
+        supports_structured_output,
     )
 
     models = []
@@ -254,7 +256,8 @@ def get_available_models():
             id=model_id,
             display_name=display_name,
             provider=provider,
-            is_available=is_available
+            is_available=is_available,
+            supports_structured_output=supports_structured_output(model_id),
         ))
 
     return AvailableModelsResponse(models=models)

--- a/builtin_data/models/chatgpt-4o-latest.json
+++ b/builtin_data/models/chatgpt-4o-latest.json
@@ -7,6 +7,7 @@
   "default_max_history_messages": 40,
   "metabolism_keep_messages": 20,
   "supports_images": true,
+  "supports_structured_output": false,
   "parameters": {
     "temperature": {
       "type": "float",

--- a/frontend/src/components/GlobalSettingsModal.tsx
+++ b/frontend/src/components/GlobalSettingsModal.tsx
@@ -40,6 +40,7 @@ interface ModelInfo {
     display_name: string;
     provider: string;
     is_available: boolean;
+    supports_structured_output?: boolean;
 }
 
 type TabId = 'env' | 'world' | 'db' | 'models' | 'about';
@@ -587,7 +588,7 @@ export default function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsM
                                                     {expandedModelRole === role && (
                                                         <div className={styles.roleDropdown}>
                                                             {modelsAvailable
-                                                                .filter(m => m.is_available)
+                                                                .filter(m => m.is_available && (role !== 'agentic_model' || m.supports_structured_output !== false))
                                                                 .map(model => (
                                                                     <div
                                                                         key={model.id}

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -1201,6 +1201,14 @@ class SEARuntime:
             if not supports_structured_output(base_model):
                 # Model doesn't support structured output, switch to agentic model
                 agentic_model = get_agentic_model()
+                # Guard: if the agentic model itself doesn't support structured output,
+                # fall back to the built-in default instead
+                if not supports_structured_output(agentic_model):
+                    builtin_default = "gemini-2.5-flash-lite-preview-09-2025"
+                    LOGGER.warning(
+                        "[sea] Agentic model '%s' also doesn't support structured output, "
+                        "falling back to built-in default: %s", agentic_model, builtin_default)
+                    agentic_model = builtin_default
                 LOGGER.info("[sea] Model '%s' doesn't support structured output, switching to agentic model: %s",
                            base_model, agentic_model)
                 try:


### PR DESCRIPTION
## Summary
- `chatgpt-4o-latest` が構造化出力（Structured Output）に非対応であることを明示し、memory_research/deep_research等のプレイブックで発生するInvalidRequestErrorを修正
- UIのエージェントモデル選択ドロップダウンから構造化出力非対応モデルを除外
- 既に非対応モデルをagenticモデルとして設定済みのユーザー向けに、ビルトインデフォルトへの安全なフォールバックを追加

## Test plan
- [ ] chatgpt-4o-latestをペルソナのデフォルトモデルに設定し、memory_researchプレイブックを実行 → agenticモデルに自動切り替えされエラーなく完了すること
- [ ] GlobalSettings > モデル設定 > エージェントモデルのドロップダウンにchatgpt-4o-latestが表示されないこと
- [ ] `.env`で`SAIVERSE_AGENTIC_MODEL=chatgpt-4o-latest`を設定した状態で構造化出力を使うプレイブック実行 → WARNINGログ付きでビルトインデフォルトにフォールバックすること
- [ ] chatgpt-4o-latestでの通常発話（meta_user → sub_speak）が引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)