### PR TITLE
Add timezone auto-detection in tutorial and startup mismatch popup

### DIFF
--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -1273,3 +1273,101 @@
 :global([data-theme="dark"]) .toastClose {
     color: #fbbf24;
 }
+
+/* Timezone Mismatch Popup */
+.tzPopup {
+    background-color: #ffffff;
+    border-radius: 12px;
+    padding: 2rem;
+    max-width: 480px;
+    width: 90%;
+    margin: auto;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+}
+
+.tzPopupTitle {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 1rem 0;
+}
+
+.tzPopupText {
+    color: #475569;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0 0 0.5rem 0;
+}
+
+.tzPopupText strong {
+    color: #2563eb;
+}
+
+.tzPopupActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.tzPopupDismiss {
+    background: none;
+    border: 1px solid #cbd5e1;
+    color: #64748b;
+    padding: 0.6rem 1.2rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.tzPopupDismiss:hover {
+    border-color: #94a3b8;
+    color: #334155;
+}
+
+.tzPopupUpdate {
+    background-color: #4dabf7;
+    border: none;
+    color: #fff;
+    padding: 0.6rem 1.2rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.tzPopupUpdate:hover {
+    background-color: #339af0;
+}
+
+.tzPopupUpdate:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+:global([data-theme="dark"]) .tzPopup {
+    background-color: #1e1f22;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+}
+
+:global([data-theme="dark"]) .tzPopupTitle {
+    color: #e0e0e0;
+}
+
+:global([data-theme="dark"]) .tzPopupText {
+    color: #aaa;
+}
+
+:global([data-theme="dark"]) .tzPopupText strong {
+    color: #4dabf7;
+}
+
+:global([data-theme="dark"]) .tzPopupDismiss {
+    border-color: #555;
+    color: #aaa;
+}
+
+:global([data-theme="dark"]) .tzPopupDismiss:hover {
+    border-color: #888;
+    color: #ccc;
+}

--- a/frontend/src/components/tutorial/TutorialWizard.tsx
+++ b/frontend/src/components/tutorial/TutorialWizard.tsx
@@ -53,6 +53,7 @@ interface ModelRoleAssignment {
 interface TutorialState {
     userName: string;
     cityName: string;
+    timezone: string;
     personaChoice: 'new' | 'import' | null;
     apiKeys: Record<string, string>;
     createdPersonaId: string | null;
@@ -98,6 +99,7 @@ export default function TutorialWizard({
     const [state, setState] = useState<TutorialState>({
         userName: '',
         cityName: '',
+        timezone: '',
         personaChoice: null,
         apiKeys: {},
         createdPersonaId: null,
@@ -119,6 +121,7 @@ export default function TutorialWizard({
             setState({
                 userName: '',
                 cityName: '',
+                timezone: '',
                 personaChoice: null,
                 apiKeys: {},
                 createdPersonaId: null,
@@ -162,6 +165,10 @@ export default function TutorialWizard({
                 if (cities.length > 0) {
                     // Use DESCRIPTION (display name) if available, else CITYNAME
                     updates.cityName = cities[0].DESCRIPTION || cities[0].CITYNAME || '';
+                    // Auto-detect timezone from browser if city still has default 'UTC'
+                    const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                    const cityTz = cities[0].TIMEZONE || 'UTC';
+                    updates.timezone = (cityTz === 'UTC') ? browserTz : cityTz;
                 }
             }
             if (Object.keys(updates).length > 0) {
@@ -296,7 +303,7 @@ export default function TutorialWizard({
                 online_mode: city.START_IN_ONLINE_MODE ?? false,
                 ui_port: city.UI_PORT ?? 8000,
                 api_port: city.API_PORT ?? 8001,
-                timezone: city.TIMEZONE || 'UTC',
+                timezone: state.timezone || city.TIMEZONE || 'UTC',
             })
         });
         if (!updateRes.ok) {
@@ -398,6 +405,8 @@ export default function TutorialWizard({
                     <StepCityName
                         value={state.cityName}
                         onChange={(v) => updateState({ cityName: v })}
+                        timezone={state.timezone}
+                        onTimezoneChange={(v) => updateState({ timezone: v })}
                     />
                 );
             case 4:

--- a/frontend/src/components/tutorial/steps/StepCityName.tsx
+++ b/frontend/src/components/tutorial/steps/StepCityName.tsx
@@ -6,9 +6,11 @@ import styles from './Steps.module.css';
 interface StepCityNameProps {
     value: string;
     onChange: (value: string) => void;
+    timezone?: string;
+    onTimezoneChange?: (value: string) => void;
 }
 
-export default function StepCityName({ value, onChange }: StepCityNameProps) {
+export default function StepCityName({ value, onChange, timezone, onTimezoneChange }: StepCityNameProps) {
     return (
         <div className={styles.formContainer}>
             <h3 className={styles.title}>あなたの都市に名前をつけてください</h3>
@@ -29,6 +31,21 @@ export default function StepCityName({ value, onChange }: StepCityNameProps) {
                     英数字とアンダースコアのみ使用できます。スキップした場合は「city_a」になります
                 </p>
             </div>
+
+            {onTimezoneChange && (
+                <div className={styles.field}>
+                    <label>タイムゾーン</label>
+                    <input
+                        type="text"
+                        value={timezone || ''}
+                        onChange={(e) => onTimezoneChange(e.target.value)}
+                        placeholder="例: Asia/Tokyo"
+                    />
+                    <p className={styles.fieldHint}>
+                        ブラウザから自動検出されたタイムゾーンです。変更も可能です
+                    </p>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- チュートリアルのCity名ステップ（Step 3）にタイムゾーン入力フィールドを追加。ブラウザから`Intl.DateTimeFormat`で自動検出した値をプリフィルし、ユーザーが確認・変更可能
- 既存ユーザー向けに、起動時にCityのタイムゾーンとブラウザのタイムゾーンが不一致の場合、更新を促すモーダルポップアップを表示
- ポップアップのdismissはlocalStorageに記録し、同じTZ組み合わせでは再表示しない（TZ変更時は再表示）

## Test plan
- [ ] 新規セットアップ: seed.pyでDBリセット → チュートリアル実行 → Step 3でブラウザTZが自動検出されることを確認
- [ ] チュートリアル完了後: DBのCity.TIMEZONEがブラウザTZに設定されていることを確認
- [ ] 既存ユーザー: City.TIMEZONEを"UTC"に手動設定 → ページリロード → ポップアップ表示を確認
- [ ] ポップアップ「更新」ボタン: TZが更新されトースト通知が表示されることを確認
- [ ] ポップアップ「閉じる」ボタン: ポップアップが消え、リロードしても再表示されないことを確認
- [ ] localStorageクリア後のリロードで再表示されることを確認
- [ ] ダークモード/ライトモードの両方でポップアップの見た目を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)