### PR TITLE
Add CREATE_BREAKAWAY_FROM_JOB for updater process survival

### DIFF
--- a/builtin_data/models/openrouter-z-ai-glm-5.json
+++ b/builtin_data/models/openrouter-z-ai-glm-5.json
@@ -1,0 +1,49 @@
+{
+  "model": "z-ai/glm-5",
+  "system_prompt": "",
+  "display_name": "Z.ai GLM-5 (Open Router)",
+  "provider": "openai",
+  "supports_structured_output": true,
+  "context_length": 202752,
+  "default_max_history_messages": 50,
+  "metabolism_keep_messages": 30,
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "supports_images": false,
+  "convert_system_to_user": true,
+  "parameters": {
+    "temperature": {
+      "type": "float",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1,
+      "label": "Temperature",
+      "description": "Controls randomness."
+    },
+    "top_p": {
+      "type": "float",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "default": 0.95,
+      "label": "Top P",
+      "description": "Nucleus sampling cutoff."
+    },
+    "max_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 120000,
+      "step": 1,
+      "default": 8000,
+      "label": "Max tokens",
+      "description": "Upper bound on generated tokens."
+    }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 0.80,
+    "cached_input_per_1m_tokens": 0.16,
+    "output_per_1m_tokens": 2.56,
+    "currency": "USD"
+  }
+}


### PR DESCRIPTION
## Summary
- On Windows, `self_update.py` was being killed when the backend called `os._exit(0)` because both were in the same Job Object
- Adding `CREATE_BREAKAWAY_FROM_JOB` (0x01000000) lets the updater escape the Job Object and survive the parent's exit
- Falls back to old flags if the Job doesn't allow breakaway
- Also adds openrouter-z-ai-glm-5 model config

## Root cause
Windows Terminal and modern console hosts create implicit Job Objects with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` alone doesn't escape the Job, so the updater dies 3 seconds after spawn when the backend exits. Confirmed via `self_update.log` showing three attempts all dying at Step 1.

## Test plan
- [ ] Click Update button on Windows
- [ ] Verify `self_update.log` progresses past Step 1
- [ ] Verify full update cycle completes (git pull → pip install → restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)