### PR TITLE
Fix building deletion causing Unknown state for remaining buildings

### DIFF
--- a/frontend/src/components/settings/WorldEditor.tsx
+++ b/frontend/src/components/settings/WorldEditor.tsx
@@ -188,7 +188,16 @@ export default function WorldEditor() {
     };
     const handleCreateBuilding = async () => { if (await apiCall('/api/world/buildings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: formData.name, description: formData.description || "", capacity: formData.capacity || 1, system_instruction: formData.system_instruction || "", city_id: formData.city_id, building_id: formData.building_id || null }) })) { loadBuildings(); setFormData({}); } };
     const handleUpdateBuilding = async () => { if (await apiCall(`/api/world/buildings/${selectedBuilding!.BUILDINGID}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...formData, tool_ids: formData.tool_ids || [] }) })) { loadBuildings(); } };
-    const handleDeleteBuilding = async () => { if (confirm("この Building を削除しますか？") && await apiCall(`/api/world/buildings/${selectedBuilding!.BUILDINGID}`, { method: 'DELETE' })) { setSelectedBuilding(null); setFormData({}); loadBuildings(); } };
+    const handleDeleteBuilding = async () => {
+        const deletedId = selectedBuilding!.BUILDINGID;
+        if (confirm("この Building を削除しますか？") && await apiCall(`/api/world/buildings/${deletedId}`, { method: 'DELETE' })) {
+            setSelectedBuilding(null);
+            setFormData({});
+            loadBuildings();
+            // Notify main page so it can update if the deleted building was current
+            window.dispatchEvent(new CustomEvent('building-deleted', { detail: { buildingId: deletedId } }));
+        }
+    };
 
     // --- AI Handlers ---
     const handleAISelect = (ai: AI) => {

--- a/manager/admin.py
+++ b/manager/admin.py
@@ -388,6 +388,7 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
             if not building:
                 return "Error: Building not found."
 
+            # Check AI occupancy
             occupancy = (
                 db.query(BuildingOccupancyLog)
                 .filter_by(BUILDINGID=building_id, EXIT_TIMESTAMP=None)
@@ -397,6 +398,19 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
                 return (
                     f"Error: Cannot delete '{building.BUILDINGNAME}' because it is "
                     "occupied."
+                )
+
+            # Check user occupancy (users are tracked via User.CURRENT_BUILDINGID,
+            # not BuildingOccupancyLog)
+            user_in_building = (
+                db.query(UserModel)
+                .filter_by(CURRENT_BUILDINGID=building_id)
+                .first()
+            )
+            if user_in_building:
+                return (
+                    f"Error: Cannot delete '{building.BUILDINGNAME}' because a "
+                    "user is currently in it."
                 )
 
             db.query(BuildingOccupancyLog).filter_by(BUILDINGID=building_id).delete()


### PR DESCRIPTION
## Summary
- ワールドエディタでBuildingを削除すると、削除していないBuildingもチャットUI上部やサイドバーで「Unknown」表示になりペルソナが見えなくなる問題を修正
- `_reload_buildings()` のレースコンディション、ユーザー占有チェック漏れ、フロントエンド通知欠如など複数の根本原因に対処

## Changes
- **`saiverse/saiverse_manager.py`**: `_reload_buildings()` を `clear()+update()` から差分更新に変更し、concurrent request が空の `building_map` を参照する窓を除去。DB読み込みエラー時は既存stateを維持。削除されたbuildingの `occupants`/`building_histories` もクリーンアップ
- **`manager/admin.py`**: `delete_building()` に `User.CURRENT_BUILDINGID` チェックを追加し、ユーザーが現在いるBuildingの削除を防止
- **`frontend/src/components/settings/WorldEditor.tsx`**: 削除成功時に `building-deleted` CustomEvent を dispatch
- **`frontend/src/app/page.tsx`**: イベントをリッスンし、現在のBuildingが削除された場合は自動的に別Buildingへ移動

## Test plan
- [ ] Building削除後、他のBuildingの名前が正しく表示され続けることを確認
- [ ] ユーザーが現在いるBuildingの削除を試みるとエラーが返ることを確認
- [ ] 削除したBuildingに移動していた場合、自動的に別Buildingに切り替わることを確認
- [ ] AIペルソナがいるBuildingの削除が従来通りブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)