### PR TITLE
Fix: ペルソナ作成時にフォールバックモデルがDEFAULT_MODELに焼き込まれる問題

### DIFF
--- a/manager/persona.py
+++ b/manager/persona.py
@@ -308,7 +308,7 @@ class PersonaMixin:
                 AUTO_COUNT=0,
                 INTERACTION_MODE="manual",
                 IS_DISPATCHED=False,
-                DEFAULT_MODEL=self.model or self._base_model,
+                DEFAULT_MODEL=self.model,
                 CHRONICLE_ENABLED=False,
                 PRIVATE_ROOM_ID=new_building_id,
             )


### PR DESCRIPTION
## Summary
- ペルソナ作成時に `self.model or self._base_model` でフォールバック値（gemini-2.5-flash-lite）がDBの `DEFAULT_MODEL` に焼き込まれていた問題を修正
- チュートリアルではペルソナ作成(step 4)がモデル自動設定(step 5)より前に行われるため、常にハードコードのフォールバック値が入っていた
- `DEFAULT_MODEL` を `None`（未設定）にすることで、実行時にグローバル設定へ正しくフォールバックするようになる

## Test plan
- [ ] チュートリアルでGemini無料枠を設定してペルソナ作成 → ペルソナ設定画面で DEFAULT_MODEL が空（未設定）であることを確認
- [ ] チュートリアル完了後、チャットで auto-configure で設定されたモデルが使用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)