### PR TITLE
Fix chat option model override reset by persona config PATCH

### DIFF
--- a/manager/admin.py
+++ b/manager/admin.py
@@ -845,7 +845,12 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
                 persona.lightweight_model = lightweight_model
 
                 # Update default model and recreate LLM client if model changed
-                new_model = default_model or self.model
+                # If a global chat-option override is active, preserve it;
+                # only the DB value (ai.DEFAULT_MODEL) was updated above.
+                if self.model and self.model != "None":
+                    new_model = self.model
+                else:
+                    new_model = default_model or self.model
                 if persona.model != new_model:
                     persona.model = new_model
                     from llm_clients import get_llm_client


### PR DESCRIPTION
## Summary
- チャットオプションでモデルを指定した後、ペルソナ設定を更新（リンクユーザー変更等）すると、`update_ai()` がDBの `DEFAULT_MODEL` でin-memoryモデルを上書きし、チャットオプションの指定が消えていた
- グローバルオーバーライドがアクティブな場合はそれを維持するように修正。ドキュメントの優先度（chat UI override > persona DEFAULT_MODEL）に準拠

## Test plan
- [ ] チャットオプションでモデルA指定 → ペルソナ設定でモデル以外を変更して保存 → 発話 → モデルAが使われることを確認
- [ ] チャットオプション未指定 → ペルソナ設定でDEFAULT_MODELを変更して保存 → 発話 → 新モデルが使われることを確認
- [ ] チャットオプションでモデル指定 → オーバーライドをクリア → DB DEFAULT_MODELに戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)