### PR TITLE
Fix model override 'None' sentinel and surface LLM errors to frontend

### DIFF
--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -225,7 +225,7 @@ def get_playbook_params(name: str, manager=Depends(get_manager)):
 @router.get("/config", response_model=ModelConfigResponse)
 def get_current_config(manager = Depends(get_manager)):
     """Get current model and parameter configuration."""
-    current_model = manager.model if manager.model != "None" else None
+    current_model = manager.model or None
     
     # If no model selected, return empty (but still include overrides)
     if not current_model:
@@ -303,7 +303,7 @@ def set_model(req: UpdateModelRequest, manager = Depends(get_manager)):
     manager.set_model(req.model, req.parameters)
     
     # Return full config inline to avoid a separate /config fetch
-    current_model = manager.model if manager.model != "None" else None
+    current_model = manager.model or None
     
     if not current_model:
         return {
@@ -488,7 +488,7 @@ class CacheConfigRequest(BaseModel):
 @router.get("/cache", response_model=CacheConfigResponse)
 def get_cache_settings(manager = Depends(get_manager)):
     """Get current cache settings and model cache support info."""
-    current_model = manager.model if manager.model != "None" else None
+    current_model = manager.model or None
 
     # Get cache config for current model
     cache_config = {}
@@ -544,7 +544,7 @@ def get_max_history_messages(manager=Depends(get_manager)):
     from saiverse.model_configs import get_default_max_history_messages
 
     override = getattr(manager, "max_history_messages_override", None)
-    current_model = manager.model if manager.model != "None" else None
+    current_model = manager.model or None
 
     model_default = None
     if current_model:
@@ -579,7 +579,7 @@ def get_metabolism_settings(manager=Depends(get_manager)):
     """Get current metabolism settings."""
     from saiverse.model_configs import get_metabolism_keep_messages, get_default_max_history_messages
 
-    current_model = manager.model if manager.model != "None" else None
+    current_model = manager.model or None
     metab_override = getattr(manager, "metabolism_keep_messages_override", None)
     metab_model_default = None
     high_wm = None
@@ -607,7 +607,7 @@ def set_metabolism_settings(req: MetabolismConfigRequest, manager=Depends(get_ma
             raise HTTPException(status_code=400, detail="keep_messages must be >= 1")
         # Validate: high_wm - keep_messages >= 20
         from saiverse.model_configs import get_default_max_history_messages
-        current_model = manager.model if manager.model != "None" else None
+        current_model = manager.model or None
         high_wm_override = getattr(manager, "max_history_messages_override", None)
         high_wm = high_wm_override
         if high_wm is None and current_model:

--- a/api/routes/people/config.py
+++ b/api/routes/people/config.py
@@ -83,6 +83,13 @@ def update_persona_config(
     if result.startswith("Error:"):
         raise HTTPException(status_code=400, detail=result)
 
+    # Extract LLM warnings if present
+    llm_warning = None
+    if "[WARNING:LLM]" in result:
+        parts = result.split("[WARNING:LLM]", 1)
+        result = parts[0].strip()
+        llm_warning = parts[1].strip()
+
     # Handle linked user update
     if req.linked_user_id is not None:
         session = manager.SessionLocal()
@@ -112,7 +119,10 @@ def update_persona_config(
         finally:
             session.close()
 
-    return {"success": True, "message": result}
+    response = {"success": True, "message": result}
+    if llm_warning:
+        response["warning"] = llm_warning
+    return response
 
 
 @router.post("/{persona_id}/organize-memory")

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -183,7 +183,9 @@ export default function SettingsModal({ isOpen, onClose, personaId }: SettingsMo
 
             if (res.ok) {
                 const data = await res.json();
-                // Close on success
+                if (data.warning) {
+                    alert(`設定は保存されましたが、警告があります:\n${data.warning}`);
+                }
                 onClose();
             } else {
                 const err = await res.json();

--- a/manager/state.py
+++ b/manager/state.py
@@ -15,7 +15,7 @@ class CoreState:
     session_factory: Session
     city_id: int
     city_name: str
-    model: str
+    model: Optional[str]
     provider: str
     context_length: int
     saiverse_home: Path

--- a/saiverse/saiverse_manager.py
+++ b/saiverse/saiverse_manager.py
@@ -655,7 +655,7 @@ class SAIVerseManager(
         - If model is "None" or empty: clear the override and reset each persona to its DB-defined default model.
         - Otherwise: set the given model for all personas (temporary, not persisted).
         """
-        if model == "None" or not model or not model.strip():
+        if not model or not model.strip():
             logging.info("Clearing global model override; restoring each persona's DB default model.")
             self.model_parameter_overrides = {}
             db = self.SessionLocal()
@@ -667,7 +667,7 @@ class SAIVerseManager(
                     m = ai.DEFAULT_MODEL or getattr(self, '_base_model', None) or _get_default_model()
                     persona.set_model(m, get_context_length(m), get_model_provider(m))
                 # Reflect no-override state in manager
-                self.model = "None"
+                self.model = None
                 self.state.model = self.model
                 if hasattr(self.runtime, "model"):
                     self.runtime.model = self.model
@@ -695,7 +695,7 @@ class SAIVerseManager(
     def set_model_parameters(self, parameters: Optional[Dict[str, Any]] = None) -> None:
         """Update model parameters for the current override model."""
         self.model_parameter_overrides = dict(parameters or {})
-        if self.model == "None":
+        if not self.model:
             logging.info("Parameter overrides ignored because no global model override is active.")
             return
         for persona in self.personas.values():

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -1195,6 +1195,14 @@ class SEARuntime:
             base_model = getattr(persona, "model", "unknown")
             LOGGER.info("[sea] persona.model=%s, llm_client type=%s", base_model, type(base_client).__name__)
 
+        # Guard: if no client was resolved, raise a clear error
+        if base_client is None:
+            persona_name = getattr(persona, "persona_name", "unknown")
+            raise LLMError(
+                f"LLM client is not initialized for persona '{persona_name}' (model={base_model})",
+                user_message=f"ペルソナ「{persona_name}」のLLMクライアントが初期化されていません。チャットオプションでモデルを選択してください。",
+            )
+
         # If structured output is needed, check if the selected model supports it
         if needs_structured_output:
             from saiverse.model_configs import supports_structured_output, get_agentic_model, get_context_length, get_model_provider


### PR DESCRIPTION
## Summary

- **根本原因修正**: グローバルモデルオーバーライド解除時に `self.model = "None"`（文字列）をセンチネルとして使っていたのを `None`（Python None）に修正。`default_model or "None"` が truthy な文字列 "None" を返してしまい、存在しないモデル名でLLMクライアント作成が失敗していた
- **LLMクライアント未初期化時の防御追加**: `SEARuntime._select_llm_client()` で `persona.llm_client` が None の場合、ユーザーに分かるエラーメッセージ付きの `LLMError` を投げるようにし、フロントエンドのエラー表示チェーンに乗せた
- **エラーの可視化**: PATCH `/api/people/{id}/config` でLLMクライアント作成失敗時、レスポンスに `warning` フィールドを追加。SettingsModal で警告をアラート表示

## 再現手順

1. 新規インストール（seed.py でDB初期化）
2. チュートリアルでモデル自動設定 → グローバルオーバーライド有効化
3. ペルソナ設定PATCH（linked_user 等）→ `update_ai()` で `default_model or self.model` が "None" に
4. LLMクライアント作成失敗、以降発話不能
5. フロントエンドにはエラーが一切表示されない

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `saiverse/saiverse_manager.py` | `self.model = "None"` → `None`、関連チェック修正 |
| `manager/state.py` | `CoreState.model` 型を `Optional[str]` に |
| `manager/admin.py` | None チェック統一、`new_model` None時スキップ、警告収集 |
| `api/routes/config.py` | 6箇所の `!= "None"` → `or None` |
| `api/routes/people/config.py` | レスポンスに `warning` フィールド追加 |
| `sea/runtime.py` | `_select_llm_client()` に None ガード + LLMError |
| `frontend/.../SettingsModal.tsx` | warning アラート表示 |

## Test plan

- [ ] 新規DB + チュートリアルフローでモデル設定後、ペルソナ設定PATCHしてもLLMクライアントが壊れないこと
- [ ] グローバルモデルオーバーライド設定 → 解除 → 設定のサイクルが正常に動作すること
- [ ] LLMクライアント作成に失敗した場合、SettingsModal に警告が表示されること
- [ ] LLMクライアント未初期化状態でチャット送信時、フロントエンドにエラーメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)