### PR TITLE
Fix embedding model double-onnx path and persona creation DB timing

### DIFF
--- a/manager/persona.py
+++ b/manager/persona.py
@@ -362,6 +362,11 @@ class PersonaMixin:
             )
             self.building_histories[new_building_id] = []
 
+            # Commit DB records before creating PersonaCore so that
+            # load_session_data (which opens a separate DB session) can
+            # find the AI record.
+            db.commit()
+
             new_persona_model = self.model or self._base_model
             new_persona_provider = get_model_provider(new_persona_model)  # Get provider for model
             new_persona_context_length = get_context_length(new_persona_model)
@@ -406,7 +411,6 @@ class PersonaMixin:
             self.id_to_name_map[new_ai_id] = name
             self.persona_map[name] = new_ai_id
 
-            db.commit()
             return True, f"Persona '{name}' created successfully.", new_ai_id, new_building_id
         except Exception as exc:
             db.rollback()

--- a/sai_memory/memory/recall.py
+++ b/sai_memory/memory/recall.py
@@ -198,8 +198,10 @@ def _build_local_model_kwargs(
         raise FileNotFoundError(f"SAIMemory embedding model path does not exist: {model_dir}")
 
     model_file = _resolve_model_file(model_dir)
-    model_file_path = (model_dir / model_file).resolve()
-    model_base = model_file_path.parent if model_file_path.exists() else model_dir
+    # Always use model_dir as the base: fastembed resolves model_file
+    # (e.g. "onnx/model.onnx") relative to specific_model_path, so using
+    # model_file_path.parent would double the "onnx/" prefix.
+    model_base = model_dir
     embedding_dim = explicit_dim or _infer_embedding_dimension(model_dir)
     pooling = _infer_pooling(model_dir)
     normalization = _infer_normalization(model_dir)


### PR DESCRIPTION
## Summary

新規インストール時の起動で発生する2つの問題を修正:

- **Embeddingモデルパス二重化**: `_build_local_model_kwargs` が `model_file_path.parent`（例: `sbert/e5-small/onnx/`）を `specific_model_path` として渡していたが、fastembed は内部で `onnx/model.onnx` を追加するため `onnx/onnx/model.onnx` になりSAIMemory初期化が失敗していた。`model_dir`（モデルルート）をそのまま使うよう修正
- **PersonaCore作成前にDBコミット**: `_create_persona()` で `db.commit()` の前に PersonaCore を作成していたため、`load_session_data`（別DBセッション使用）が未コミットのAIレコードを発見できず「No AI record found in DB」の警告が出ていた

## Test plan

- [ ] 新規DB（seed.py）で起動して「No AI record found in DB」の警告が出ないこと
- [ ] `sbert/multilingual-e5-small/` にローカルモデルがある環境で、SAIMemory初期化が成功すること（`onnx/onnx` 二重パスにならないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)