### PR TITLE
Fix Ctrl+Enter not sending on touch-screen Windows PCs

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1218,20 +1218,13 @@ export default function Home() {
     };
 
     const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-        // Mobile: only send button sends (Enter = newline)
-        // PC: Ctrl+Enter sends (Enter = newline)
-        if (e.key === 'Enter') {
-            if (isMobile) {
-                // On mobile, Enter always inserts newline (default behavior)
-                return;
-            } else {
-                // On PC, Ctrl+Enter sends, regular Enter inserts newline
-                if (e.ctrlKey || e.metaKey) {
-                    e.preventDefault();
-                    handleSendMessage();
-                }
-                // Regular Enter: let default behavior insert newline
-            }
+        // Ctrl+Enter (or Cmd+Enter) sends the message on any device.
+        // Regular Enter always inserts a newline.
+        // No isMobile gate needed: actual mobile devices have no Ctrl key,
+        // while touch-screen laptops do need Ctrl+Enter to work.
+        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            handleSendMessage();
         }
     };
 


### PR DESCRIPTION
## Summary

- タッチスクリーン付きWindows PCで Ctrl+Enter による送信が効かない問題を修正
- 原因: `isMobile` 判定に `navigator.maxTouchPoints > 0` を使用しており、タッチ対応PCで `true` になる。`handleKeyDown` で `if (isMobile) return;` が先に実行され、Ctrl+Enter チェックに到達しなかった
- 修正: `isMobile` ゲートを削除し、`e.ctrlKey || e.metaKey` だけで判定。実際のモバイルデバイスにはCtrlキーがないので問題なし

## Test plan

- [ ] タッチスクリーン付きWindows PCで Ctrl+Enter で送信できること
- [ ] 通常のPC（タッチなし）で Ctrl+Enter で送信できること
- [ ] モバイル端末で Enter キーが改行になること（送信ボタンで送信）

🤖 Generated with [Claude Code](https://claude.com/claude-code)