### PR TITLE
Fix tutorial setting global model override instead of default

### DIFF
--- a/api/routes/tutorial.py
+++ b/api/routes/tutorial.py
@@ -479,8 +479,8 @@ def auto_configure_models(
     """Auto-configure all 6 model role env vars based on available API keys.
 
     If provider is not specified, auto-detects the highest-priority provider
-    with an API key set. Writes to .env, updates os.environ, and sets the
-    session model on the manager.
+    with an API key set. Writes to .env, updates os.environ, and updates
+    the base default model for personas without an explicit DB override.
     """
     from api.routes.admin import write_env_updates
     from saiverse.model_configs import get_model_display_name
@@ -534,13 +534,13 @@ def auto_configure_models(
     if env_updates:
         write_env_updates(env_updates)
 
-    # 4. Set session model on manager
+    # 4. Update base default model (without global override)
     default_model = preset.get("default_model")
     if default_model:
         try:
-            manager.set_model(default_model, None)
+            manager.update_default_model(default_model)
         except Exception as exc:
-            LOGGER.warning("Failed to set session model to %s: %s", default_model, exc)
+            LOGGER.warning("Failed to update default model to %s: %s", default_model, exc)
 
     LOGGER.info(
         "Auto-configured models for provider=%s: %s",


### PR DESCRIPTION
## Summary
- チュートリアルの auto-configure が `manager.set_model()` を呼んでグローバルオーバーライドを設定していた問題を修正
- `update_default_model()` メソッドを新設し、`_base_model` の更新とDB明示設定のないペルソナのみモデル更新を行うように変更
- `manager.model` (グローバルオーバーライド) は `None` のまま維持されるため、Chat Options にオーバーライドが表示されなくなる

## 変更内容
- `saiverse/saiverse_manager.py`: `update_default_model()` メソッド追加
- `api/routes/tutorial.py`: `manager.set_model()` → `manager.update_default_model()` に置き換え

## Test plan
- [ ] チュートリアル完了後、Chat Options を開いてモデルがオーバーライドされていないことを確認
- [ ] チュートリアル完了後、ペルソナが正しく発話できることを確認
- [ ] DB で DEFAULT_MODEL を明示設定しているペルソナが影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)