### PR TITLE
Fix timezone not propagating to personas during tutorial

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1841,10 +1841,10 @@ export default function Home() {
                     isOpen={showTutorial}
                     onClose={() => setShowTutorial(false)}
                     onComplete={(roomId) => {
-                        setShowTutorial(false);
-                        // Reload page to apply new settings
-                        // User move is already handled in TutorialWizard.handleComplete,
-                        // so after reload the page will load the persona's room
+                        // Reload page to apply new settings.
+                        // Do NOT call setShowTutorial(false) before reload — keeping
+                        // showTutorial=true prevents stale tzMismatch state from
+                        // flashing the timezone modal for one frame before the reload.
                         window.location.reload();
                     }}
                 />

--- a/frontend/src/components/tutorial/TutorialWizard.tsx
+++ b/frontend/src/components/tutorial/TutorialWizard.tsx
@@ -279,9 +279,6 @@ export default function TutorialWizard({
     };
 
     const saveCityName = async () => {
-        const name = state.cityName.trim();
-        if (!name) return; // Skip if empty, will use default
-
         const res = await fetch('/api/db/tables/city');
         if (!res.ok) {
             throw new Error('City情報の取得に失敗しました');
@@ -292,8 +289,10 @@ export default function TutorialWizard({
         }
 
         const city = cities[0];
+        const name = state.cityName.trim() || city.DESCRIPTION || city.CITYNAME;
         // PUT requires all fields. Keep CITYNAME (internal ID) unchanged,
         // save user-entered display name to DESCRIPTION.
+        // Always send the timezone — even if city name was left empty.
         const updateRes = await fetch(`/api/world/cities/${city.CITYID}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },

--- a/manager/admin.py
+++ b/manager/admin.py
@@ -166,6 +166,15 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
                 self.manager.user_room_id = self.state.user_room_id
                 self.user_room_id = self.state.user_room_id
                 self._update_timezone_cache(tz_candidate)
+                # _update_timezone_cache updates manager & state; sync admin's
+                # own cached copies so _create_persona / _load_single_persona
+                # pick up the new timezone immediately.
+                self.timezone_name = self.state.timezone_name
+                self.timezone_info = self.state.timezone_info
+                # Propagate to existing in-memory personas
+                for persona in self.state.personas.values():
+                    persona.timezone = self.state.timezone_info
+                    persona.timezone_name = self.state.timezone_name
                 self.manager.reload_host_avatar(avatar_value)
 
             self._load_cities_from_db()

--- a/saiverse/saiverse_manager.py
+++ b/saiverse/saiverse_manager.py
@@ -129,6 +129,8 @@ class SAIVerseManager(
             start_in_online_mode=self.start_in_online_mode,
             ui_port=self.ui_port,
             api_port=self.api_port,
+            timezone_name=self.timezone_name,
+            timezone_info=self.timezone_info,
         )
         self.state.items = self.items
         self.state.item_locations = self.item_locations


### PR DESCRIPTION
## Summary
- `_update_timezone_cache()` がmanagerのみ更新してCoreState/AdminServiceに伝搬していなかったため、チュートリアルで作成されたペルソナが常にUTCを使用していた問題を修正
- チュートリアル完了時のページリロード前に `setShowTutorial(false)` を呼んでいたため、古い `tzMismatch` ステートがタイムゾーンモーダルを1フレームだけフラッシュ表示していた問題を修正
- `saveCityName` でCity名が空の場合にearly returnしてタイムゾーンも保存されない問題を修正

## Root cause
`_update_timezone_cache()` は `manager.timezone_name` / `manager.timezone_info` のみ更新。`CoreState` のデフォルトは `"UTC"` / `None` で、`AdminService.__init__` はstateからコピーするため、`admin._create_persona()` → `PersonaCore(timezone_info=None)` → UTCフォールバックとなっていた。

## Test plan
- [ ] 新規DBでチュートリアルを完了し、ペルソナが正しいタイムゾーンで時刻を認知するか確認
- [ ] チュートリアル完了時にタイムゾーンモーダルがフラッシュしないことを確認
- [ ] 設定画面からタイムゾーンを変更後、既存ペルソナにも反映されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)