### PR TITLE
Add per-persona Memory Weave context toggle and auto-migration

### DIFF
--- a/api/routes/people/config.py
+++ b/api/routes/people/config.py
@@ -32,6 +32,7 @@ def get_persona_config(persona_id: str, manager = Depends(get_manager)):
         lightweight_model=details.get("LIGHTWEIGHT_MODEL"),
         interaction_mode=details["INTERACTION_MODE"],
         chronicle_enabled=details.get("CHRONICLE_ENABLED", True),
+        memory_weave_context=details.get("MEMORY_WEAVE_CONTEXT", True),
         avatar_path=avatar_path_to_url(details.get("AVATAR_IMAGE")),
         appearance_image_path=avatar_path_to_url(details.get("APPEARANCE_IMAGE_PATH")),
         home_city_id=details["HOME_CITYID"],
@@ -78,6 +79,7 @@ def update_persona_config(
         avatar_upload=None,
         appearance_image_path=new_appearance,
         chronicle_enabled=req.chronicle_enabled,
+        memory_weave_context=req.memory_weave_context,
     )
 
     if result.startswith("Error:"):

--- a/api/routes/people/models.py
+++ b/api/routes/people/models.py
@@ -120,6 +120,7 @@ class AIConfigResponse(BaseModel):
     lightweight_model: Optional[str] = None
     interaction_mode: str
     chronicle_enabled: bool = True
+    memory_weave_context: bool = True
     avatar_path: Optional[str] = None
     appearance_image_path: Optional[str] = None  # Visual context appearance image
     home_city_id: int
@@ -132,6 +133,7 @@ class UpdateAIConfigRequest(BaseModel):
     lightweight_model: Optional[str] = None
     interaction_mode: Optional[str] = None
     chronicle_enabled: Optional[bool] = None
+    memory_weave_context: Optional[bool] = None
     avatar_path: Optional[str] = None
     appearance_image_path: Optional[str] = None  # Visual context appearance image
     linked_user_id: Optional[int] = None  # Set linked user (None = no change, 0 = clear)

--- a/builtin_data/tools/get_memory_weave_context.py
+++ b/builtin_data/tools/get_memory_weave_context.py
@@ -38,13 +38,6 @@ def get_memory_weave_context(
         List of messages to insert into context.
         Returns empty list if Memory Weave is not available.
     """
-    # Check environment variable
-    env_value = os.getenv("ENABLE_MEMORY_WEAVE_CONTEXT", "false")
-    LOGGER.info("get_memory_weave_context: ENABLE_MEMORY_WEAVE_CONTEXT=%s", env_value)
-    if env_value.lower() != "true":
-        LOGGER.debug("get_memory_weave_context: Disabled by environment variable")
-        return []
-
     # Get persona context
     from tools.context import get_active_persona_id, get_active_persona_path
 

--- a/database/models.py
+++ b/database/models.py
@@ -48,6 +48,7 @@ class AI(Base):
     PRIVATE_ROOM_ID = Column(String(255), ForeignKey("building.BUILDINGID"), nullable=True)
     PREVIOUS_INTERACTION_MODE = Column(String(32), default='auto', nullable=False)
     CHRONICLE_ENABLED = Column(Boolean, default=True, nullable=False)  # Per-persona Chronicle auto-generation toggle
+    MEMORY_WEAVE_CONTEXT = Column(Boolean, default=True, nullable=False)  # Per-persona Memory Weave context injection toggle
     METABOLISM_ANCHORS = Column(Text, nullable=True)  # JSON: per-model anchor state {"model": {"anchor_id": "...", "updated_at": "..."}}
 
 class Building(Base):

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -18,6 +18,7 @@ interface AIConfig {
     lightweight_model: string | null;
     interaction_mode: string;
     chronicle_enabled: boolean;
+    memory_weave_context: boolean;
     avatar_path: string | null;
     appearance_image_path: string | null;  // Visual context appearance image
     linked_user_id: number | null;  // First linked user ID
@@ -72,6 +73,7 @@ export default function SettingsModal({ isOpen, onClose, personaId }: SettingsMo
     const [lightweightModel, setLightweightModel] = useState<string>('');
     const [interactionMode, setInteractionMode] = useState<string>('auto');
     const [chronicleEnabled, setChronicleEnabled] = useState(true);
+    const [memoryWeaveContext, setMemoryWeaveContext] = useState(true);
     const [costEstimate, setCostEstimate] = useState<ChronicleCostEstimate | null>(null);
     const [avatarPath, setAvatarPath] = useState('');
     const [appearanceImagePath, setAppearanceImagePath] = useState('');
@@ -131,6 +133,7 @@ export default function SettingsModal({ isOpen, onClose, personaId }: SettingsMo
                 setLightweightModel(data.lightweight_model || '');
                 setInteractionMode(data.interaction_mode || 'auto');
                 setChronicleEnabled(data.chronicle_enabled ?? true);
+                setMemoryWeaveContext(data.memory_weave_context ?? true);
                 setAvatarPath(data.avatar_path || '');
                 setAppearanceImagePath(data.appearance_image_path || '');
                 setLinkedUserId(data.linked_user_id ? String(data.linked_user_id) : '');
@@ -175,6 +178,7 @@ export default function SettingsModal({ isOpen, onClose, personaId }: SettingsMo
                     lightweight_model: lightweightModel,  // empty string = clear to None
                     interaction_mode: interactionMode,
                     chronicle_enabled: chronicleEnabled,
+                    memory_weave_context: memoryWeaveContext,
                     avatar_path: avatarPath || null,
                     appearance_image_path: appearanceImagePath || null,
                     linked_user_id: linkedUserId ? parseInt(linkedUserId) : 0  // 0 = clear link
@@ -332,6 +336,23 @@ export default function SettingsModal({ isOpen, onClose, personaId }: SettingsMo
                                         <div>推定LLM呼び出し: {costEstimate.estimated_llm_calls}回</div>
                                     </div>
                                 )}
+                            </div>
+
+                            <div className={styles.fieldGroup}>
+                                <label className={styles.label}>Memory Weave コンテキスト</label>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                                    <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                                        <input
+                                            type="checkbox"
+                                            checked={memoryWeaveContext}
+                                            onChange={(e) => setMemoryWeaveContext(e.target.checked)}
+                                        />
+                                        <span>{memoryWeaveContext ? '有効' : '無効'}</span>
+                                    </label>
+                                </div>
+                                <div className={styles.description}>
+                                    会話時にChronicle・Memopediaの情報をLLMに提供します。無効にするとコンテキスト量が減りますが、長期記憶を参照できなくなります。
+                                </div>
                             </div>
 
                             <div className={styles.fieldGroup}>

--- a/main.py
+++ b/main.py
@@ -293,6 +293,13 @@ def main():
     else:
         db_path = default_db_path()
 
+    # Auto-migrate database schema if needed (must run before backup to avoid file lock conflicts)
+    from database.migrate import needs_migration, migrate_database_in_place
+    if needs_migration(str(db_path)):
+        logging.info("Database schema change detected. Running auto-migration...")
+        migrate_database_in_place(str(db_path))
+        logging.info("Database migration completed.")
+
     # Start database backup in background thread
     threading.Thread(target=run_startup_backup, args=(db_path,), daemon=True).start()
 

--- a/manager/admin.py
+++ b/manager/admin.py
@@ -703,6 +703,7 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
                 "LIGHTWEIGHT_MODEL": ai.LIGHTWEIGHT_MODEL,
                 "INTERACTION_MODE": ai.INTERACTION_MODE,
                 "CHRONICLE_ENABLED": ai.CHRONICLE_ENABLED,
+                "MEMORY_WEAVE_CONTEXT": ai.MEMORY_WEAVE_CONTEXT,
             }
         finally:
             db.close()
@@ -743,6 +744,7 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
         avatar_upload: Optional[str],
         appearance_image_path: Optional[str] = None,
         chronicle_enabled: Optional[bool] = None,
+        memory_weave_context: Optional[bool] = None,
     ) -> str:
         db = self.SessionLocal()
         try:
@@ -844,6 +846,9 @@ class AdminService(BlueprintMixin, HistoryMixin, PersonaMixin):
             # Update Chronicle auto-generation toggle
             if chronicle_enabled is not None:
                 ai.CHRONICLE_ENABLED = chronicle_enabled
+            # Update Memory Weave context injection toggle
+            if memory_weave_context is not None:
+                ai.MEMORY_WEAVE_CONTEXT = memory_weave_context
             db.commit()
 
             llm_warnings = []

--- a/saiverse/saiverse_manager.py
+++ b/saiverse/saiverse_manager.py
@@ -1049,6 +1049,7 @@ class SAIVerseManager(
         avatar_upload: Optional[str],
         appearance_image_path: Optional[str] = None,
         chronicle_enabled: Optional[bool] = None,
+        memory_weave_context: Optional[bool] = None,
     ) -> str:
         """ワールドエディタからAIの設定を更新する"""
         return self.admin.update_ai(
@@ -1064,6 +1065,7 @@ class SAIVerseManager(
             avatar_upload,
             appearance_image_path,
             chronicle_enabled=chronicle_enabled,
+            memory_weave_context=memory_weave_context,
         )
 
     def delete_ai(self, ai_id: str) -> str:


### PR DESCRIPTION
## Summary
- Memory Weave コンテキスト注入が環境変数 `ENABLE_MEMORY_WEAVE_CONTEXT` (デフォルト: false) でゲートされており、全ユーザーで無効化されていた問題を修正
- 環境変数ゲートを廃止し、ペルソナごとのDB設定 `MEMORY_WEAVE_CONTEXT` (デフォルト: true) に置き換え
- 設定UIからペルソナごとに有効/無効を切り替え可能に
- 起動時の自動DBマイグレーションを追加（既存ユーザーは再起動だけでカラムが追加される）
- `database/migrate.py` から pandas 依存を除去（純粋な SQLAlchemy に置き換え）
- コンテキストプレビューが実際の会話プロファイル（conversation）を使うように修正

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `database/models.py` | `MEMORY_WEAVE_CONTEXT` カラム追加 |
| `api/routes/people/models.py` | API Response/Request モデルに追加 |
| `api/routes/people/config.py` | GET/PATCH エンドポイント対応 |
| `manager/admin.py` | `update_ai()` / `get_ai_details()` 対応 |
| `saiverse/saiverse_manager.py` | パススルー追加 |
| `sea/runtime.py` | ペルソナごとチェック追加、プレビュー修正 |
| `builtin_data/tools/get_memory_weave_context.py` | 環境変数チェック削除 |
| `frontend/src/components/SettingsModal.tsx` | UIトグル追加 |
| `main.py` | 起動時自動マイグレーション追加 |
| `database/migrate.py` | pandas → SQLAlchemy 置き換え |

## Test plan
- [x] `ruff check` パス
- [x] `pytest` 全テストパス（既存の `test_model_configs` 失敗を除く）
- [ ] 起動時にDBマイグレーションが自動実行されることを確認
- [ ] コンテキストプレビューで Memory Weave セクションが表示されることを確認
- [ ] 設定UIで Memory Weave コンテキストを無効化 → コンテキストから除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)