### PR TITLE
Fix user avatar resetting to default on restart

### DIFF
--- a/manager/runtime.py
+++ b/manager/runtime.py
@@ -122,7 +122,12 @@ class RuntimeService(
                 )
                 avatar_data = None
                 if getattr(user, "AVATAR_IMAGE", None):
-                    avatar_data = self.manager._load_avatar_data(Path(user.AVATAR_IMAGE))
+                    from manager.user_state import UserStateMixin
+                    avatar_path = UserStateMixin._resolve_avatar_to_path(
+                        user.AVATAR_IMAGE
+                    )
+                    if avatar_path:
+                        avatar_data = self.manager._load_avatar_data(avatar_path)
                 self.state.user_avatar_data = avatar_data or self.manager.default_avatar
                 self.id_to_name_map[str(self.state.user_id)] = (
                     self.state.user_display_name


### PR DESCRIPTION
## Summary
- ユーザーアバターが再起動時にデフォルトに戻る不具合を修正
- `PATCH /api/user/me` がフロントエンドから受け取ったメディアURL (`/api/media/images/xxx.jpg`) をそのまま `AVATAR_IMAGE` カラムに保存していたのが原因
- 起動時に `Path(url)` でファイルとして読もうとして失敗 → デフォルトアバターにリセットされていた

## Changes
- **`api/routes/user.py`**: メディアURLを受け取った場合、実ファイルを解決して `_process_avatar_upload()` でWebP変換してからファイルパスを保存するように修正。runtime stateも正しくdata URLに変換
- **`manager/user_state.py`**: `_resolve_avatar_to_path()` ヘルパーを追加。URL形式・ファイルパス形式の両方を実ファイルの `Path` に解決。既存DB値への後方互換対応
- **`manager/runtime.py`**: runtime経由の `load_user_state_from_db()` でも同じ `_resolve_avatar_to_path()` を使用

## Test plan
- [ ] ユーザーアバターを設定 → 反映されることを確認
- [ ] SAIVerseを再起動 → アバターが保持されていることを確認
- [ ] DBの `AVATAR_IMAGE` カラムがファイルパス形式 (`~/.saiverse/user_data/icons/...`) になっていることを確認
- [ ] 既存のURL形式のDB値でも起動時にアバターが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)