### PR TITLE
Unify visual context with structured environment info

### DIFF
--- a/builtin_data/tools/get_visual_context.py
+++ b/builtin_data/tools/get_visual_context.py
@@ -1,8 +1,10 @@
-"""Build visual context messages for LLM with Building/Persona images."""
+"""Build visual context messages for LLM with structured environment info."""
 from __future__ import annotations
 
 import logging
+import mimetypes
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from tools.context import get_active_persona_id, get_active_manager
@@ -16,11 +18,14 @@ VISUAL_CONTEXT_MARKER = "__visual_context__"
 # API media URL prefix
 API_MEDIA_PREFIX = "/api/media/images/"
 
+# Maximum characters for open document content
+DOCUMENT_CONTENT_MAX_CHARS = 8000
+
 
 def _resolve_image_path(path_or_url: Optional[str]) -> Optional[str]:
     """
     Resolve an image path or API URL to an actual filesystem path.
-    
+
     Handles:
     - API URLs like /api/media/images/filename.jpg -> ~/.saiverse/image/filename.jpg
     - Already absolute filesystem paths -> returned as-is
@@ -28,13 +33,12 @@ def _resolve_image_path(path_or_url: Optional[str]) -> Optional[str]:
     """
     if not path_or_url:
         return None
-    
+
     # Handle API URL format
     if path_or_url.startswith(API_MEDIA_PREFIX):
         filename = path_or_url[len(API_MEDIA_PREFIX):]
-        from pathlib import Path
         return str(Path.home() / ".saiverse" / "image" / filename)
-    
+
     # Handle saiverse:// URI format
     if path_or_url.startswith("saiverse://"):
         try:
@@ -43,7 +47,7 @@ def _resolve_image_path(path_or_url: Optional[str]) -> Optional[str]:
             return str(resolved) if resolved else None
         except ImportError:
             pass
-    
+
     # Already an absolute or relative filesystem path
     return path_or_url
 
@@ -51,33 +55,31 @@ def _resolve_image_path(path_or_url: Optional[str]) -> Optional[str]:
 def _resolve_item_file_path(manager, file_path_str: str) -> Optional[str]:
     """
     Resolve an item file path to an actual filesystem path.
-    
+
     Handles:
     - Relative paths (e.g., "image/filename.png") -> saiverse_home / relative_path
     - Legacy WSL absolute paths (e.g., "/home/maha/.saiverse/image/...") -> extract and remap
     """
-    from pathlib import Path
-    
     if not file_path_str:
         return None
-    
+
     path = Path(file_path_str)
-    
+
     # If path exists as-is, return it
     if path.exists():
         return str(path)
-    
+
     # Try recovery strategies using saiverse_home
     home = getattr(manager, 'saiverse_home', None)
     if not home:
         home = Path.home() / ".saiverse"
-    
+
     # Strategy 0: Relative path (new format)
     if not path.is_absolute():
         candidate = home / file_path_str
         if candidate.exists():
             return str(candidate)
-    
+
     # Strategy 1: Extract from legacy paths containing 'image' or 'documents'
     parts = path.parts
     for folder in ['image', 'documents']:
@@ -87,14 +89,102 @@ def _resolve_item_file_path(manager, file_path_str: str) -> Optional[str]:
             candidate = home / rel
             if candidate.exists():
                 return str(candidate)
-    
+
     # Strategy 2: Just filename fallback
     for folder in ['image', 'documents']:
         candidate = home / folder / path.name
         if candidate.exists():
             return str(candidate)
-    
+
     return None
+
+
+def _add_to_media_list(file_path: str, media_list: List[Dict[str, str]]) -> None:
+    """Add an image file to the media list with its MIME type."""
+    mime_type = mimetypes.guess_type(file_path)[0] or "image/png"
+    media_list.append({
+        "path": file_path,
+        "mime_type": mime_type,
+        "type": "image",
+    })
+
+
+def _render_item(
+    item: Dict[str, Any],
+    text_parts: List[str],
+    media_list: List[Dict[str, str]],
+    manager: Any,
+) -> None:
+    """Render a single item into the visual context text and media list."""
+    item_id = item.get("item_id", "")
+    item_type = (item.get("type") or "").lower()
+    item_name = item.get("name", "不明なアイテム")
+    description = (item.get("description") or "").strip() or "(説明なし)"
+    state = item.get("state", {})
+    is_open = isinstance(state, dict) and state.get("is_open", False)
+    file_path_str = item.get("file_path")
+
+    type_label = {
+        "picture": "Image",
+        "document": "Document",
+        "object": "Object",
+    }.get(item_type, item_type.capitalize() or "Item")
+
+    if item_type == "object":
+        # Objects have no open/closed concept
+        text_parts.append(f"[{type_label}] {item_name}")
+        text_parts.append(f"id: {item_id}")
+        text_parts.append(description)
+        text_parts.append("")
+
+    elif item_type == "picture":
+        open_label = "(Open) " if is_open else "(Closed) "
+        text_parts.append(f"[{type_label}] {item_name}")
+        text_parts.append(f"{open_label}id: {item_id}")
+
+        if is_open and file_path_str:
+            resolved = _resolve_item_file_path(manager, file_path_str)
+            if resolved and os.path.exists(resolved):
+                text_parts.append(f"saiverse://item/{item_id}/image")
+                _add_to_media_list(resolved, media_list)
+                LOGGER.debug("get_visual_context: Added open picture item: %s", item_name)
+            else:
+                text_parts.append(description)
+        else:
+            text_parts.append(description)
+        text_parts.append("")
+
+    elif item_type == "document":
+        open_label = "(Open) " if is_open else "(Closed) "
+        text_parts.append(f"[{type_label}] {item_name}")
+        text_parts.append(f"{open_label}id: {item_id}")
+
+        if is_open and file_path_str:
+            resolved = _resolve_item_file_path(manager, file_path_str)
+            if resolved and os.path.exists(resolved):
+                try:
+                    content = Path(resolved).read_text(encoding="utf-8")
+                    if len(content) > DOCUMENT_CONTENT_MAX_CHARS:
+                        content = content[:DOCUMENT_CONTENT_MAX_CHARS] + "\n... (以下省略)"
+                    text_parts.append("```")
+                    text_parts.append(content)
+                    text_parts.append("```")
+                    LOGGER.debug("get_visual_context: Added open document: %s (%d chars)", item_name, len(content))
+                except Exception as exc:
+                    LOGGER.warning("get_visual_context: Failed to read document %s: %s", item_name, exc)
+                    text_parts.append(description)
+            else:
+                text_parts.append(description)
+        else:
+            text_parts.append(description)
+        text_parts.append("")
+
+    else:
+        # Unknown type — show as generic item
+        text_parts.append(f"[{type_label}] {item_name}")
+        text_parts.append(f"id: {item_id}")
+        text_parts.append(description)
+        text_parts.append("")
 
 
 def get_visual_context(
@@ -103,14 +193,10 @@ def get_visual_context(
     include_building: bool = True,
     include_other_personas: bool = True,
 ) -> List[Dict[str, Any]]:
-    """Build visual context messages containing Building and Persona images.
+    """Build structured visual context message for LLM.
 
-    Returns a list of messages (user/assistant pair) that provide visual context
-    about the current environment. These messages should be inserted after the
-    system prompt in the conversation history.
-
-    The returned messages include a special marker in metadata so that LLM clients
-    can identify them and exempt them from attachment limits.
+    Returns a single-element list containing a user message with structured
+    environment info: persona presence, building details, and all items.
 
     Args:
         building_id: Building ID. Defaults to current building.
@@ -119,8 +205,7 @@ def get_visual_context(
         include_other_personas: Include appearance images of other personas in the building.
 
     Returns:
-        List of message dicts with 'role', 'content', and optionally 'metadata' keys.
-        Returns empty list if no visual context images are available.
+        List of message dicts with 'role', 'content', and 'metadata' keys.
     """
     persona_id = get_active_persona_id()
     if not persona_id:
@@ -144,157 +229,137 @@ def get_visual_context(
         LOGGER.debug("get_visual_context: No building_id")
         return []
 
-    # Collect image paths
-    image_items: List[Dict[str, str]] = []  # [{"path": str, "label": str, "type": str}]
+    text_parts: List[str] = []
+    media_list: List[Dict[str, str]] = []
 
-    # 1. Building interior image
-    if include_building:
-        building_image_url = _get_building_image_path(manager, building_id)
-        building_image_path = _resolve_image_path(building_image_url)
-        LOGGER.debug("get_visual_context: Building %s image_url from DB: %s -> resolved: %s", building_id, building_image_url, building_image_path)
-        if building_image_path:
-            exists = os.path.exists(building_image_path)
-            LOGGER.debug("get_visual_context: Building image file exists: %s", exists)
-            if exists:
-                building_obj = getattr(persona, "buildings", {}).get(building_id)
-                building_name = building_obj.name if building_obj else building_id
-                image_items.append({
-                    "path": building_image_path,
-                    "label": f"現在地「{building_name}」の内装",
-                    "filename": os.path.basename(building_image_path),
-                    "type": "building",
-                })
-                LOGGER.debug("get_visual_context: Added building image: %s", building_image_path)
+    text_parts.append("<system>")
+    text_parts.append("# ビジュアルコンテキスト")
+    text_parts.append("以下は現在の状況を視覚的に示す情報です。")
+    text_parts.append("")
+    text_parts.append("---")
+    text_parts.append("")
 
-    # 2. Self appearance image
+    # ========== Section 1: ペルソナ ==========
+    text_parts.append("## ペルソナ")
+    occupants = manager.occupants.get(building_id, [])
+    persona_count = len(occupants)
+    if persona_count <= 1:
+        text_parts.append("現在、このBuildingにはあなただけがいます。")
+    else:
+        text_parts.append(f"現在、このBuildingにはあなた含め{persona_count}人のペルソナがいます。")
+    text_parts.append("")
+
+    # Self appearance
     if include_self:
+        persona_name = getattr(persona, "persona_name", persona_id)
+        text_parts.append(f"[あなた自身（{persona_name}）の外見]")
+        text_parts.append(f"saiverse://persona/{persona_id}/image")
+
         self_image_url = _get_persona_appearance_path(manager, persona_id)
         self_image_path = _resolve_image_path(self_image_url)
-        LOGGER.debug("get_visual_context: Persona %s appearance_url from DB: %s -> resolved: %s", persona_id, self_image_url, self_image_path)
-        if self_image_path:
-            exists = os.path.exists(self_image_path)
-            LOGGER.debug("get_visual_context: Self image file exists: %s", exists)
-            if exists:
-                persona_name = getattr(persona, "persona_name", persona_id)
-                image_items.append({
-                    "path": self_image_path,
-                    "label": f"あなた自身（{persona_name}）の外見",
-                    "filename": os.path.basename(self_image_path),
-                    "type": "self",
-                })
-                LOGGER.debug("get_visual_context: Added self image: %s", self_image_path)
+        if self_image_path and os.path.exists(self_image_path):
+            _add_to_media_list(self_image_path, media_list)
+            LOGGER.debug("get_visual_context: Added self image: %s", self_image_path)
+        text_parts.append("")
 
-    # 3. Other personas in the building
+    # Other personas
     if include_other_personas:
-        occupants = manager.occupants.get(building_id, [])
         for other_id in occupants:
             if other_id == persona_id:
                 continue
+            other_persona = manager.all_personas.get(other_id)
+            other_name = getattr(other_persona, "persona_name", other_id) if other_persona else other_id
+            text_parts.append(f"[{other_name}の外見]")
+            text_parts.append(f"saiverse://persona/{other_id}/image")
+
             other_image_url = _get_persona_appearance_path(manager, other_id)
             other_image_path = _resolve_image_path(other_image_url)
             if other_image_path and os.path.exists(other_image_path):
-                other_persona = manager.all_personas.get(other_id)
-                other_name = getattr(other_persona, "persona_name", other_id) if other_persona else other_id
-                image_items.append({
-                    "path": other_image_path,
-                    "label": f"{other_name}の外見",
-                    "filename": os.path.basename(other_image_path),
-                    "type": "other_persona",
-                })
+                _add_to_media_list(other_image_path, media_list)
                 LOGGER.debug("get_visual_context: Added other persona image: %s (%s)", other_id, other_image_path)
+            text_parts.append("")
 
-    # 4. Open items in the building (pictures and documents)
-    document_items: List[Dict[str, str]] = []  # For document content
-    if hasattr(manager, 'get_open_items_in_building'):
-        open_items = manager.get_open_items_in_building(building_id)
-        for item in open_items:
-            item_type = (item.get("type") or "").lower()
-            item_name = item.get("name", "不明なアイテム")
-            file_path_str = item.get("file_path")
-            
-            if not file_path_str:
-                LOGGER.debug("get_visual_context: Open item %s has no file_path", item.get("item_id"))
-                continue
-            
-            # Resolve path (handle relative paths and legacy WSL paths)
-            resolved_path = _resolve_item_file_path(manager, file_path_str)
-            if not resolved_path or not os.path.exists(resolved_path):
-                LOGGER.debug("get_visual_context: Open item %s file not found: %s", item.get("item_id"), file_path_str)
-                continue
-            
-            if item_type == "picture":
-                image_items.append({
-                    "path": resolved_path,
-                    "label": f"開かれたアイテム「{item_name}」",
-                    "filename": os.path.basename(resolved_path),
-                    "type": "open_item_picture",
-                })
-                LOGGER.debug("get_visual_context: Added open picture item: %s", item_name)
-            
-            elif item_type == "document":
-                try:
-                    from pathlib import Path
-                    content = Path(resolved_path).read_text(encoding="utf-8")
-                    # Truncate if too long
-                    if len(content) > 8000:
-                        content = content[:8000] + "\n... (以下省略)"
-                    document_items.append({
-                        "name": item_name,
-                        "content": content,
-                    })
-                    LOGGER.debug("get_visual_context: Added open document item: %s (%d chars)", item_name, len(content))
-                except Exception as exc:
-                    LOGGER.warning("get_visual_context: Failed to read document %s: %s", item_name, exc)
+    # ========== Section 2: Building ==========
+    text_parts.append("---")
+    text_parts.append("")
+    text_parts.append("## Building")
 
-    if not image_items and not document_items:
-        LOGGER.debug("get_visual_context: No images or documents available")
-        return []
+    building_obj = getattr(persona, "buildings", {}).get(building_id)
+    building_name = building_obj.name if building_obj else building_id
+    text_parts.append(f"現在、「{building_name}」にいます。")
+    text_parts.append("")
 
-    # Build message content and metadata
-    import mimetypes
-    text_parts = ["<system>", "[ビジュアルコンテキスト] 以下は現在の状況を視覚的に示す情報です。"]
-    
-    # Image descriptions
-    if image_items:
+    # Building interior image
+    if include_building:
+        building_image_url = _get_building_image_path(manager, building_id)
+        building_image_path = _resolve_image_path(building_image_url)
+        if building_image_path and os.path.exists(building_image_path):
+            text_parts.append("[内装]")
+            text_parts.append(f"saiverse://building/{building_id}/image")
+            _add_to_media_list(building_image_path, media_list)
+            LOGGER.debug("get_visual_context: Added building image: %s", building_image_path)
+            text_parts.append("")
+
+    # Building system instruction
+    if building_obj:
+        base_sys = getattr(building_obj, "base_system_instruction", "") or ""
+        if base_sys.strip():
+            text_parts.append("[システムプロンプト]")
+            text_parts.append(base_sys.strip())
+            text_parts.append("")
+
+    # ========== Section 3: Item ==========
+    text_parts.append("---")
+    text_parts.append("")
+    text_parts.append("## Item")
+    text_parts.append("")
+
+    persona_name = getattr(persona, "persona_name", persona_id)
+
+    # 3a. Persona inventory items
+    inventory_items = (
+        manager.get_all_items_for_persona(persona_id)
+        if hasattr(manager, 'get_all_items_for_persona') else []
+    )
+    if inventory_items:
+        text_parts.append(f"### あなた自身（{persona_name}）のインベントリ内")
         text_parts.append("")
-        text_parts.append("【画像】")
-        for item in image_items:
-            text_parts.append(f"- {item['label']} (file: {item['filename']})")
-    
-    # Document contents
-    if document_items:
+        for item in inventory_items:
+            _render_item(item, text_parts, media_list, manager)
+
+    # 3b. Building items
+    building_items = (
+        manager.get_all_items_in_building(building_id)
+        if hasattr(manager, 'get_all_items_in_building') else []
+    )
+    if building_items:
+        text_parts.append("### Building内")
         text_parts.append("")
-        text_parts.append("【開かれた文書】")
-        for doc in document_items:
-            text_parts.append(f"\n[文書: {doc['name']}]")
-            text_parts.append("```")
-            text_parts.append(doc["content"])
-            text_parts.append("```")
-    
+        for item in building_items:
+            _render_item(item, text_parts, media_list, manager)
+
+    if not inventory_items and not building_items:
+        text_parts.append("アイテムはありません。")
+        text_parts.append("")
+
     text_parts.append("</system>")
 
-    media_list = []
-    for item in image_items:
-        mime_type = mimetypes.guess_type(item["path"])[0] or "image/png"
-        media_list.append({
-            "path": item["path"],
-            "mime_type": mime_type,
-            "type": "image",
-        })
-
-    # Return single user message (no assistant response to avoid character break)
+    # Build message
     messages: List[Dict[str, Any]] = [
         {
             "role": "user",
             "content": "\n".join(text_parts),
             "metadata": {
                 "media": media_list,
-                VISUAL_CONTEXT_MARKER: True,  # Marker for attachment limit exemption
+                VISUAL_CONTEXT_MARKER: True,
             },
         },
     ]
 
-    LOGGER.info("get_visual_context: Generated %d images, %d documents in visual context", len(image_items), len(document_items))
+    LOGGER.info(
+        "get_visual_context: Generated visual context (%d images, %d inventory items, %d building items)",
+        len(media_list), len(inventory_items), len(building_items),
+    )
     return messages
 
 
@@ -335,7 +400,7 @@ def _get_persona_appearance_path(manager, persona_id: str) -> Optional[str]:
 def schema() -> ToolSchema:
     return ToolSchema(
         name="get_visual_context",
-        description="Build visual context messages containing Building and Persona images for LLM context.",
+        description="Build visual context messages containing structured environment info for LLM context.",
         parameters={
             "type": "object",
             "properties": {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -102,7 +102,7 @@ interface FileAttachment {
 // File type detection
 const TEXT_EXTENSIONS = new Set(['txt', 'md', 'py', 'js', 'ts', 'tsx', 'json', 'yaml', 'yml', 'csv',
     'html', 'css', 'xml', 'log', 'sh', 'bat', 'sql', 'java', 'c', 'cpp',
-    'h', 'hpp', 'go', 'rs', 'rb', 'swift', 'kt', 'scala', 'r', 'lua', 'pl']);
+    'h', 'hpp', 'go', 'rs', 'rb', 'swift', 'kt', 'scala', 'r', 'lua', 'pl', 'pdf']);
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp']);
 
 function getFileType(filename: string, mimeType: string): 'image' | 'document' | 'unknown' {
@@ -1776,7 +1776,7 @@ export default function Home() {
                             style={{ display: 'none' }}
                             onChange={handleFileUpload}
                             multiple
-                            accept="image/*,.txt,.md,.py,.js,.ts,.tsx,.json,.yaml,.yml,.csv,.html,.css,.xml,.log,.sh,.sql,.java,.c,.cpp,.go,.rs,.rb"
+                            accept="image/*,.txt,.md,.py,.js,.ts,.tsx,.json,.yaml,.yml,.csv,.html,.css,.xml,.log,.sh,.bat,.sql,.java,.c,.cpp,.h,.hpp,.go,.rs,.rb,.swift,.kt,.scala,.r,.lua,.pl,.pdf"
                         />
                         <textarea
                             ref={textareaRef}

--- a/manager/items.py
+++ b/manager/items.py
@@ -600,6 +600,36 @@ class ItemService:
                     open_items.append(item)
         return open_items
 
+    def get_open_items_for_persona(self, persona_id: str) -> List[Dict]:
+        """Get all items in a persona's inventory that have is_open = True."""
+        open_items = []
+        item_ids = self.items_by_persona.get(persona_id, [])
+        for item_id in item_ids:
+            item = self.items.get(item_id)
+            if item:
+                state = item.get("state", {})
+                if isinstance(state, dict) and state.get("is_open", False):
+                    open_items.append(item)
+        return open_items
+
+    def get_all_items_in_building(self, building_id: str) -> List[Dict]:
+        """Get all items in a building (regardless of open state)."""
+        all_items = []
+        for item_id in self.items_by_building.get(building_id, []):
+            item = self.items.get(item_id)
+            if item:
+                all_items.append(item)
+        return all_items
+
+    def get_all_items_for_persona(self, persona_id: str) -> List[Dict]:
+        """Get all items in a persona's inventory (regardless of open state)."""
+        all_items = []
+        for item_id in self.items_by_persona.get(persona_id, []):
+            item = self.items.get(item_id)
+            if item:
+                all_items.append(item)
+        return all_items
+
     def create_document_item(self, persona_id: str, name: str, description: str, content: str, source_context: Optional[str] = None) -> str:
         """Create a new document item and place it in the current building."""
         persona = self.manager.personas.get(persona_id)

--- a/saiverse/saiverse_manager.py
+++ b/saiverse/saiverse_manager.py
@@ -458,6 +458,18 @@ class SAIVerseManager(
         """Get all items in a building that have is_open = True."""
         return self.item_service.get_open_items_in_building(building_id)
 
+    def get_open_items_for_persona(self, persona_id: str) -> list:
+        """Get all items in a persona's inventory that have is_open = True."""
+        return self.item_service.get_open_items_for_persona(persona_id)
+
+    def get_all_items_in_building(self, building_id: str) -> list:
+        """Get all items in a building (regardless of open state)."""
+        return self.item_service.get_all_items_in_building(building_id)
+
+    def get_all_items_for_persona(self, persona_id: str) -> list:
+        """Get all items in a persona's inventory (regardless of open state)."""
+        return self.item_service.get_all_items_for_persona(persona_id)
+
     def create_document_item(self, persona_id: str, name: str, description: str, content: str, source_context: Optional[str] = None) -> str:
         """Create a new document item and place it in the current building."""
         return self.item_service.create_document_item(persona_id, name, description, content, source_context=source_context)


### PR DESCRIPTION
## Summary
- ビジュアルコンテキストを構造化フォーマットに全面改修。ペルソナの在室情報、Building情報（システムプロンプト含む）、全アイテム（Open/Closed）を統一的に格納
- `visual_context=True` 時はシステムプロンプトからBuilding セクションとインベントリを除外（重複排除）
- フロントエンドのドキュメント拡張子リスト（`TEXT_EXTENSIONS` / `accept`属性）をバックエンドと整合

## Test plan
- [ ] チャット送信 → `llm_io.log` で新フォーマットのビジュアルコンテキスト確認（ペルソナ/Building/Itemセクション）
- [ ] システムプロンプトにBuilding情報・インベントリが含まれていないことを確認
- [ ] Open/Closedドキュメントの表示が正しいことを確認（Open: 内容表示、Closed: description）
- [ ] 画像添付が従来通り動作すること
- [ ] routerプロファイル（lightweight model）で正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)