### PR TITLE
Filter model list by API key availability and show pricing

### DIFF
--- a/frontend/src/components/ChatOptions.tsx
+++ b/frontend/src/components/ChatOptions.tsx
@@ -5,6 +5,8 @@ import { X, ChevronDown } from 'lucide-react';
 interface ModelInfo {
     id: string;
     name: string;
+    input_price?: number | null;   // USD per 1M input tokens
+    output_price?: number | null;  // USD per 1M output tokens
 }
 
 interface PlaybookParamOption {
@@ -423,6 +425,18 @@ export default function ChatOptions({ isOpen, onClose, currentPlaybook, onPlaybo
                                             <option key={m.id} value={m.id}>{m.name}</option>
                                         ))}
                                     </select>
+                                    {(() => {
+                                        const sel = models.find(m => m.id === currentModel);
+                                        if (!sel || (sel.input_price == null && sel.output_price == null)) return null;
+                                        const fmt = (v: number) => v < 1 ? `$${v}` : `$${v}`;
+                                        return (
+                                            <span className={styles.hint}>
+                                                {sel.input_price != null && `入力: ${fmt(sel.input_price)}/1M tokens`}
+                                                {sel.input_price != null && sel.output_price != null && ' ・ '}
+                                                {sel.output_price != null && `出力: ${fmt(sel.output_price)}/1M tokens`}
+                                            </span>
+                                        );
+                                    })()}
                                 </div>
                                 <div className={styles.formGroup}>
                                     <label>Playbook（次のメッセージに適用）</label>


### PR DESCRIPTION
## Summary
- APIキーが未設定のモデルをチャットオプションのモデル選択ドロップダウンから非表示にする
- モデル選択ドロップダウンの直下に、選択中モデルの入出力料金（USD/1M tokens）を小さく表示

## Changes
- `saiverse/model_configs.py`: `is_model_available()` を追加。プロバイダーごとの必要APIキー環境変数を判定し、設定有無をチェック
- `api/routes/config.py`: `/api/config/models` のレスポンスにAPIキーフィルタリングと pricing 情報を追加
- `frontend/src/components/ChatOptions.tsx`: pricing 表示をモデルドロップダウン直下に追加

## Test plan
- [ ] APIキーが設定されているプロバイダーのモデルのみドロップダウンに表示されることを確認
- [ ] ローカルモデル（Ollama等）はAPIキー不要で常に表示されることを確認
- [ ] モデル選択時にドロップダウン下部に料金が表示されることを確認
- [ ] 料金情報がないモデル（ローカルモデル等）では料金表示が出ないことを確認
- [ ] 「（デフォルト）」選択時は料金表示が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)