### PR TITLE
Fix infinite recursion in image summary and unify attachment limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,15 @@ SAIVERSE_GATEWAY_TOKEN=
 SAIVERSE_GATEWAY_CHANNEL_MAP={}
 SAIVERSE_GATEWAY_MEMORY_CHUNK_SIZE=65536
 
-SAIVERSE_GEMINI_ATTACHMENT_LIMIT=4
+# Image attachment embed limit (images beyond the limit are replaced with text summaries)
+SAIVERSE_ATTACHMENT_LIMIT=4
+# Provider-specific overrides (take precedence over the universal limit):
+# SAIVERSE_GEMINI_ATTACHMENT_LIMIT=4
+# SAIVERSE_OPENAI_ATTACHMENT_LIMIT=4
+# SAIVERSE_ANTHROPIC_ATTACHMENT_LIMIT=4
+
+# Image summary model (used when images cannot be embedded directly)
+# SAIVERSE_IMAGE_SUMMARY_MODEL=gemini-2.5-flash-lite-preview-09-2025
 SAIVERSE_DISABLE_GEMINI_SSE_PATCH=0
 SAIVERSE_DISABLE_GEMINI_STREAMING=0
 SAIVERSE_LLM_CONTEXT_DUMP=llm_context.log

--- a/llm_clients/utils.py
+++ b/llm_clients/utils.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List
+import os
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 _log = logging.getLogger(__name__)
 
@@ -57,3 +58,102 @@ def merge_reasoning_strings(chunks: List[str]) -> List[Dict[str, str]]:
     if not text:
         return []
     return [{"title": "", "text": text}]
+
+
+# ---------------------------------------------------------------------------
+# Image attachment helpers (shared across providers)
+# ---------------------------------------------------------------------------
+
+def parse_attachment_limit(provider: str = "") -> Optional[int]:
+    """Parse image attachment embed limit from environment variables.
+
+    Checks ``SAIVERSE_{PROVIDER}_ATTACHMENT_LIMIT`` first, then the
+    universal ``SAIVERSE_ATTACHMENT_LIMIT`` as fallback.
+    Returns ``None`` when no limit is configured.
+    """
+    limit_str = None
+    if provider:
+        limit_str = os.getenv(f"SAIVERSE_{provider.upper()}_ATTACHMENT_LIMIT")
+    if limit_str is None:
+        limit_str = os.getenv("SAIVERSE_ATTACHMENT_LIMIT")
+    if limit_str is None:
+        return None
+    try:
+        val = int(limit_str.strip())
+        return max(val, 0)
+    except ValueError:
+        _log.warning("Invalid attachment limit '%s'; ignoring", limit_str)
+        return None
+
+
+def compute_allowed_attachment_keys(
+    attachment_cache: Dict[int, list],
+    max_embeds: Optional[int],
+    exempt_indices: Optional[Set[int]] = None,
+) -> Optional[Set[Tuple[int, int]]]:
+    """Determine which ``(msg_idx, att_idx)`` pairs should be embedded.
+
+    Selects the *max_embeds* most-recent attachments (by message index,
+    most recent first).  Attachments in *exempt_indices* (e.g.
+    ``__visual_context__`` messages) are always allowed and do not count
+    towards the limit.
+
+    Returns ``None`` when *max_embeds* is ``None`` (unlimited).
+    """
+    if max_embeds is None:
+        return None
+    if not attachment_cache:
+        return set()
+
+    exempt = exempt_indices or set()
+    ordered: List[Tuple[int, int]] = []
+    for msg_idx in sorted(attachment_cache.keys(), reverse=True):
+        if msg_idx in exempt:
+            continue
+        for att_idx in range(len(attachment_cache[msg_idx])):
+            ordered.append((msg_idx, att_idx))
+
+    allowed: Set[Tuple[int, int]] = set(ordered[:max_embeds]) if max_embeds > 0 else set()
+
+    # Exempt attachments are always allowed
+    for msg_idx in exempt:
+        if msg_idx in attachment_cache:
+            for att_idx in range(len(attachment_cache[msg_idx])):
+                allowed.add((msg_idx, att_idx))
+            _log.debug(
+                "visual context at idx=%d exempted from attachment limit (%d images)",
+                msg_idx,
+                len(attachment_cache[msg_idx]),
+            )
+
+    return allowed
+
+
+def image_summary_note(
+    path: str,
+    mime_type: str,
+    uri: str,
+    skip_summary: bool = False,
+) -> str:
+    """Build a text note for an image that will not be embedded as binary.
+
+    Tries ``ensure_image_summary()`` for a meaningful description.
+    Falls back to a bare ``[画像: {uri}]`` reference with a warning
+    when the summary is unavailable.
+    """
+    if not skip_summary:
+        try:
+            from pathlib import Path as _Path
+
+            from saiverse.media_summary import ensure_image_summary
+
+            summary = ensure_image_summary(_Path(path), mime_type)
+            if summary:
+                return f"[画像: {uri}] {summary}"
+        except Exception:
+            _log.exception("Image summary generation error for %s", path)
+        _log.warning(
+            "Image summary unavailable for %s; using URI-only reference",
+            path,
+        )
+    return f"[画像: {uri}]"


### PR DESCRIPTION
## Summary
- **Critical fix**: PR #154 introduced infinite recursion when Gemini client processes images without cached summaries — `_convert_messages()` → `ensure_image_summary()` → `client.generate()` → `_convert_messages()` → ∞. This caused the backend to hang with Ctrl+C ineffective.
- **Re-entrancy guard (P0)**: Thread-safe guard in `ensure_image_summary()` prevents recursive calls for the same image path
- **`__skip_image_summary__` flag (P1)**: Summary generation requests now signal LLM clients to skip summary processing on their images
- **Image summaries for all providers**: OpenAI and Anthropic clients now generate text summaries for non-embeddable images (previously just showed `[画像: {file_path}]` which is useless to the LLM)
- **Unified attachment limit**: New `SAIVERSE_ATTACHMENT_LIMIT` env var applies to all providers, with per-provider overrides (`SAIVERSE_{GEMINI,OPENAI,ANTHROPIC}_ATTACHMENT_LIMIT`)

## Changed Files
| File | Change |
|------|--------|
| `saiverse/media_summary.py` | Re-entrancy guard + `__skip_image_summary__` flag on summary request messages |
| `llm_clients/gemini.py` | Respect `__skip_image_summary__` flag, use shared `parse_attachment_limit()` |
| `llm_clients/openai.py` | Add pre-scan phase, attachment limits, image summary text generation |
| `llm_clients/anthropic.py` | Same as OpenAI |
| `llm_clients/utils.py` | Shared helpers: `parse_attachment_limit()`, `compute_allowed_attachment_keys()`, `image_summary_note()` |
| `.env.example` | Document new env vars |

## Test plan
- [x] `ruff check` passes on all changed files
- [x] `pytest tests/test_llm_clients.py` — 18/18 passed
- [x] Manual test: send image with Gemini model — no infinite loop
- [ ] Manual test: send image with OpenRouter model, verify summary text appears in logs
- [ ] Manual test: set `SAIVERSE_ATTACHMENT_LIMIT=2`, send 3+ images, verify oldest gets text summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)