### PR TITLE
Add multi-turn reasoning support and update model configs

### DIFF
--- a/builtin_data/models/gemini-2.5-flash-lite-preview-09-2025.json
+++ b/builtin_data/models/gemini-2.5-flash-lite-preview-09-2025.json
@@ -1,7 +1,7 @@
 {
   "model": "gemini-2.5-flash-lite-preview-09-2025",
   "system_prompt": "",
-  "display_name": "Gemini V2.5 Flash Lite Preview 09 2025(無料枠)",
+  "display_name": "Gemini 2.5 Flash Lite Preview 09 2025(無料枠)",
   "provider": "gemini",
   "context_length": 250000,
   "default_max_history_messages": 80,

--- a/builtin_data/models/gemini-2.5-flash-preview-09-2025.json
+++ b/builtin_data/models/gemini-2.5-flash-preview-09-2025.json
@@ -1,7 +1,7 @@
 {
   "model": "gemini-2.5-flash-preview-09-2025",
   "system_prompt": "",
-  "display_name": "Gemini 2.5 Flash Preview 09 2025(Free)",
+  "display_name": "Gemini 2.5 Flash Preview 09 2025(無料枠)",
   "provider": "gemini",
   "context_length": 250000,
   "supports_images": true,

--- a/builtin_data/models/gemini-3-flash-preview-paid.json
+++ b/builtin_data/models/gemini-3-flash-preview-paid.json
@@ -1,7 +1,7 @@
 {
   "model": "gemini-3-flash-preview",
   "system_prompt": "",
-  "display_name": "Gemini 3 Flash (有料Tier)",
+  "display_name": "Gemini 3 Flash(有料Tier)",
   "provider": "gemini",
   "context_length": 1000000,
   "default_max_history_messages": 80,

--- a/builtin_data/models/gemini-3-flash-preview.json
+++ b/builtin_data/models/gemini-3-flash-preview.json
@@ -1,7 +1,7 @@
 {
   "model": "gemini-3-flash-preview",
   "system_prompt": "",
-  "display_name": "Gemini 3 Flash (無料枠)",
+  "display_name": "Gemini 3 Flash(無料枠)",
   "provider": "gemini",
   "context_length": 250000,
   "default_max_history_messages": 80,

--- a/builtin_data/models/gemini-3-pro-preview.json
+++ b/builtin_data/models/gemini-3-pro-preview.json
@@ -1,7 +1,7 @@
 {
   "model": "gemini-3-pro-preview",
   "system_prompt": "",
-  "display_name": "Gemini 3 Pro (有料Tier, <200k)",
+  "display_name": "Gemini 3 Pro(有料Tier, <200k)",
   "provider": "gemini",
   "context_length": 200000,
   "default_max_history_messages": 80,

--- a/builtin_data/models/nim-deepseek-v3.2.json
+++ b/builtin_data/models/nim-deepseek-v3.2.json
@@ -11,6 +11,14 @@
   "api_key_env": "NVIDIA_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "request_kwargs": {
+    "extra_body": {
+      "chat_template_kwargs": {
+        "enable_thinking": true,
+        "clear_thinking": false
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",
@@ -33,17 +41,11 @@
     "max_tokens": {
       "type": "int",
       "min": 32,
-      "max": 4096,
+      "max": 8192,
       "step": 1,
-      "default": 4096,
+      "default": 8192,
       "label": "Max tokens",
       "description": "Upper bound on generated tokens."
     }
-  },
-  "pricing": {
-    "input_per_1m_tokens": 0.26,
-    "cached_input_per_1m_tokens": 0.013,
-    "output_per_1m_tokens": 0.38,
-    "currency": "USD"
   }
 }

--- a/builtin_data/models/nim-kimi-k2.5.json
+++ b/builtin_data/models/nim-kimi-k2.5.json
@@ -11,6 +11,14 @@
   "api_key_env": "NVIDIA_API_KEY",
   "convert_system_to_user": true,
   "supports_images": true,
+  "request_kwargs": {
+    "extra_body": {
+      "chat_template_kwargs": {
+        "enable_thinking": true,
+        "clear_thinking": false
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/nim-qwen3-235b-a22b.json
+++ b/builtin_data/models/nim-qwen3-235b-a22b.json
@@ -1,7 +1,7 @@
 {
   "model": "qwen/qwen3-235b-a22b",
   "system_prompt": "",
-  "display_name": "Qwen 3 235B-A22B(NIM)",
+  "display_name": "Qwen 3 235B-A22B Instruct(NIM)",
   "provider": "nvidia_nim",
   "supports_structured_output": false,
   "context_length": 128000,
@@ -10,6 +10,14 @@
   "base_url": "https://integrate.api.nvidia.com/v1",
   "api_key_env": "NVIDIA_API_KEY",
   "convert_system_to_user": true,
+  "request_kwargs": {
+    "extra_body": {
+      "chat_template_kwargs": {
+        "enable_thinking": true,
+        "clear_thinking": false
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/nim-step-3.5-flash.json
+++ b/builtin_data/models/nim-step-3.5-flash.json
@@ -11,6 +11,14 @@
   "api_key_env": "NVIDIA_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "request_kwargs": {
+    "extra_body": {
+      "chat_template_kwargs": {
+        "enable_thinking": true,
+        "clear_thinking": false
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/nim-z-ai-glm-4.7.json
+++ b/builtin_data/models/nim-z-ai-glm-4.7.json
@@ -11,6 +11,14 @@
   "api_key_env": "NVIDIA_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "request_kwargs": {
+    "extra_body": {
+      "chat_template_kwargs": {
+        "enable_thinking": true,
+        "clear_thinking": false
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/nim-z-ai-glm-5.json
+++ b/builtin_data/models/nim-z-ai-glm-5.json
@@ -1,16 +1,16 @@
 {
-  "model": "qwen/qwen3-next-80b-a3b-thinking",
+  "model": "z-ai/glm5",
   "system_prompt": "",
-  "display_name": "Qwen 3 Next 80B A3B thinking(NIM)",
+  "display_name": "Z.ai GLM-5 (NIM)",
   "provider": "nvidia_nim",
   "supports_structured_output": true,
-  "context_length": 262144,
-  "default_max_history_messages": 60,
-  "metabolism_keep_messages": 40,
+  "context_length": 205000,
+  "default_max_history_messages": 50,
+  "metabolism_keep_messages": 30,
   "base_url": "https://integrate.api.nvidia.com/v1",
   "api_key_env": "NVIDIA_API_KEY",
-  "convert_system_to_user": true,
   "supports_images": false,
+  "convert_system_to_user": true,
   "request_kwargs": {
     "extra_body": {
       "chat_template_kwargs": {
@@ -25,7 +25,7 @@
       "min": 0,
       "max": 2,
       "step": 0.1,
-      "default": 0.6,
+      "default": 1,
       "label": "Temperature",
       "description": "Controls randomness."
     },
@@ -34,16 +34,16 @@
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "default": 0.7,
+      "default": 0.95,
       "label": "Top P",
       "description": "Nucleus sampling cutoff."
     },
     "max_tokens": {
       "type": "int",
       "min": 32,
-      "max": 8192,
+      "max": 120000,
       "step": 1,
-      "default": 4096,
+      "default": 8000,
       "label": "Max tokens",
       "description": "Upper bound on generated tokens."
     }

--- a/builtin_data/models/openrouter-deepseek-v3.2.json
+++ b/builtin_data/models/openrouter-deepseek-v3.2.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-gpt-4o-2024-11-20.json
+++ b/builtin_data/models/openrouter-gpt-4o-2024-11-20.json
@@ -1,31 +1,23 @@
 {
-  "model": "qwen/qwen3-next-80b-a3b-thinking",
+  "model": "openai/gpt-4o-2024-11-20",
   "system_prompt": "",
-  "display_name": "Qwen 3 Next 80B A3B thinking(NIM)",
-  "provider": "nvidia_nim",
+  "display_name": "GPT-4o 2024-11-20 (Open Router)",
+  "provider": "openai",
   "supports_structured_output": true,
-  "context_length": 262144,
-  "default_max_history_messages": 60,
-  "metabolism_keep_messages": 40,
-  "base_url": "https://integrate.api.nvidia.com/v1",
-  "api_key_env": "NVIDIA_API_KEY",
+  "context_length": 128000,
+  "default_max_history_messages": 40,
+  "metabolism_keep_messages": 20,
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "supports_images": true,
   "convert_system_to_user": true,
-  "supports_images": false,
-  "request_kwargs": {
-    "extra_body": {
-      "chat_template_kwargs": {
-        "enable_thinking": true,
-        "clear_thinking": false
-      }
-    }
-  },
   "parameters": {
     "temperature": {
       "type": "float",
       "min": 0,
       "max": 2,
       "step": 0.1,
-      "default": 0.6,
+      "default": 1,
       "label": "Temperature",
       "description": "Controls randomness."
     },
@@ -34,18 +26,24 @@
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "default": 0.7,
+      "default": 0.95,
       "label": "Top P",
       "description": "Nucleus sampling cutoff."
     },
     "max_tokens": {
       "type": "int",
       "min": 32,
-      "max": 8192,
+      "max": 120000,
       "step": 1,
-      "default": 4096,
+      "default": 8000,
       "label": "Max tokens",
       "description": "Upper bound on generated tokens."
     }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 2.50,
+    "cached_input_per_1m_tokens": 1.25,
+    "output_per_1m_tokens": 10,
+    "currency": "USD"
   }
 }

--- a/builtin_data/models/openrouter-gpt-oss-120b-free.json
+++ b/builtin_data/models/openrouter-gpt-oss-120b-free.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-gpt-oss-120b.json
+++ b/builtin_data/models/openrouter-gpt-oss-120b.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-gpt-oss-20b-free.json
+++ b/builtin_data/models/openrouter-gpt-oss-20b-free.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-gpt-oss-20b.json
+++ b/builtin_data/models/openrouter-gpt-oss-20b.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-kimi-k2.5.json
+++ b/builtin_data/models/openrouter-kimi-k2.5.json
@@ -10,6 +10,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-minimax-m2.1.json
+++ b/builtin_data/models/openrouter-minimax-m2.1.json
@@ -10,6 +10,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": false,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-minimax-m2.5.json
+++ b/builtin_data/models/openrouter-minimax-m2.5.json
@@ -1,21 +1,20 @@
 {
-  "model": "qwen/qwen3-next-80b-a3b-thinking",
+  "model": "minimax/minimax-m2.5",
   "system_prompt": "",
-  "display_name": "Qwen 3 Next 80B A3B thinking(NIM)",
-  "provider": "nvidia_nim",
-  "supports_structured_output": true,
-  "context_length": 262144,
+  "display_name": "MiniMax M2.5 (OpenRouter)",
+  "provider": "openai",
+  "context_length": 196608,
   "default_max_history_messages": 60,
   "metabolism_keep_messages": 40,
-  "base_url": "https://integrate.api.nvidia.com/v1",
-  "api_key_env": "NVIDIA_API_KEY",
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": false,
+  "reasoning_passback_field": "reasoning_details",
   "request_kwargs": {
     "extra_body": {
-      "chat_template_kwargs": {
-        "enable_thinking": true,
-        "clear_thinking": false
+      "reasoning": {
+        "enabled": true
       }
     }
   },
@@ -25,7 +24,7 @@
       "min": 0,
       "max": 2,
       "step": 0.1,
-      "default": 0.6,
+      "default": 1,
       "label": "Temperature",
       "description": "Controls randomness."
     },
@@ -34,18 +33,33 @@
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "default": 0.7,
+      "default": 0.95,
       "label": "Top P",
       "description": "Nucleus sampling cutoff."
+    },
+    "top_k": {
+      "type": "int",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "default": 40,
+      "label": "Top K",
+      "description": "Top K."
     },
     "max_tokens": {
       "type": "int",
       "min": 32,
-      "max": 8192,
+      "max": 4096,
       "step": 1,
       "default": 4096,
       "label": "Max tokens",
       "description": "Upper bound on generated tokens."
     }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 0.3,
+    "cached_input_per_1m_tokens": 0.03,
+    "output_per_1m_tokens": 1.2,
+    "currency": "USD"
   }
 }

--- a/builtin_data/models/openrouter-qwen3.5-397b-a17b.json
+++ b/builtin_data/models/openrouter-qwen3.5-397b-a17b.json
@@ -1,21 +1,21 @@
 {
-  "model": "qwen/qwen3-next-80b-a3b-thinking",
+  "model": "qwen/qwen3.5-397b-a17b",
   "system_prompt": "",
-  "display_name": "Qwen 3 Next 80B A3B thinking(NIM)",
-  "provider": "nvidia_nim",
+  "display_name": "Qwen3.5 397B A17B (Open Router)",
+  "provider": "openai",
   "supports_structured_output": true,
-  "context_length": 262144,
-  "default_max_history_messages": 60,
-  "metabolism_keep_messages": 40,
-  "base_url": "https://integrate.api.nvidia.com/v1",
-  "api_key_env": "NVIDIA_API_KEY",
+  "context_length": 256000,
+  "default_max_history_messages": 80,
+  "metabolism_keep_messages": 60,
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
-  "supports_images": false,
+  "supports_images": true,
+  "reasoning_passback_field": "reasoning_details",
   "request_kwargs": {
     "extra_body": {
-      "chat_template_kwargs": {
-        "enable_thinking": true,
-        "clear_thinking": false
+      "reasoning": {
+        "enabled": true
       }
     }
   },
@@ -24,8 +24,8 @@
       "type": "float",
       "min": 0,
       "max": 2,
-      "step": 0.1,
-      "default": 0.6,
+      "step": 0.01,
+      "default": 0.7,
       "label": "Temperature",
       "description": "Controls randomness."
     },
@@ -34,18 +34,23 @@
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "default": 0.7,
+      "default": 0.8,
       "label": "Top P",
       "description": "Nucleus sampling cutoff."
     },
     "max_tokens": {
       "type": "int",
       "min": 32,
-      "max": 8192,
+      "max": 260000,
       "step": 1,
-      "default": 4096,
+      "default": 8000,
       "label": "Max tokens",
       "description": "Upper bound on generated tokens."
     }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 0.60,
+    "output_per_1m_tokens": 3.60,
+    "currency": "USD"
   }
 }

--- a/builtin_data/models/openrouter-qwen3.5-plus-2026-02-15.json
+++ b/builtin_data/models/openrouter-qwen3.5-plus-2026-02-15.json
@@ -1,21 +1,21 @@
 {
-  "model": "qwen/qwen3-next-80b-a3b-thinking",
+  "model": "qwen/qwen3.5-plus-02-15",
   "system_prompt": "",
-  "display_name": "Qwen 3 Next 80B A3B thinking(NIM)",
-  "provider": "nvidia_nim",
+  "display_name": "Qwen3.5 Plus 2026-02-15 (Open Router)",
+  "provider": "openai",
   "supports_structured_output": true,
-  "context_length": 262144,
-  "default_max_history_messages": 60,
-  "metabolism_keep_messages": 40,
-  "base_url": "https://integrate.api.nvidia.com/v1",
-  "api_key_env": "NVIDIA_API_KEY",
+  "context_length": 256000,
+  "default_max_history_messages": 80,
+  "metabolism_keep_messages": 60,
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
-  "supports_images": false,
+  "supports_images": true,
+  "reasoning_passback_field": "reasoning_details",
   "request_kwargs": {
     "extra_body": {
-      "chat_template_kwargs": {
-        "enable_thinking": true,
-        "clear_thinking": false
+      "reasoning": {
+        "enabled": true
       }
     }
   },
@@ -24,8 +24,8 @@
       "type": "float",
       "min": 0,
       "max": 2,
-      "step": 0.1,
-      "default": 0.6,
+      "step": 0.01,
+      "default": 0.7,
       "label": "Temperature",
       "description": "Controls randomness."
     },
@@ -34,18 +34,23 @@
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "default": 0.7,
+      "default": 0.8,
       "label": "Top P",
       "description": "Nucleus sampling cutoff."
     },
     "max_tokens": {
       "type": "int",
       "min": 32,
-      "max": 8192,
+      "max": 260000,
       "step": 1,
-      "default": 4096,
+      "default": 8000,
       "label": "Max tokens",
       "description": "Upper bound on generated tokens."
     }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 0.40,
+    "output_per_1m_tokens": 2.40,
+    "currency": "USD"
   }
 }

--- a/builtin_data/models/openrouter-step-3.5-flash-free.json
+++ b/builtin_data/models/openrouter-step-3.5-flash-free.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-trinity-large-preview-free.json
+++ b/builtin_data/models/openrouter-trinity-large-preview-free.json
@@ -10,6 +10,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": false,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-z-ai-glm-4.7-flash.json
+++ b/builtin_data/models/openrouter-z-ai-glm-4.7-flash.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-z-ai-glm-4.7.json
+++ b/builtin_data/models/openrouter-z-ai-glm-4.7.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/builtin_data/models/openrouter-z-ai-glm-5.json
+++ b/builtin_data/models/openrouter-z-ai-glm-5.json
@@ -11,6 +11,14 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": false,
   "convert_system_to_user": true,
+  "reasoning_passback_field": "reasoning_details",
+  "request_kwargs": {
+    "extra_body": {
+      "reasoning": {
+        "enabled": true
+      }
+    }
+  },
   "parameters": {
     "temperature": {
       "type": "float",

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/memory/MemoryBrowser.module.css
+++ b/frontend/src/components/memory/MemoryBrowser.module.css
@@ -386,6 +386,68 @@
     position: relative;
 }
 
+/* Thinking/Reasoning block */
+.thinkingBlock {
+    margin-bottom: 8px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, rgba(6, 182, 212, 0.1) 0%, rgba(14, 165, 233, 0.08) 100%);
+    border: 1px solid rgba(6, 182, 212, 0.2);
+    font-size: 0.85rem;
+    overflow: hidden;
+}
+
+.thinkingSummary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    cursor: pointer;
+    user-select: none;
+    color: rgba(6, 182, 212, 0.8);
+    font-weight: 500;
+    font-size: 0.8rem;
+    list-style: none;
+}
+
+.thinkingSummary::-webkit-details-marker {
+    display: none;
+}
+
+.thinkingSummary::after {
+    content: '';
+    margin-left: auto;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid currentColor;
+    opacity: 0.5;
+    transition: transform 0.2s;
+}
+
+.thinkingBlock[open] .thinkingSummary::after {
+    transform: rotate(180deg);
+}
+
+.thinkingContent {
+    padding: 0 12px 10px;
+    color: rgba(180, 180, 200, 0.8);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+:global([data-theme="light"]) .thinkingBlock {
+    background: linear-gradient(135deg, rgba(6, 182, 212, 0.06) 0%, rgba(14, 165, 233, 0.06) 100%);
+    border-color: rgba(6, 182, 212, 0.15);
+}
+
+:global([data-theme="light"]) .thinkingContent {
+    color: rgba(100, 100, 120, 0.85);
+}
+
 .contentCollapsed {
     max-height: 200px;
     overflow: hidden;

--- a/frontend/src/components/memory/MemoryBrowser.tsx
+++ b/frontend/src/components/memory/MemoryBrowser.tsx
@@ -20,7 +20,7 @@ interface MessageItem {
     role: string;
     content: string;
     created_at: number;
-    metadata?: { tags?: string[] };
+    metadata?: { tags?: string[]; reasoning?: string };
 }
 
 interface MemoryBrowserProps {
@@ -688,6 +688,17 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
                                         )}
                                     </div>
                                 </div>
+                                {msg.metadata?.reasoning && (
+                                    <details className={styles.thinkingBlock}>
+                                        <summary className={styles.thinkingSummary}>
+                                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                                            <span>Thought process</span>
+                                        </summary>
+                                        <div className={styles.thinkingContent}>
+                                            {msg.metadata.reasoning}
+                                        </div>
+                                    </details>
+                                )}
                                 <div
                                     className={`${styles.content} ${overflowingMsgs.has(msg.id) && !expandedMsgs.has(msg.id) && editingMsgId !== msg.id ? styles.contentCollapsed : ''}`}
                                     ref={contentRefCallback(msg.id)}

--- a/llm_clients/base.py
+++ b/llm_clients/base.py
@@ -35,6 +35,7 @@ class LLMClient:
 
     def __init__(self, supports_images: bool = False) -> None:
         self._latest_reasoning: List[Dict[str, str]] = []
+        self._latest_reasoning_details: Any = None
         self._latest_attachments: List[Dict[str, Any]] = []
         self._latest_tool_detection: Dict[str, Any] | None = None
         self._latest_usage: Optional[UsageInfo] = None
@@ -87,6 +88,14 @@ class LLMClient:
         entries = self._latest_reasoning
         self._latest_reasoning = []
         return entries
+
+    def _store_reasoning_details(self, details: Any) -> None:
+        self._latest_reasoning_details = details
+
+    def consume_reasoning_details(self) -> Any:
+        details = self._latest_reasoning_details
+        self._latest_reasoning_details = None
+        return details
 
     def _store_tool_detection(self, result: Dict[str, Any] | None) -> None:
         """Store tool detection result for later retrieval."""

--- a/llm_clients/factory.py
+++ b/llm_clients/factory.py
@@ -74,6 +74,11 @@ def get_llm_client(model: str, provider: str, context_length: int, config: Dict 
                 extra_kwargs["structured_output_backend"] = structured_output_backend
                 logging.info("Using structured_output_backend='%s' for model '%s'", structured_output_backend, api_model)
 
+            # Multi-turn reasoning pass-back field (e.g., "reasoning_details" for OpenRouter)
+            reasoning_passback = config.get("reasoning_passback_field")
+            if isinstance(reasoning_passback, str) and reasoning_passback.strip():
+                extra_kwargs["reasoning_passback_field"] = reasoning_passback.strip()
+
         logging.debug("Creating OpenAI client for model '%s' with kwargs: %s", api_model, extra_kwargs)
         client = OpenAIClient(api_model, supports_images=supports_images, **extra_kwargs)
     elif provider == "nvidia_nim":
@@ -94,6 +99,10 @@ def get_llm_client(model: str, provider: str, context_length: int, config: Dict 
             convert_system = config.get("convert_system_to_user")
             if isinstance(convert_system, bool):
                 extra_kwargs["convert_system_to_user"] = convert_system
+
+            reasoning_passback = config.get("reasoning_passback_field")
+            if isinstance(reasoning_passback, str) and reasoning_passback.strip():
+                extra_kwargs["reasoning_passback_field"] = reasoning_passback.strip()
 
         logging.debug("Creating Nvidia NIM client for model '%s' with kwargs: %s", api_model, extra_kwargs)
         client = NvidiaNIMClient(api_model, supports_images=supports_images, **extra_kwargs)

--- a/llm_clients/nvidia_nim.py
+++ b/llm_clients/nvidia_nim.py
@@ -32,6 +32,7 @@ class NvidiaNIMClient(OpenAIClient):
         request_kwargs: Optional[Dict[str, Any]] = None,
         max_image_bytes: Optional[int] = None,
         convert_system_to_user: bool = False,
+        reasoning_passback_field: Optional[str] = None,
     ) -> None:
         # Nvidia NIM doesn't need structured_output_backend parameter
         super().__init__(
@@ -44,6 +45,7 @@ class NvidiaNIMClient(OpenAIClient):
             max_image_bytes=max_image_bytes,
             convert_system_to_user=convert_system_to_user,
             structured_output_backend=None,  # Not used for NIM
+            reasoning_passback_field=reasoning_passback_field,
         )
         self._nim_base_url = base_url or "https://integrate.api.nvidia.com/v1"
         self._nim_api_key = api_key
@@ -234,7 +236,7 @@ class NvidiaNIMClient(OpenAIClient):
         if not use_tools and response_schema:
             try:
                 prepared_messages = _prepare_openai_messages(
-                    messages, self.supports_images, self.max_image_bytes, self.convert_system_to_user
+                    messages, self.supports_images, self.max_image_bytes, self.convert_system_to_user, self.reasoning_passback_field
                 )
                 # Use forced function calling to get structured output
                 text_body = self._create_nim_structured_output_via_tool(


### PR DESCRIPTION
## Summary

- マルチターン推論（reasoning_details パスバック）の完全サポートを追加
- ストリーミング時の reasoning_details を構造化オブジェクトとして収集・保存（プレーン文字列ではなく配列形式）
- SAIMemory に reasoning メタデータを保存し、メモリモーダルのチャットログで折りたたみ表示
- NIM / OpenRouter モデルコンフィグの思考・推論設定を追加・更新
- 新規モデル追加: GLM-5 (NIM), MiniMax M2.5, Qwen3.5, GPT-4o (OpenRouter)

### Backend changes
- `llm_clients/base.py`: `consume_reasoning_details()` (consume-and-clear パターン) 追加
- `llm_clients/openai.py`: ストリーミングデルタから `reasoning_details` 構造化オブジェクトを収集・マージ。パスバック時はリスト型のみ許可（文字列は無視）
- `llm_clients/factory.py`: `reasoning_passback_field` コンフィグ読み取り
- `sea/runtime.py`: ストリーミングパスで reasoning を state に保存、`_emit_speak` に `extra_metadata` パラメータ追加で SAIMemory に reasoning を保存

### Frontend changes
- `MemoryBrowser.tsx`: メタデータの reasoning を折りたたみ表示（チャット UI と同様のパターン）
- `MemoryBrowser.module.css`: thinking block スタイル追加

### Model configs
- NIM モデル: `chat_template_kwargs` で `enable_thinking`/`clear_thinking` 設定追加
- OpenRouter モデル: `reasoning` enabled 設定 + `reasoning_passback_field` 追加
- 新規モデルファイル 5 件追加

## Test plan

- [ ] OpenRouter GLM-5 でマルチターン会話 → 2ターン目以降も 500 エラーなく動作すること
- [ ] NIM GLM-5 で思考付き会話 → 思考内容がチャット UI に表示されること
- [ ] メモリモーダルのチャットログで reasoning が折りたたみ表示されること
- [ ] `reasoning_passback_field` なしのモデル（Gemini, Anthropic 等）が影響を受けないこと
- [ ] 既存の文字列形式 reasoning_details が保存済みメッセージでエラーを起こさないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)