### PR TITLE
Add stop generation button

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -491,6 +491,13 @@ def _store_uploaded_attachment_v2(
         logging.error(f"Failed to process attachment: {e}")
         return None
 
+@router.post("/stop")
+def stop_generation(manager = Depends(get_manager)):
+    """Stop the active LLM generation for the user's current building."""
+    cancelled = manager.cancel_active_generation()
+    return {"cancelled": cancelled}
+
+
 @router.post("/send")
 def send_message(req: SendMessageRequest, manager = Depends(get_manager)):
     building_id = req.building_id or manager.user_current_building_id

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -658,6 +658,25 @@
     background: rgba(6, 182, 212, 0.1);
 }
 
+.stopBtn {
+    background: none;
+    border: none;
+    color: var(--danger, #ef4444);
+    cursor: pointer;
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background 0.2s;
+    min-width: 36px;
+    min-height: 36px;
+}
+
+.stopBtn:hover {
+    background: rgba(239, 68, 68, 0.1);
+}
+
 /* Plus button active state */
 .plusBtnActive {
     background: rgba(6, 182, 212, 0.15);

--- a/manager/runtime.py
+++ b/manager/runtime.py
@@ -435,6 +435,10 @@ class RuntimeService(
         # SEAモード: タイムアウト回避のためのスレッド実行とKeep-Alive
         response_queue = queue.Queue()
 
+        # Stop event for user-initiated cancellation
+        stop_event = threading.Event()
+        self.manager._active_stop_events[building_id] = stop_event
+
         def _enrich_event(event):
             """Enrich streaming events with resolved persona name and avatar URL."""
             if isinstance(event, dict) and event.get("persona_id"):
@@ -453,6 +457,10 @@ class RuntimeService(
         def backend_worker():
             try:
                 for persona in responding_personas:
+                    if stop_event.is_set():
+                        logging.info("[runtime] Stop event detected; breaking persona loop for building %s", building_id)
+                        response_queue.put({"type": "cancelled", "content": "生成を中止しました。"})
+                        break
                     # SEA実行。イベントはコールバック経由でキューに送る
                     self.manager.run_sea_user(
                         persona, building_id, message,
@@ -461,33 +469,56 @@ class RuntimeService(
                         playbook_params=playbook_params,
                         event_callback=_enrich_event
                     )
+                    # Check stop event after each persona completes
+                    if stop_event.is_set():
+                        logging.info("[runtime] Stop event detected after persona %s; breaking loop", persona.persona_id)
+                        response_queue.put({"type": "cancelled", "content": "生成を中止しました。"})
+                        break
             except LLMError as e:
                 logging.error("SEA worker LLM error: %s", e, exc_info=True)
-                response_queue.put(e.to_dict())
+                if stop_event.is_set():
+                    response_queue.put({"type": "cancelled", "content": "生成を中止しました。"})
+                else:
+                    response_queue.put(e.to_dict())
             except Exception as e:
                 logging.error("SEA worker error", exc_info=True)
-                response_queue.put({
-                    "type": "error",
-                    "error_code": "unknown",
-                    "content": "予期せぬエラーが発生しました。",
-                    "technical_detail": str(e),
-                })
+                if stop_event.is_set():
+                    response_queue.put({"type": "cancelled", "content": "生成を中止しました。"})
+                else:
+                    response_queue.put({
+                        "type": "error",
+                        "error_code": "unknown",
+                        "content": "予期せぬエラーが発生しました。",
+                        "technical_detail": str(e),
+                    })
             finally:
                 response_queue.put(None)  # 番兵
 
         threading.Thread(target=backend_worker, daemon=True).start()
 
         # メインスレッド: キューを監視してクライアントに送信
-        while True:
-            try:
-                # 2.0秒待機 (Keep-Aliveのため)
-                item = response_queue.get(timeout=2.0)
-                if item is None:
-                    break
-                yield json.dumps(item, ensure_ascii=False) + "\n"
-            except queue.Empty:
-                # プロキシ等のタイムアウトを防ぐためのPing
-                yield json.dumps({"type": "ping"}, ensure_ascii=False) + "\n"
+        try:
+            while True:
+                try:
+                    # 2.0秒待機 (Keep-Aliveのため)
+                    item = response_queue.get(timeout=2.0)
+                    if item is None:
+                        break
+                    yield json.dumps(item, ensure_ascii=False) + "\n"
+                    # cancelled イベント送信後はストリーム終了
+                    if isinstance(item, dict) and item.get("type") == "cancelled":
+                        # Drain remaining items until sentinel
+                        while True:
+                            remaining = response_queue.get(timeout=5.0)
+                            if remaining is None:
+                                break
+                        break
+                except queue.Empty:
+                    # プロキシ等のタイムアウトを防ぐためのPing
+                    yield json.dumps({"type": "ping"}, ensure_ascii=False) + "\n"
+        finally:
+            # Clean up stop event
+            self.manager._active_stop_events.pop(building_id, None)
 
         bh_sizes = {bid: len(h) for bid, h in self.building_histories.items() if h}
         logging.debug("[runtime] pre-save building_histories sizes: %s", bh_sizes)


### PR DESCRIPTION
## Summary
- LLM生成中に停止ボタンを表示し、押下でAPIサーバー側のトークン生成を即座に停止（従量課金も停止）
- 途中までのテキストはbuilding historyとSAIMemoryに正常保存され、UIにも表示される
- 既存の `CancellationToken` 基盤を活用。サブプレイブック実行時のトークン継承バグも修正

## Changes
- **`api/routes/chat.py`**: `POST /api/chat/stop` エンドポイント追加
- **`saiverse/saiverse_manager.py`**: `cancel_active_generation()` メソッド + `_active_stop_events` 管理
- **`manager/runtime.py`**: `backend_worker` 内の stop_event チェック + cancelled イベント送信
- **`sea/runtime.py`**: ストリーミングループ内キャンセルチェック + `stream_iter.close()` でHTTP切断 + サブプレイブックへのCancellationToken継承修正
- **`frontend/src/app/page.tsx`**: 停止ボタンUI + `handleStopGeneration` + `cancelled` イベントハンドリング
- **`frontend/src/app/page.module.css`**: `.stopBtn` スタイル

## Test plan
- [x] ストリーミング中に停止ボタン押下 → 途中テキストが残り、loadingStatusが消える
- [x] 停止後に再度メッセージ送信 → 正常に動作
- [x] 停止ボタンを押さない場合 → 従来通りの動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)