### PR TITLE
Add city-scoped playbook execution permission system

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -606,3 +606,26 @@ def preview_context(req: PreviewRequest, manager=Depends(get_manager)):
     except Exception as e:
         logging.error("Error previewing context: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# ── Playbook permission response ──────────────────────────────────
+
+class PermissionResponseRequest(BaseModel):
+    request_id: str
+    decision: str  # allow | deny | always_allow | never_use
+
+
+@router.post("/permission-response")
+def respond_to_permission(req: PermissionResponseRequest, manager=Depends(get_manager)):
+    """Respond to a playbook execution permission request."""
+    valid_decisions = ("allow", "deny", "always_allow", "never_use")
+    if req.decision not in valid_decisions:
+        raise HTTPException(status_code=400, detail=f"Invalid decision. Must be one of: {valid_decisions}")
+
+    event = manager._pending_permission_requests.get(req.request_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Permission request not found or expired")
+
+    manager._permission_responses[req.request_id] = req.decision
+    event.set()  # Wake up the waiting worker thread
+    return {"success": True}

--- a/builtin_data/tools/list_available_playbooks.py
+++ b/builtin_data/tools/list_available_playbooks.py
@@ -10,8 +10,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from database.paths import default_db_path
-from database.models import Base, Playbook
-from tools.context import get_active_persona_id, get_active_manager
+from database.models import Base, Playbook, PlaybookPermission
+from tools.context import get_active_persona_id, get_active_manager, get_auto_mode
 from tools.core import ToolSchema
 
 
@@ -19,13 +19,16 @@ def list_available_playbooks(persona_id: Optional[str] = None, building_id: Opti
     """List playbooks available for router selection.
 
     Returns router_callable=True playbooks that the persona has access to based on scope as a JSON string.
+    Filters out playbooks whose city-scoped permission is ``blocked`` or ``user_only``.
+    In auto_mode, also filters out ``ask_every_time`` playbooks (no user present to confirm).
     """
     # Get context if not provided
     if not persona_id:
         persona_id = get_active_persona_id()
 
+    manager = get_active_manager()
+
     if not building_id:
-        manager = get_active_manager()
         if manager:
             # Get current building from in-memory PersonaCore
             try:
@@ -42,9 +45,12 @@ def list_available_playbooks(persona_id: Optional[str] = None, building_id: Opti
 
     # Check developer mode
     developer_mode = False
-    manager = get_active_manager()
     if manager and hasattr(manager, "state"):
         developer_mode = getattr(manager.state, "developer_mode", False)
+
+    # City-scoped permission overrides
+    city_id = getattr(manager, "city_id", None) if manager else None
+    auto_mode = get_auto_mode()
 
     with Session() as session:
         # Get all router_callable playbooks
@@ -52,6 +58,19 @@ def list_available_playbooks(persona_id: Optional[str] = None, building_id: Opti
         if not developer_mode:
             query = query.filter(Playbook.dev_only == False)
         all_playbooks = query.all()
+
+        # Load permission overrides for this city in one query
+        permissions: dict[str, str] = {}
+        if city_id is not None:
+            try:
+                perm_rows = (
+                    session.query(PlaybookPermission)
+                    .filter(PlaybookPermission.CITYID == city_id)
+                    .all()
+                )
+                permissions = {r.playbook_name: r.permission_level for r in perm_rows}
+            except Exception:
+                _log.warning("Failed to load playbook permissions for city %s", city_id, exc_info=True)
 
         available = []
         for pb in all_playbooks:
@@ -66,6 +85,14 @@ def list_available_playbooks(persona_id: Optional[str] = None, building_id: Opti
                 include = (pb.building_id == building_id)
             else:
                 include = False
+
+            # Check city-scoped permission
+            if include:
+                perm = permissions.get(pb.name, "ask_every_time")
+                if perm in ("blocked", "user_only"):
+                    include = False
+                elif perm == "ask_every_time" and auto_mode:
+                    include = False  # No user present to confirm in auto mode
 
             if include:
                 available.append({

--- a/database/models.py
+++ b/database/models.py
@@ -152,6 +152,24 @@ class Playbook(Base):
     created_at = Column(DateTime, server_default=func.now(), nullable=False)
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
 
+
+class PlaybookPermission(Base):
+    """City-scoped playbook execution permission levels.
+
+    Stored separately from Playbook table so force-updating playbooks
+    (via import_all_playbooks.py --force) does not overwrite user preferences.
+    """
+    __tablename__ = "playbook_permission"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    CITYID = Column(Integer, ForeignKey("city.CITYID"), nullable=False)
+    playbook_name = Column(String(255), nullable=False)
+    permission_level = Column(String(32), nullable=False, default="ask_every_time")
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    __table_args__ = (
+        UniqueConstraint("CITYID", "playbook_name", name="uq_city_playbook_perm"),
+    )
+
+
 class Blueprint(Base):
     __tablename__ = "blueprint"
     BLUEPRINT_ID = Column(Integer, primary_key=True, autoincrement=True)

--- a/frontend/src/components/GlobalSettingsModal.module.css
+++ b/frontend/src/components/GlobalSettingsModal.module.css
@@ -908,6 +908,104 @@
     }
 }
 
+/* ── Playbook Permissions Tab ── */
+.pbSubtitle {
+    font-size: 0.8rem;
+    color: #94a3b8;
+    margin: 0.25rem 0 0;
+}
+
+.pbEmpty {
+    text-align: center;
+    padding: 2rem;
+    color: #94a3b8;
+}
+
+.pbList {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.pbItem {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    gap: 1rem;
+}
+
+.pbItemInfo {
+    flex: 1;
+    min-width: 0;
+}
+
+.pbItemName {
+    font-size: 0.875rem;
+    color: #f1f5f9;
+    font-weight: 500;
+}
+
+.pbItemDesc {
+    font-size: 0.75rem;
+    color: #94a3b8;
+    margin-top: 0.125rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.pbSelect {
+    flex-shrink: 0;
+    background: #1e293b;
+    color: #d1d5db;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+
+.pbSelect:focus {
+    outline: none;
+    border-color: #3b82f6;
+}
+
+/* ── Light Mode: Playbook Permissions ── */
+:global([data-theme="light"]) .pbSubtitle {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .pbEmpty {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .pbItem {
+    background: #f8fafc;
+    border-color: #e2e8f0;
+}
+
+:global([data-theme="light"]) .pbItemName {
+    color: #1f2937;
+}
+
+:global([data-theme="light"]) .pbItemDesc {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .pbSelect {
+    background: #ffffff;
+    color: #374151;
+    border-color: #cbd5e1;
+}
+
+:global([data-theme="light"]) .pbSelect:focus {
+    border-color: #3b82f6;
+}
+
 /* ── About Tab ── */
 .aboutContainer {
     max-width: 600px;

--- a/frontend/src/components/PlaybookPermissionDialog.module.css
+++ b/frontend/src/components/PlaybookPermissionDialog.module.css
@@ -1,0 +1,174 @@
+.modal {
+    background: #1f2937;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 440px;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1.25rem 1.5rem 1rem;
+}
+
+.icon {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #374151;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #60a5fa;
+}
+
+.headerText h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: #f9fafb;
+    font-weight: 600;
+}
+
+.headerText p {
+    margin: 0.25rem 0 0;
+    font-size: 0.8rem;
+    color: #9ca3af;
+}
+
+.body {
+    padding: 0 1.5rem 1rem;
+}
+
+.description {
+    font-size: 0.875rem;
+    color: #d1d5db;
+    line-height: 1.5;
+    margin: 0;
+}
+
+.timer {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #6b7280;
+    text-align: right;
+}
+
+.timerWarn {
+    color: #f59e0b;
+}
+
+.actions {
+    padding: 0.75rem 1.5rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.primaryRow {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.primaryRow button {
+    flex: 1;
+    padding: 0.625rem 1rem;
+    border-radius: 8px;
+    border: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, opacity 0.15s;
+}
+
+.allowBtn {
+    background: #3b82f6;
+    color: #fff;
+}
+
+.allowBtn:hover {
+    background: #2563eb;
+}
+
+.denyBtn {
+    background: #374151;
+    color: #d1d5db;
+}
+
+.denyBtn:hover {
+    background: #4b5563;
+}
+
+.secondaryRow {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+}
+
+.secondaryRow button {
+    background: none;
+    border: none;
+    font-size: 0.75rem;
+    color: #6b7280;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    transition: color 0.15s;
+}
+
+.secondaryRow button:hover {
+    color: #d1d5db;
+}
+
+/* ── Light mode overrides ── */
+
+:global([data-theme="light"]) .modal {
+    background: #ffffff;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+}
+
+:global([data-theme="light"]) .icon {
+    background: #e2e8f0;
+    color: #3b82f6;
+}
+
+:global([data-theme="light"]) .headerText h3 {
+    color: #1e293b;
+}
+
+:global([data-theme="light"]) .headerText p {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .description {
+    color: #475569;
+}
+
+:global([data-theme="light"]) .timer {
+    color: #94a3b8;
+}
+
+:global([data-theme="light"]) .timerWarn {
+    color: #d97706;
+}
+
+:global([data-theme="light"]) .denyBtn {
+    background: #e2e8f0;
+    color: #475569;
+}
+
+:global([data-theme="light"]) .denyBtn:hover {
+    background: #cbd5e1;
+}
+
+:global([data-theme="light"]) .secondaryRow button {
+    color: #94a3b8;
+}
+
+:global([data-theme="light"]) .secondaryRow button:hover {
+    color: #475569;
+}

--- a/frontend/src/components/PlaybookPermissionDialog.tsx
+++ b/frontend/src/components/PlaybookPermissionDialog.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Shield } from 'lucide-react';
+import ModalOverlay from './common/ModalOverlay';
+import styles from './PlaybookPermissionDialog.module.css';
+
+export interface PermissionRequestData {
+    requestId: string;
+    playbookName: string;
+    playbookDisplayName: string;
+    playbookDescription: string;
+    personaName: string;
+}
+
+interface PlaybookPermissionDialogProps {
+    request: PermissionRequestData;
+    onRespond: (requestId: string, decision: string) => void;
+}
+
+const TIMEOUT_SEC = 60;
+
+export default function PlaybookPermissionDialog({ request, onRespond }: PlaybookPermissionDialogProps) {
+    const [remaining, setRemaining] = useState(TIMEOUT_SEC);
+
+    useEffect(() => {
+        setRemaining(TIMEOUT_SEC);
+        const interval = setInterval(() => {
+            setRemaining(prev => {
+                if (prev <= 1) {
+                    clearInterval(interval);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+        return () => clearInterval(interval);
+    }, [request.requestId]);
+
+    const respond = useCallback((decision: string) => {
+        onRespond(request.requestId, decision);
+    }, [request.requestId, onRespond]);
+
+    return (
+        <ModalOverlay onClose={() => respond('deny')}>
+            <div className={styles.modal}>
+                <div className={styles.header}>
+                    <div className={styles.icon}>
+                        <Shield size={18} />
+                    </div>
+                    <div className={styles.headerText}>
+                        <h3>Playbook実行の確認</h3>
+                        <p>{request.personaName} が実行しようとしています</p>
+                    </div>
+                </div>
+
+                <div className={styles.body}>
+                    <p className={styles.description}>
+                        <strong>{request.playbookDisplayName}</strong>
+                        {request.playbookDescription && (
+                            <><br />{request.playbookDescription}</>
+                        )}
+                    </p>
+                    <div className={`${styles.timer} ${remaining <= 10 ? styles.timerWarn : ''}`}>
+                        {remaining > 0 ? `${remaining}秒後に自動拒否` : 'タイムアウト...'}
+                    </div>
+                </div>
+
+                <div className={styles.actions}>
+                    <div className={styles.primaryRow}>
+                        <button className={styles.allowBtn} onClick={() => respond('allow')}>
+                            許可
+                        </button>
+                        <button className={styles.denyBtn} onClick={() => respond('deny')}>
+                            拒否
+                        </button>
+                    </div>
+                    <div className={styles.secondaryRow}>
+                        <button onClick={() => respond('always_allow')}>
+                            常に許可する
+                        </button>
+                        <button onClick={() => respond('never_use')}>
+                            以後使用しない
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </ModalOverlay>
+    );
+}

--- a/saiverse/saiverse_manager.py
+++ b/saiverse/saiverse_manager.py
@@ -139,6 +139,10 @@ class SAIVerseManager(
         self.state.world_items = self.world_items
         self.state.persona_pending_events = self.persona_pending_events
 
+        # --- Playbook permission request synchronisation (transient, in-memory) ---
+        self._pending_permission_requests: dict[str, threading.Event] = {}
+        self._permission_responses: dict[str, str] = {}
+
         self.personas = self.state.personas
         self.visiting_personas = self.state.visiting_personas
         self.avatar_map = self.state.avatar_map

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -292,8 +292,8 @@ class SEARuntime:
         compiled = compile_playbook(
             playbook,
             llm_node_factory=lambda node_def: self._lg_llm_node(node_def, persona, building_id, playbook, event_callback),
-            tool_node_factory=lambda node_def: self._lg_tool_node(node_def, persona, playbook, event_callback),
-            tool_call_node_factory=lambda node_def: self._lg_tool_call_node(node_def, persona, playbook, event_callback),
+            tool_node_factory=lambda node_def: self._lg_tool_node(node_def, persona, playbook, event_callback, auto_mode=auto_mode),
+            tool_call_node_factory=lambda node_def: self._lg_tool_call_node(node_def, persona, playbook, event_callback, auto_mode=auto_mode),
             speak_node=lambda state: self._lg_speak_node(state, persona, building_id, playbook, _lg_outputs, event_callback),
             think_node=lambda state: self._lg_think_node(state, persona, playbook, _lg_outputs, event_callback),
             say_node_factory=lambda node_def: self._lg_say_node(node_def, persona, building_id, playbook, _lg_outputs, event_callback),
@@ -1607,7 +1607,7 @@ class SEARuntime:
         else:
             state["selected_args"] = {"input": state.get("input")}
 
-    def _lg_tool_node(self, node_def: Any, persona: Any, playbook: PlaybookSchema, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None):
+    def _lg_tool_node(self, node_def: Any, persona: Any, playbook: PlaybookSchema, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None, auto_mode: bool = False):
         from tools import TOOL_REGISTRY
         from tools.context import persona_context
 
@@ -1658,11 +1658,11 @@ class SEARuntime:
 
                 # Execute tool with persona context
                 if persona_id and persona_dir:
-                    with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name):
+                    with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name, auto_mode=auto_mode):
                         result = tool_func(**kwargs) if callable(tool_func) else None
                 else:
                     result = tool_func(**kwargs) if callable(tool_func) else None
-                
+
                 # Log tool result
                 result_str = str(result)
                 result_preview = result_str[:200] + "..." if len(result_str) > 200 else result_str
@@ -1708,7 +1708,7 @@ class SEARuntime:
 
         return node
 
-    def _lg_tool_call_node(self, node_def: Any, persona: Any, playbook: PlaybookSchema, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None):
+    def _lg_tool_call_node(self, node_def: Any, persona: Any, playbook: PlaybookSchema, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None, auto_mode: bool = False):
         """Execute a tool dynamically based on an LLM node's tool call decision.
 
         Reads tool name and arguments from state (stored by an LLM node with
@@ -1772,7 +1772,7 @@ class SEARuntime:
                 LOGGER.info("[sea][tool_call] CALL %s (persona=%s) args=%s", tool_name, persona_id, tool_args)
 
                 if persona_id and persona_dir:
-                    with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name):
+                    with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name, auto_mode=auto_mode):
                         result = tool_func(**tool_args)
                 else:
                     result = tool_func(**tool_args)
@@ -1811,6 +1811,155 @@ class SEARuntime:
 
         return node
 
+    # ── Playbook permission helpers ──────────────────────────────────
+    def _get_playbook_permission(self, city_id: int, playbook_name: str) -> str:
+        """Return the permission level for *playbook_name* in *city_id*.
+
+        When no row exists the default is ``"ask_every_time"``.
+        """
+        from database.models import PlaybookPermission
+        try:
+            db = self.manager.SessionLocal()
+            try:
+                row = (
+                    db.query(PlaybookPermission)
+                    .filter(
+                        PlaybookPermission.CITYID == city_id,
+                        PlaybookPermission.playbook_name == playbook_name,
+                    )
+                    .first()
+                )
+                return row.permission_level if row else "ask_every_time"
+            finally:
+                db.close()
+        except Exception:
+            LOGGER.warning("[sea][perm] Failed to query permission for %s", playbook_name, exc_info=True)
+            return "ask_every_time"
+
+    def _set_playbook_permission(self, city_id: int, playbook_name: str, level: str) -> None:
+        """Insert or update the permission level for *playbook_name* in *city_id*."""
+        from database.models import PlaybookPermission
+        try:
+            db = self.manager.SessionLocal()
+            try:
+                row = (
+                    db.query(PlaybookPermission)
+                    .filter(
+                        PlaybookPermission.CITYID == city_id,
+                        PlaybookPermission.playbook_name == playbook_name,
+                    )
+                    .first()
+                )
+                if row:
+                    row.permission_level = level
+                else:
+                    db.add(PlaybookPermission(
+                        CITYID=city_id,
+                        playbook_name=playbook_name,
+                        permission_level=level,
+                    ))
+                db.commit()
+                LOGGER.info("[sea][perm] Set %s → %s (city=%s)", playbook_name, level, city_id)
+            finally:
+                db.close()
+        except Exception:
+            LOGGER.warning("[sea][perm] Failed to set permission for %s", playbook_name, exc_info=True)
+
+    def _request_playbook_permission(
+        self,
+        playbook_name: str,
+        persona: Any,
+        event_callback: Optional[Callable[[Dict[str, Any]], None]],
+    ) -> str:
+        """Send a ``permission_request`` event and block until the user responds.
+
+        Returns one of: ``"allow"``, ``"deny"``, ``"always_allow"``,
+        ``"never_use"``, or ``"timeout"``.
+        """
+        import threading as _threading
+
+        if not event_callback:
+            LOGGER.warning("[sea][perm] No event_callback — auto-denying %s", playbook_name)
+            return "deny"
+
+        request_id = str(uuid.uuid4())
+        event = _threading.Event()
+        self.manager._pending_permission_requests[request_id] = event
+
+        # Look up display name / description for the dialog
+        display_name = playbook_name
+        description = ""
+        try:
+            db = self.manager.SessionLocal()
+            try:
+                pb = db.query(PlaybookModel).filter(PlaybookModel.name == playbook_name).first()
+                if pb:
+                    display_name = pb.display_name or pb.name
+                    description = pb.description or ""
+            finally:
+                db.close()
+        except Exception:
+            LOGGER.warning("[sea][perm] Failed to look up playbook info for %s", playbook_name, exc_info=True)
+
+        persona_id = getattr(persona, "persona_id", None)
+        persona_name = getattr(persona, "persona_name", None)
+
+        event_callback({
+            "type": "permission_request",
+            "request_id": request_id,
+            "playbook_name": playbook_name,
+            "playbook_display_name": display_name,
+            "playbook_description": description,
+            "persona_id": persona_id,
+            "persona_name": persona_name,
+        })
+        LOGGER.info("[sea][perm] Sent permission_request for %s (id=%s)", playbook_name, request_id)
+
+        # Block until the user responds or timeout
+        timeout_sec = 60
+        responded = event.wait(timeout=timeout_sec)
+
+        # Cleanup
+        self.manager._pending_permission_requests.pop(request_id, None)
+        response = self.manager._permission_responses.pop(request_id, None)
+
+        if not responded or response is None:
+            LOGGER.info("[sea][perm] Permission request %s timed out after %ds", request_id, timeout_sec)
+            if event_callback:
+                event_callback({
+                    "type": "warning",
+                    "content": f"Playbook実行の許可リクエストがタイムアウトしました（{display_name}）。スキップします。",
+                    "warning_code": "permission_timeout",
+                    "display": "toast",
+                })
+            return "timeout"
+
+        LOGGER.info("[sea][perm] Permission response for %s: %s", playbook_name, response)
+        return response
+
+    def _notify_persona_permission_result(
+        self,
+        state: Dict[str, Any],
+        persona: Any,
+        playbook_name: str,
+        message: str,
+        event_callback: Optional[Callable[[Dict[str, Any]], None]],
+    ) -> None:
+        """Inform the persona about a permission denial/timeout.
+
+        Records the result in state, message history, and SAIMemory so the
+        persona can adjust its response accordingly.
+        """
+        state["last"] = message
+        self._append_tool_result_message(state, playbook_name, message)
+        if not self._store_memory(
+            persona, message,
+            role="system",
+            tags=["permission", "denied", playbook_name],
+            pulse_id=state.get("pulse_id"),
+        ):
+            LOGGER.warning("[sea][perm] Failed to store permission result to SAIMemory")
+
     def _lg_exec_node(
         self,
         node_def: Any,
@@ -1845,6 +1994,47 @@ class SEARuntime:
                 sub_input = state.get("inputs", {}).get("input")
 
             eff_bid = self._effective_building_id(persona, building_id)
+
+            # ── Playbook permission check ──
+            clean_name = str(sub_name).strip()
+            if clean_name != "basic_chat":
+                city_id = getattr(self.manager, "city_id", None)
+                if city_id is not None:
+                    perm = self._get_playbook_permission(city_id, clean_name)
+                    log_sea_trace(playbook.name, node_id, "PERM", f"{clean_name} → {perm}")
+
+                    if perm in ("blocked", "user_only"):
+                        denial_msg = f"Playbook '{clean_name}' is not available (permission: {perm})"
+                        self._notify_persona_permission_result(state, persona, clean_name, denial_msg, event_callback)
+                        return state
+
+                    if perm == "ask_every_time":
+                        if auto_mode:
+                            denial_msg = f"Playbook '{clean_name}' requires user permission but running in auto mode. Skipped."
+                            self._notify_persona_permission_result(state, persona, clean_name, denial_msg, event_callback)
+                            return state
+
+                        response = self._request_playbook_permission(clean_name, persona, event_callback)
+
+                        if response in ("deny", "timeout"):
+                            denial_msg = (
+                                f"User denied execution of playbook '{clean_name}'. Please respond without using this tool."
+                                if response == "deny"
+                                else f"Permission request for playbook '{clean_name}' timed out. Please respond without using this tool."
+                            )
+                            self._notify_persona_permission_result(state, persona, clean_name, denial_msg, event_callback)
+                            return state
+
+                        if response == "always_allow":
+                            self._set_playbook_permission(city_id, clean_name, "auto_allow")
+
+                        if response == "never_use":
+                            denial_msg = f"User disabled playbook '{clean_name}'. This playbook will not be available in future. Please respond without using this tool."
+                            self._set_playbook_permission(city_id, clean_name, "user_only")
+                            self._notify_persona_permission_result(state, persona, clean_name, denial_msg, event_callback)
+                            return state
+
+                    # perm == "auto_allow" or allowed via dialog → continue
 
             # Determine execution mode
             execution = getattr(node_def, "execution", "inline") or "inline"

--- a/tools/context.py
+++ b/tools/context.py
@@ -9,6 +9,7 @@ _PERSONA_ID: ContextVar[Optional[str]] = ContextVar("saiverse_persona_id", defau
 _PERSONA_PATH: ContextVar[Optional[str]] = ContextVar("saiverse_persona_path", default=None)
 _MANAGER: ContextVar[Optional[Any]] = ContextVar("saiverse_manager_ref", default=None)
 _PLAYBOOK_NAME: ContextVar[Optional[str]] = ContextVar("saiverse_playbook_name", default=None)
+_AUTO_MODE: ContextVar[bool] = ContextVar("saiverse_auto_mode", default=False)
 
 
 def get_active_persona_id() -> Optional[str]:
@@ -28,18 +29,24 @@ def get_active_playbook_name() -> Optional[str]:
     return _PLAYBOOK_NAME.get()
 
 
+def get_auto_mode() -> bool:
+    return _AUTO_MODE.get()
+
+
 @contextmanager
 def persona_context(
     persona_id: str,
     persona_path: Path | str,
     manager: Optional[Any] = None,
     playbook_name: Optional[str] = None,
+    auto_mode: bool = False,
 ) -> Iterator[None]:
     """Temporarily set the active persona identity for tool execution."""
     token_id = _PERSONA_ID.set(persona_id)
     token_path = _PERSONA_PATH.set(str(persona_path))
     token_manager = _MANAGER.set(manager)
     token_playbook = _PLAYBOOK_NAME.set(playbook_name)
+    token_auto = _AUTO_MODE.set(auto_mode)
     try:
         yield
     finally:
@@ -47,3 +54,4 @@ def persona_context(
         _PERSONA_PATH.reset(token_path)
         _MANAGER.reset(token_manager)
         _PLAYBOOK_NAME.reset(token_playbook)
+        _AUTO_MODE.reset(token_auto)


### PR DESCRIPTION
## Summary
- ペルソナが意図しないPlaybookを実行する問題に対応するため、City単位のPlaybook実行権限システムを追加
- 4段階の権限レベル: `blocked`(DB直接), `user_only`(手動選択のみ), `ask_every_time`(確認ダイアログ/デフォルト), `auto_allow`(自動実行)
- 権限データはPlaybookテーブルとは独立した`PlaybookPermission`テーブルに保存（force-updateで上書きされない）

## Changes

### Backend
- **database/models.py**: `PlaybookPermission` テーブル追加（City×Playbook名のユニーク制約）
- **sea/runtime.py**: `_lg_exec_node`に権限チェック挿入、確認ダイアログ送信・応答待機、ペルソナへの3層通知（state/message history/SAIMemory）
- **tools/context.py**: `_AUTO_MODE` ContextVar追加（自動パルス判定をツール層に伝播）
- **builtin_data/tools/list_available_playbooks.py**: 権限レベルに基づくプレフィルタリング（auto_modeではask_every_timeも除外）
- **saiverse/saiverse_manager.py**: 権限応答の同期用dict追加
- **api/routes/chat.py**: `POST /permission-response` エンドポイント追加
- **api/routes/config.py**: `GET/POST /api/config/playbook-permissions` CRUD追加

### Frontend
- **PlaybookPermissionDialog**: 確認ダイアログ（許可/拒否/常に許可/以後使用しない + 60秒カウントダウン）
- **page.tsx**: NDJSONストリームの`permission_request`イベントハンドリング
- **GlobalSettingsModal**: 「Playbook権限」タブ追加（権限レベルの一覧・変更UI）
- ライトモード/ダークモード両対応

## Test plan
- [ ] 新規CityでPlaybook権限がデフォルト(`ask_every_time`)で動作することを確認
- [ ] チャットでペルソナがPlaybookを選択した際に確認ダイアログが表示されることを確認
- [ ] 「常に許可する」選択後、同Playbookが確認なしで実行されることを確認
- [ ] 「以後使用しない」選択後、同Playbookがリストから除外されることを確認
- [ ] 60秒タイムアウト後に自動拒否されることを確認
- [ ] 自動パルス時にask_every_timeのPlaybookがルーターに提示されないことを確認
- [ ] グローバル設定UIで権限レベルの変更が反映されることを確認
- [ ] ライトモード/ダークモードの切り替えでUIが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)