### PR TITLE
Fix usage monitor daily chart ignoring period filter

### DIFF
--- a/frontend/src/app/usage/page.tsx
+++ b/frontend/src/app/usage/page.tsx
@@ -86,10 +86,13 @@ export default function UsagePage() {
         try {
             const personaParam = selectedPersona ? `&persona_id=${selectedPersona}` : '';
             const categoryParam = selectedCategory ? `&category=${selectedCategory}` : '';
+            const startDate = new Date();
+            startDate.setDate(startDate.getDate() - days);
+            const startDateStr = startDate.toISOString().split('T')[0];
 
             const [summaryRes, dailyRes, personasRes, categoriesRes, categoryUsageRes] = await Promise.all([
                 fetch(`/api/usage/summary?days=${days}${personaParam}${categoryParam}`),
-                fetch(`/api/usage/daily?${personaParam}${categoryParam}`),
+                fetch(`/api/usage/daily?start_date=${startDateStr}${personaParam}${categoryParam}`),
                 fetch('/api/usage/personas'),
                 fetch('/api/usage/categories'),
                 fetch(`/api/usage/by-category?days=${days}${personaParam}`),


### PR DESCRIPTION
## Summary
- API使用状況モニターのグラフが期間フィルター（7日/30日/90日）を無視していた問題を修正
- `/api/usage/daily` の呼び出しに `start_date` が渡されておらず、常にバックエンドのデフォルト（30日）が適用されていた
- フロントエンドで `days` から `start_date` を計算してAPIに渡すように修正

## Test plan
- [ ] 「過去7日間」を選択して、グラフが7日分だけ表示されることを確認
- [ ] 「過去30日間」「過去90日間」でも正しく期間が切り替わることを確認
- [ ] サマリーカード・カテゴリ別の値とグラフの期間が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)