### PR TITLE
Fix message edit resetting timestamp seconds to zero

### DIFF
--- a/frontend/src/components/memory/MemoryBrowser.tsx
+++ b/frontend/src/components/memory/MemoryBrowser.tsx
@@ -43,6 +43,7 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
     const [editingMsgId, setEditingMsgId] = useState<string | null>(null);
     const [editContent, setEditContent] = useState("");
     const [editTimestamp, setEditTimestamp] = useState<string>("");
+    const [originalEditTimestamp, setOriginalEditTimestamp] = useState<string>("");
 
     // Selection state for bulk delete
     const [selectionMode, setSelectionMode] = useState(false);
@@ -227,18 +228,21 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
     const handleEditStart = (msg: MessageItem) => {
         setEditingMsgId(msg.id);
         setEditContent(msg.content);
-        // Convert Unix timestamp to datetime-local format (local time)
+        // Convert Unix timestamp to datetime-local format (local time, including seconds)
         if (msg.created_at) {
             const d = new Date(msg.created_at * 1000);
-            // Format as YYYY-MM-DDTHH:mm in local time
             const year = d.getFullYear();
             const month = (d.getMonth() + 1).toString().padStart(2, '0');
             const day = d.getDate().toString().padStart(2, '0');
             const hours = d.getHours().toString().padStart(2, '0');
             const minutes = d.getMinutes().toString().padStart(2, '0');
-            setEditTimestamp(`${year}-${month}-${day}T${hours}:${minutes}`);
+            const seconds = d.getSeconds().toString().padStart(2, '0');
+            const formatted = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+            setEditTimestamp(formatted);
+            setOriginalEditTimestamp(formatted);
         } else {
             setEditTimestamp("");
+            setOriginalEditTimestamp("");
         }
     };
 
@@ -246,13 +250,15 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
         setEditingMsgId(null);
         setEditContent("");
         setEditTimestamp("");
+        setOriginalEditTimestamp("");
     };
 
     const handleEditSave = async (msgId: string) => {
         try {
             const body: { content?: string; created_at?: number } = {};
             body.content = editContent;
-            if (editTimestamp) {
+            // Only send created_at if the timestamp was actually changed
+            if (editTimestamp && editTimestamp !== originalEditTimestamp) {
                 const ts = new Date(editTimestamp).getTime() / 1000;
                 body.created_at = ts;
             }
@@ -264,6 +270,7 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
             if (res.ok) {
                 setEditingMsgId(null);
                 setEditTimestamp("");
+                setOriginalEditTimestamp("");
                 // Refresh current page
                 if (selectedThreadId) loadMessages(selectedThreadId, page);
             } else {
@@ -616,6 +623,7 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
                             <label>日時:</label>
                             <input
                                 type="datetime-local"
+                                step="1"
                                 value={newMsgTimestamp}
                                 onChange={(e) => setNewMsgTimestamp(e.target.value)}
                                 className={styles.timestampInput}
@@ -709,6 +717,7 @@ export default function MemoryBrowser({ personaId }: MemoryBrowserProps) {
                                                 <label>日時:</label>
                                                 <input
                                                     type="datetime-local"
+                                                    step="1"
                                                     className={styles.editTimestampInput}
                                                     value={editTimestamp}
                                                     onChange={(e) => setEditTimestamp(e.target.value)}


### PR DESCRIPTION
## Summary
- Memory Browserのメッセージ編集で、秒部分が00にリセットされてしまい発言順序がズレる問題を修正
- `datetime-local` 入力に `step="1"` を追加して秒の指定を可能に
- タイムスタンプを変更していない場合は `created_at` をAPIに送信しないよう変更（内容のみの編集で時刻が変わらなくなる）

## Test plan
- [ ] メッセージを編集して内容のみ変更 → タイムスタンプ（秒含む）が変わらないことを確認
- [ ] メッセージ編集時に秒フィールドが表示・入力可能であることを確認
- [ ] タイムスタンプを意図的に変更した場合、正しく反映されることを確認
- [ ] 新規メッセージ追加時も秒指定が可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)