### PR TITLE
Fix test collection errors and outdated model config assertions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,14 @@
 """Shared pytest fixtures and helpers for SAIVerse test suite."""
-import importlib.util
-import os
+
 import sys
 from pathlib import Path
 
-import pytest
+import pytest  # noqa: F401
 
 # Ensure project root is in sys.path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-
-def load_builtin_tool(name: str):
-    """Load a tool module from builtin_data/tools/ by name.
-
-    Usage::
-
-        calculator = load_builtin_tool("calculator")
-        result = calculator.calculate_expression("1+2")
-    """
-    tool_path = PROJECT_ROOT / "builtin_data" / "tools" / f"{name}.py"
-    if not tool_path.exists():
-        raise FileNotFoundError(f"Tool not found: {tool_path}")
-    spec = importlib.util.spec_from_file_location(f"_builtin_tools.{name}", tool_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+# Re-export for backward compatibility
+from tool_loader import load_builtin_tool  # noqa: E402, F401

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,6 +1,6 @@
 import unittest
 
-from conftest import load_builtin_tool
+from tool_loader import load_builtin_tool
 
 calculator = load_builtin_tool("calculator")
 calculate_expression = calculator.calculate_expression

--- a/tests/test_image_generator.py
+++ b/tests/test_image_generator.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from conftest import load_builtin_tool
+from tool_loader import load_builtin_tool
 from tools.core import ToolResult
 
 _mod = load_builtin_tool("image_generator")

--- a/tests/test_model_configs.py
+++ b/tests/test_model_configs.py
@@ -19,7 +19,7 @@ class TestGetModelProvider(unittest.TestCase):
 class TestGetContextLength(unittest.TestCase):
     def test_known_model_returns_configured_length(self):
         length = model_configs.get_context_length("claude-sonnet-4-5")
-        self.assertEqual(length, 64000)
+        self.assertEqual(length, 200000)
 
     def test_unknown_model_raises_error(self):
         with self.assertRaises(ValueError) as ctx:
@@ -75,7 +75,7 @@ class TestModelSupportsImages(unittest.TestCase):
         self.assertTrue(model_configs.model_supports_images("claude-sonnet-4-5"))
 
     def test_non_vision_model(self):
-        self.assertFalse(model_configs.model_supports_images("stockmark-stockmark-2-100b-instruct"))
+        self.assertFalse(model_configs.model_supports_images("nim-deepseek-v3.2"))
 
 
 class TestFindModelConfig(unittest.TestCase):
@@ -85,9 +85,9 @@ class TestFindModelConfig(unittest.TestCase):
         self.assertEqual(config.get("provider"), "anthropic")
 
     def test_find_by_api_model_name(self):
-        key, config = model_configs.find_model_config("stockmark/stockmark-2-100b-instruct")
+        key, config = model_configs.find_model_config("mistralai/mistral-large-3-675b-instruct-2512")
         self.assertTrue(key)
-        self.assertEqual(config.get("model"), "stockmark/stockmark-2-100b-instruct")
+        self.assertEqual(config.get("model"), "mistralai/mistral-large-3-675b-instruct-2512")
 
     def test_not_found(self):
         key, config = model_configs.find_model_config("nonexistent-model-xyz-abc")
@@ -110,7 +110,7 @@ class TestSupportsStructuredOutput(unittest.TestCase):
         self.assertTrue(model_configs.supports_structured_output("claude-sonnet-4-5"))
 
     def test_explicit_false(self):
-        self.assertFalse(model_configs.supports_structured_output("stockmark-stockmark-2-100b-instruct"))
+        self.assertFalse(model_configs.supports_structured_output("nim-step-3.5-flash"))
 
 
 if __name__ == "__main__":

--- a/tests/test_task_tools.py
+++ b/tests/test_task_tools.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from conftest import load_builtin_tool
+from tool_loader import load_builtin_tool
 from persona.tasks import TaskStorage
 from tools.context import persona_context
 

--- a/tests/test_thread_switch_tool.py
+++ b/tests/test_thread_switch_tool.py
@@ -77,7 +77,7 @@ class ThreadSwitchToolTest(unittest.TestCase):
         state_file = self.persona_path / "active_state.json"
         state_file.write_text(json.dumps({"active_thread_id": sns_suffix}), encoding="utf-8")
 
-        from conftest import load_builtin_tool
+        from tool_loader import load_builtin_tool
         switch_active_thread = load_builtin_tool("thread_switch").switch_active_thread
 
         from tools.context import persona_context
@@ -137,7 +137,7 @@ class ThreadSwitchToolTest(unittest.TestCase):
         state_file = self.persona_path / "active_state.json"
         state_file.write_text(json.dumps({"active_thread_id": sns_suffix}), encoding="utf-8")
 
-        from conftest import load_builtin_tool
+        from tool_loader import load_builtin_tool
         switch_active_thread = load_builtin_tool("thread_switch").switch_active_thread
         from tools.context import persona_context
 
@@ -156,7 +156,7 @@ class ThreadSwitchToolTest(unittest.TestCase):
     def test_switch_without_origin_messages_raises(self) -> None:
         follow_suffix = "follow-no-origin"
 
-        from conftest import load_builtin_tool
+        from tool_loader import load_builtin_tool
         switch_active_thread = load_builtin_tool("thread_switch").switch_active_thread
         from tools.context import persona_context
 

--- a/tests/tool_loader.py
+++ b/tests/tool_loader.py
@@ -1,0 +1,23 @@
+"""Shared test helper for loading builtin tools by name."""
+
+import importlib.util
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_builtin_tool(name: str):
+    """Load a tool module from builtin_data/tools/ by name.
+
+    Usage::
+
+        calculator = load_builtin_tool("calculator")
+        result = calculator.calculate_expression("1+2")
+    """
+    tool_path = PROJECT_ROOT / "builtin_data" / "tools" / f"{name}.py"
+    if not tool_path.exists():
+        raise FileNotFoundError(f"Tool not found: {tool_path}")
+    spec = importlib.util.spec_from_file_location(f"_builtin_tools.{name}", tool_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
## Summary
- `from conftest import load_builtin_tool` が `discord_gateway/tests/conftest.py` と衝突してテスト3件がコレクションエラーになっていた問題を修正。`load_builtin_tool` を専用モジュール `tests/tool_loader.py` に分離
- 削除済み stockmark モデルを参照していたテスト3件の期待値を、現存するモデル (`nim-mistral-large-3`, `nim-step-3.5-flash`, `nim-deepseek-v3.2`) に更新
- `claude-sonnet-4-5` の `context_length` が 64000 → 200000 に変更されていたのに合わせてテスト期待値を修正

## Test plan
- [x] `python -m pytest tests/test_calculator.py` — コレクションエラー解消確認
- [x] `python -m pytest tests/test_image_generator.py` — コレクションエラー解消確認
- [x] `python -m pytest tests/test_task_tools.py` — コレクションエラー解消確認
- [x] `python -m pytest tests/test_model_configs.py` — 19 passed
- [x] `python -m pytest` フルスイート — 159 passed (残2件は既存のフレーキーテスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)