### PR TITLE
Add structured_output_mode and update model configs

### DIFF
--- a/llm_clients/factory.py
+++ b/llm_clients/factory.py
@@ -74,6 +74,12 @@ def get_llm_client(model: str, provider: str, context_length: int, config: Dict 
                 extra_kwargs["structured_output_backend"] = structured_output_backend
                 logging.info("Using structured_output_backend='%s' for model '%s'", structured_output_backend, api_model)
 
+            # Structured output mode: "native" (default) or "json_object" (prompt-based schema)
+            structured_output_mode = config.get("structured_output_mode")
+            if isinstance(structured_output_mode, str) and structured_output_mode.strip():
+                extra_kwargs["structured_output_mode"] = structured_output_mode.strip()
+                logging.info("Using structured_output_mode='%s' for model '%s'", structured_output_mode, api_model)
+
             # Multi-turn reasoning pass-back field (e.g., "reasoning_details" for OpenRouter)
             reasoning_passback = config.get("reasoning_passback_field")
             if isinstance(reasoning_passback, str) and reasoning_passback.strip():


### PR DESCRIPTION
## Summary
- **Add Claude Sonnet 4.6** model config and remove deprecated model configs
- **Add `structured_output_mode` option** for OpenAI-compatible LLM clients: models that don't support strict `json_schema` enforcement (e.g. local models via llama-server) can set `"structured_output_mode": "json_object"` to use prompt-based schema injection instead
- Default is `"native"` (existing behavior) — no impact on current models

## Test plan
- [x] Verified `json_object` mode produces valid JSON with llama-server (Nemotron Nano 9B)
- [x] Verified existing models (Gemini, Claude, OpenAI) are unaffected (default `"native"`)
- [x] `ruff check` passes on modified files
- [ ] Manual test: run SAIVerse with a model config using `structured_output_mode: "json_object"` and confirm structured output works via SEA runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)