### PR TITLE
Fix mobile textarea inflated height on initial load

### DIFF
--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -622,12 +622,15 @@
     outline: none;
     resize: none;
     font-family: inherit;
-    font-size: 0.95rem;
+    font-size: 1rem;
+    /* >= 16px prevents iOS auto-zoom on focus */
     line-height: 1.5;
     max-height: 240px;
     /* 10 lines * 24px line-height */
     min-height: 24px;
     /* 1 line */
+    height: 24px;
+    /* Explicit initial height — JS adjustTextareaHeight overrides dynamically */
     padding: 0.2rem 0;
     overflow-y: auto;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -200,16 +200,27 @@ export default function Home() {
         const textarea = textareaRef.current;
         if (!textarea) return;
 
-        // Reset height to calculate scrollHeight correctly
-        textarea.style.height = 'auto';
-
-        // Calculate line height (approximately 1.5 * font-size of 0.95rem ≈ 22.8px)
-        const lineHeight = 24; // px, approximate
+        const lineHeight = 24; // px (1.5 * ~16px font-size)
         const maxLines = 10;
         const maxHeight = lineHeight * maxLines;
 
-        // Set new height (capped at max)
-        const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+        // Temporarily override styles for accurate scrollHeight measurement
+        // - min-height: 0 prevents CSS min-height from inflating scrollHeight
+        // - overflow: hidden prevents scrollbar from affecting measurement
+        // - height: 0 collapses textarea to measure true content height
+        const prevMinHeight = textarea.style.minHeight;
+        const prevOverflow = textarea.style.overflow;
+        textarea.style.minHeight = '0';
+        textarea.style.overflow = 'hidden';
+        textarea.style.height = '0';
+
+        const scrollH = textarea.scrollHeight;
+
+        // Restore
+        textarea.style.minHeight = prevMinHeight;
+        textarea.style.overflow = prevOverflow;
+
+        const newHeight = Math.max(lineHeight, Math.min(scrollH, maxHeight));
         textarea.style.height = `${newHeight}px`;
     }, []);
 


### PR DESCRIPTION
## Summary
- モバイルブラウザでチャット入力欄が初期状態で3〜4行分の高さになっていた問題を修正
- `scrollHeight` 計測時に CSS `min-height` が干渉していたのが原因。計測中は `min-height: 0` / `overflow: hidden` に一時切替して正確な値を取得するように変更
- `font-size` を `0.95rem` → `1rem` (16px) に変更し、iOS Safari のオートズームを防止

## Test plan
- [x] モバイル（実機）で初期状態のテキストエリアが1行分の高さであることを確認
- [x] 複数行入力時に正しく伸びることを確認
- [x] デスクトップでも動作に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)