### PR TITLE
Add MCP client integration for external tool servers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -8,7 +8,7 @@ api_router.include_router(user.router, prefix="/user", tags=["user"])
 api_router.include_router(info.router, prefix="/info", tags=["info"])
 api_router.include_router(people.router, prefix="/people", tags=["people"])
 
-from api.routes import admin, db_manager, world, media, phenomena, usage, tutorial, uri, system
+from api.routes import admin, db_manager, world, media, phenomena, usage, tutorial, uri, system, mcp
 api_router.include_router(admin.router, prefix="/admin", tags=["admin"])
 api_router.include_router(db_manager.router, prefix="/db", tags=["db"])
 api_router.include_router(world.router, prefix="/world", tags=["world"])
@@ -18,4 +18,5 @@ api_router.include_router(usage.router, prefix="/usage", tags=["usage"])
 api_router.include_router(tutorial.router, prefix="/tutorial", tags=["tutorial"])
 api_router.include_router(uri.router, prefix="/uri", tags=["uri"])
 api_router.include_router(system.router, prefix="/system", tags=["system"])
+api_router.include_router(mcp.router, prefix="/mcp", tags=["mcp"])
 

--- a/api/routes/mcp.py
+++ b/api/routes/mcp.py
@@ -1,0 +1,60 @@
+"""MCP (Model Context Protocol) status and management API endpoints."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+from fastapi import APIRouter
+
+LOGGER = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/servers")
+def list_servers() -> List[Dict[str, Any]]:
+    """List all configured MCP servers with connection status."""
+    from tools.mcp_client import get_mcp_manager
+
+    mgr = get_mcp_manager()
+    if mgr is None:
+        return []
+    return mgr.get_server_status()
+
+
+@router.get("/tools")
+def list_mcp_tools() -> List[Dict[str, str]]:
+    """List all registered MCP tools."""
+    from tools.mcp_client import get_mcp_manager
+
+    mgr = get_mcp_manager()
+    if mgr is None:
+        return []
+
+    from tools import TOOL_SCHEMAS
+    mcp_tools = []
+    registered_names = set(mgr.get_registered_tool_names())
+    for schema in TOOL_SCHEMAS:
+        if schema.name in registered_names:
+            mcp_tools.append({
+                "name": schema.name,
+                "description": schema.description,
+                "parameters": schema.parameters,
+            })
+    return mcp_tools
+
+
+@router.post("/servers/{server_name}/reconnect")
+async def reconnect_server(server_name: str) -> Dict[str, Any]:
+    """Reconnect a specific MCP server."""
+    from tools.mcp_client import get_mcp_manager
+
+    mgr = get_mcp_manager()
+    if mgr is None:
+        return {"success": False, "error": "MCP not initialized"}
+
+    success = await mgr.reconnect_server(server_name)
+    if success:
+        return {"success": True, "message": f"Server '{server_name}' reconnected"}
+    return {"success": False, "error": f"Failed to reconnect server '{server_name}'"}

--- a/docs/features/mcp-integration.md
+++ b/docs/features/mcp-integration.md
@@ -1,0 +1,375 @@
+# MCP (Model Context Protocol) 連携
+
+SAIVerseのペルソナが外部MCPサーバーのツールを使用できるようにする機能です。
+
+## 概要
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) は、LLMアプリケーションが外部のツールやデータソースと標準化された方法で接続するためのプロトコルです。
+
+SAIVerseはMCPクライアントとして動作し、外部のMCPサーバーが提供するツールをペルソナの既存ツールシステムに統合します。MCPサーバーのツールは、ビルトインツールと同じようにプレイブックから利用できます。
+
+```
+┌─────────────────┐         stdio / HTTP          ┌───────────────────┐
+│    SAIVerse      │◄────────────────────────────►│  MCP Server       │
+│  (MCP Client)    │    list_tools / call_tool     │  (filesystem等)   │
+└─────────────────┘                               └───────────────────┘
+```
+
+## セットアップ
+
+### 1. 依存パッケージ
+
+`mcp` パッケージが必要です（`requirements.txt` に含まれています）：
+
+```bash
+pip install mcp>=1.10.0
+```
+
+### 2. MCPサーバーの準備
+
+使いたいMCPサーバーをインストールします。多くのMCPサーバーは `npx` で直接実行可能です：
+
+```bash
+# Node.js が必要（npx経由で実行するため）
+# https://nodejs.org/
+
+# 例: ファイルシステムサーバー
+npx -y @modelcontextprotocol/server-filesystem /path/to/dir
+
+# 例: テスト用のeverythingサーバー
+npx -y @modelcontextprotocol/server-everything
+```
+
+利用可能なMCPサーバーの一覧：https://github.com/modelcontextprotocol/servers
+
+### 3. 設定ファイルの作成
+
+`~/.saiverse/user_data/mcp_servers.json` を作成します：
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "C:/Users/yourname/Documents"],
+      "enabled": true
+    }
+  }
+}
+```
+
+SAIVerseを再起動すると、設定されたMCPサーバーに自動的に接続し、ツールが登録されます。
+
+## 設定ファイル
+
+### 配置場所
+
+設定ファイルは SAIVerse の3層優先度システムに従います：
+
+| 優先度 | パス | 用途 |
+|--------|------|------|
+| 高 | `~/.saiverse/user_data/mcp_servers.json` | 個人設定 |
+| 中 | `expansion_data/<pack>/mcp_servers.json` | 拡張パック同梱 |
+| 低 | `builtin_data/mcp_servers.json` | デフォルト設定 |
+
+同名のサーバーは高優先度のファイルが優先されます。
+
+### フォーマット
+
+[Claude Desktop](https://claude.ai/download) と互換性のあるフォーマットです：
+
+```json
+{
+  "mcpServers": {
+    "サーバー名": {
+      // --- stdio トランスポート（ローカルプロセス） ---
+      "command": "実行コマンド",
+      "args": ["引数1", "引数2"],
+      "env": {
+        "環境変数": "値"
+      },
+      "enabled": true,
+      "timeout": 120
+
+      // --- または HTTP トランスポート（リモートサーバー） ---
+      // "url": "http://localhost:3001/mcp",
+      // "transport": "streamable_http"
+    }
+  }
+}
+```
+
+### フィールド一覧
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `command` | string | stdio時必須 | 実行するコマンド（`npx`, `python`, `node` 等） |
+| `args` | string[] | - | コマンドの引数 |
+| `env` | object | - | サーバープロセスの環境変数 |
+| `url` | string | HTTP時必須 | リモートサーバーのURL |
+| `transport` | string | - | `"streamable_http"` または `"sse"`（URLがある場合のデフォルト: `"streamable_http"`） |
+| `enabled` | boolean | - | `false` で無効化（デフォルト: `true`） |
+| `timeout` | number | - | ツール実行タイムアウト秒数（デフォルト: `120`） |
+
+### トランスポートの判定
+
+- `command` キーがある → **stdio**（ローカルプロセスを起動）
+- `url` キーがある → **HTTP**（`transport` フィールドで種類を指定）
+
+### 環境変数の展開
+
+`env` フィールドで `${ENV_VAR}` 構文を使うと、`.env` やシステムの環境変数から値を読み込めます。APIキーなどの秘密情報をJSONに直書きする必要がありません：
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+`.env` ファイルに `GITHUB_TOKEN=ghp_xxxx...` と書いておけば、起動時に自動展開されます。
+
+## ツールの命名規則
+
+MCPサーバーから登録されるツールには、サーバー名のプレフィックスが付与されます：
+
+```
+{サーバー名}__{ツール名}
+```
+
+例：
+- `filesystem` サーバーの `read_file` → `filesystem__read_file`
+- `github` サーバーの `create_issue` → `github__create_issue`
+
+ダブルアンダースコア (`__`) で区切ります（Claude Desktop と同じ慣例）。
+
+## プレイブックでの使用
+
+MCPツールはビルトインツールと同じ方法でプレイブックから使用できます。
+
+### LLMノードの `available_tools` で指定
+
+```json
+{
+  "type": "llm",
+  "id": "use_filesystem",
+  "available_tools": ["filesystem__read_file", "filesystem__write_file"],
+  "prompt": "ユーザーの要求に応じてファイルを読み書きしてください。"
+}
+```
+
+### TOOLノードで直接呼び出し
+
+```json
+{
+  "type": "tool",
+  "id": "read_config",
+  "action": "filesystem__read_file",
+  "args_input": {
+    "path": "config_file_path"
+  },
+  "output_key": "file_content"
+}
+```
+
+## API エンドポイント
+
+MCPの状態確認と管理用のAPIが利用可能です：
+
+| メソッド | エンドポイント | 説明 |
+|---------|---------------|------|
+| GET | `/api/mcp/servers` | 接続中のサーバー一覧と状態 |
+| GET | `/api/mcp/tools` | 登録済みMCPツール一覧 |
+| POST | `/api/mcp/servers/{name}/reconnect` | サーバーの再接続 |
+
+### レスポンス例
+
+**GET /api/mcp/servers**
+```json
+[
+  {
+    "name": "filesystem",
+    "transport": "stdio",
+    "connected": true,
+    "tool_count": 3,
+    "tools": ["read_file", "write_file", "list_directory"]
+  }
+]
+```
+
+**GET /api/mcp/tools**
+```json
+[
+  {
+    "name": "filesystem__read_file",
+    "description": "[MCP:filesystem] Read the contents of a file",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string", "description": "Path to the file" }
+      },
+      "required": ["path"]
+    }
+  }
+]
+```
+
+## 設定例
+
+### ファイルシステムアクセス
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "C:/Users/yourname/Documents"]
+    }
+  }
+}
+```
+
+### GitHub 連携
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### テスト用サーバー
+
+開発時のテストには `@modelcontextprotocol/server-everything` が便利です：
+
+```json
+{
+  "mcpServers": {
+    "everything": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-everything"]
+    }
+  }
+}
+```
+
+### 複数サーバーの同時使用
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "C:/workspace"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    },
+    "remote_db": {
+      "url": "http://localhost:3001/mcp",
+      "transport": "streamable_http",
+      "timeout": 60
+    }
+  }
+}
+```
+
+## トラブルシューティング
+
+### サーバーが接続できない
+
+起動ログを確認してください：
+
+```
+WARNING MCP: server 'filesystem' failed to start, skipping: ...
+```
+
+よくある原因：
+- `npx` がPATHにない（Node.jsがインストールされていない）
+- MCPサーバーパッケージが見つからない
+- コマンドのパスが間違っている
+
+### ツールが登録されない
+
+`GET /api/mcp/servers` でサーバーの接続状態を確認：
+
+```bash
+curl http://localhost:8000/api/mcp/servers
+```
+
+`connected: false` の場合はサーバーが起動に失敗しています。バックエンドログで詳細を確認してください。
+
+### ツール実行がタイムアウトする
+
+`timeout` フィールドでタイムアウト秒数を延長できます（デフォルト: 120秒）：
+
+```json
+{
+  "mcpServers": {
+    "slow_server": {
+      "command": "python",
+      "args": ["my_server.py"],
+      "timeout": 300
+    }
+  }
+}
+```
+
+### サーバーの再接続
+
+接続が切れた場合、APIから再接続できます：
+
+```bash
+curl -X POST http://localhost:8000/api/mcp/servers/filesystem/reconnect
+```
+
+## 技術的な詳細
+
+### アーキテクチャ
+
+```
+main.py (起動)
+  └─ initialize_mcp()
+       └─ MCPClientManager.start_all()
+            ├─ load_mcp_configs()       ← mcp_servers.json 読み込み
+            ├─ MCPServerConnection.connect()  ← サーバーに接続
+            ├─ session.list_tools()     ← ツール発見
+            └─ register_external_tool() ← TOOL_REGISTRY に登録
+                 ├─ OPENAI_TOOLS_SPEC
+                 ├─ GEMINI_TOOLS_SPEC
+                 └─ TOOL_SCHEMAS
+```
+
+### 関連ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `tools/mcp_config.py` | 設定ファイルの読み込みと検証 |
+| `tools/mcp_client.py` | MCPクライアント管理（接続、ツール登録、実行） |
+| `tools/__init__.py` | `register_external_tool()` — 動的ツール登録 |
+| `sea/runtime.py` | 非同期ツール実行対応 |
+| `api/routes/mcp.py` | MCP管理APIエンドポイント |
+
+## 次のステップ
+
+- [ツールシステム](tools-system.md) - SAIVerseのツールの仕組み
+- [ツールの追加](../developer-guide/adding-tools.md) - カスタムツールの開発
+- [プレイブック](playbooks.md) - ツールを使うワークフローの設計

--- a/docs/features/tools-system.md
+++ b/docs/features/tools-system.md
@@ -80,5 +80,6 @@ SAIVerseのペルソナは、Function Calling を通じて様々なツールを�
 
 ## 次のステップ
 
+- [MCP連携](mcp-integration.md) - 外部MCPサーバーのツールを使う
 - [ツールカタログ](../reference/tool-catalog.md) - 全ツールの詳細
 - [ツールの追加](../developer-guide/adding-tools.md) - 開発者向け

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ SAIVerseの公式ドキュメントへようこそ。
 - [ツールシステム](./features/tools-system.md) - AIが使えるツール
 - [Playbook/SEA](./features/playbooks.md) - 行動パターン定義
 - [Discord連携](./features/discord-gateway.md) - Discordとの接続
-- [Unity Gateway](./features/unity-gateway.md) - 3D/VR空間連携 ⭐NEW
+- [Unity Gateway](./features/unity-gateway.md) - 3D/VR空間連携
+- [MCP連携](./features/mcp-integration.md) - 外部MCPサーバーのツール利用 ⭐NEW
 
 ### 開発者ガイド
 - [コントリビューション](./developer-guide/contributing.md) - 貢献の方法

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,9 @@ pypdf>=4.0.0
 # xAI (Grok) native SDK
 xai-sdk>=1.6.0
 
+# MCP (Model Context Protocol) client
+mcp>=1.10.0
+
 # ローカルLLM (llama.cpp) を使う場合:
 #   pip install -r requirements-local-llm.txt
 

--- a/tools/mcp_client.py
+++ b/tools/mcp_client.py
@@ -1,0 +1,434 @@
+"""MCP (Model Context Protocol) client manager for SAIVerse.
+
+Manages connections to external MCP servers, discovers their tools,
+and registers them into the SAIVerse tool system so that personas
+can use them transparently through playbooks.
+
+Usage::
+
+    from tools.mcp_client import initialize_mcp, shutdown_mcp, get_mcp_manager
+
+    # At application startup
+    manager = await initialize_mcp()
+
+    # At application shutdown
+    await shutdown_mcp()
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import AsyncExitStack
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from tools.core import ToolSchema
+
+LOGGER = logging.getLogger(__name__)
+
+# Default timeout for MCP tool calls (seconds)
+_DEFAULT_TOOL_TIMEOUT_SECONDS = 120
+
+
+class MCPServerConnection:
+    """Manages a single MCP server connection."""
+
+    def __init__(self, server_name: str, config: Dict[str, Any]) -> None:
+        self.server_name = server_name
+        self.config = config
+        self.session: Optional[ClientSession] = None
+        self.tools: List[Any] = []  # mcp.types.Tool objects
+        self._exit_stack: Optional[AsyncExitStack] = None
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected and self.session is not None
+
+    @property
+    def transport_type(self) -> str:
+        if "command" in self.config:
+            return "stdio"
+        transport = self.config.get("transport", "streamable_http")
+        return transport
+
+    async def connect(self) -> None:
+        """Connect to the MCP server and initialize the session."""
+        if self._connected:
+            return
+
+        self._exit_stack = AsyncExitStack()
+
+        try:
+            transport_type = self.transport_type
+
+            if transport_type == "stdio":
+                await self._connect_stdio()
+            elif transport_type == "sse":
+                await self._connect_sse()
+            else:  # streamable_http (default for url-based)
+                await self._connect_streamable_http()
+
+            # Initialize the session
+            if self.session:
+                init_result = await self.session.initialize()
+                LOGGER.info(
+                    "MCP server '%s' initialized (protocol=%s, server=%s)",
+                    self.server_name,
+                    getattr(init_result, "protocolVersion", "unknown"),
+                    getattr(getattr(init_result, "serverInfo", None), "name", "unknown"),
+                )
+                self._connected = True
+
+                # Discover tools
+                await self._discover_tools()
+
+        except Exception as exc:
+            LOGGER.warning("MCP server '%s' failed to connect: %s", self.server_name, exc)
+            await self._cleanup()
+            raise
+
+    async def _connect_stdio(self) -> None:
+        """Connect via stdio transport (local process)."""
+        command = self.config["command"]
+        args = self.config.get("args", [])
+        env = self.config.get("env")
+
+        server_params = StdioServerParameters(
+            command=command,
+            args=args,
+            env=env,
+        )
+
+        stdio_transport = await self._exit_stack.enter_async_context(
+            stdio_client(server_params)
+        )
+        read_stream, write_stream = stdio_transport
+        self.session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+
+    async def _connect_sse(self) -> None:
+        """Connect via SSE transport (remote server)."""
+        from mcp.client.sse import sse_client
+
+        url = self.config["url"]
+        sse_transport = await self._exit_stack.enter_async_context(
+            sse_client(url)
+        )
+        read_stream, write_stream = sse_transport
+        self.session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+
+    async def _connect_streamable_http(self) -> None:
+        """Connect via streamable HTTP transport (remote server)."""
+        from mcp.client.streamable_http import streamablehttp_client
+
+        url = self.config["url"]
+        http_transport = await self._exit_stack.enter_async_context(
+            streamablehttp_client(url)
+        )
+        read_stream, write_stream = http_transport[0], http_transport[1]
+        self.session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+
+    async def _discover_tools(self) -> None:
+        """Discover tools from the connected MCP server."""
+        if not self.session:
+            return
+
+        result = await self.session.list_tools()
+        self.tools = result.tools
+        LOGGER.info(
+            "MCP server '%s': discovered %d tool(s): %s",
+            self.server_name,
+            len(self.tools),
+            [t.name for t in self.tools],
+        )
+
+    async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Call a tool on the MCP server and return the result as a string.
+
+        Args:
+            tool_name: The original MCP tool name (without server prefix).
+            arguments: Tool arguments dict.
+
+        Returns:
+            Tool result as a string.
+        """
+        if not self.session or not self._connected:
+            raise ConnectionError(f"MCP server '{self.server_name}' is not connected")
+
+        timeout_seconds = self.config.get("timeout", _DEFAULT_TOOL_TIMEOUT_SECONDS)
+
+        try:
+            result = await self.session.call_tool(
+                name=tool_name,
+                arguments=arguments,
+                read_timeout_seconds=timedelta(seconds=timeout_seconds),
+            )
+        except Exception as exc:
+            # Try one reconnect
+            LOGGER.warning(
+                "MCP tool call '%s' on server '%s' failed: %s. Attempting reconnect...",
+                tool_name, self.server_name, exc,
+            )
+            try:
+                await self._cleanup()
+                await self.connect()
+                result = await self.session.call_tool(
+                    name=tool_name,
+                    arguments=arguments,
+                    read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                )
+            except Exception as retry_exc:
+                error_msg = (
+                    f"MCP tool '{self.server_name}__{tool_name}' failed after reconnect: {retry_exc}"
+                )
+                LOGGER.error(error_msg)
+                return error_msg
+
+        # Check if the tool reported an error
+        if result.isError:
+            LOGGER.warning(
+                "MCP tool '%s__%s' returned an error", self.server_name, tool_name
+            )
+
+        # Convert content to string
+        return _format_tool_result(result)
+
+    async def disconnect(self) -> None:
+        """Disconnect from the MCP server."""
+        await self._cleanup()
+
+    async def _cleanup(self) -> None:
+        """Clean up connection resources."""
+        self._connected = False
+        self.session = None
+        self.tools = []
+        if self._exit_stack:
+            try:
+                await self._exit_stack.aclose()
+            except Exception as exc:
+                LOGGER.debug("MCP server '%s' cleanup error: %s", self.server_name, exc)
+            self._exit_stack = None
+
+
+def _format_tool_result(result: Any) -> str:
+    """Convert a CallToolResult to a plain text string."""
+    texts: List[str] = []
+    for item in result.content:
+        if hasattr(item, "text"):
+            texts.append(item.text)
+        elif hasattr(item, "data"):
+            item_type = getattr(item, "type", "binary")
+            data_len = len(item.data) if item.data else 0
+            texts.append(f"[{item_type}: {data_len} bytes]")
+        elif hasattr(item, "uri"):
+            texts.append(f"[resource: {item.uri}]")
+        else:
+            texts.append(str(item))
+    return "\n".join(texts) if texts else "(no content)"
+
+
+class MCPClientManager:
+    """Manages all MCP server connections and tool registrations."""
+
+    def __init__(self) -> None:
+        self._connections: Dict[str, MCPServerConnection] = {}
+        self._registered_tools: List[str] = []  # namespaced tool names
+
+    async def start_all(self) -> None:
+        """Load configs, connect to all enabled servers, and register tools."""
+        from tools.mcp_config import load_mcp_configs
+
+        configs = load_mcp_configs()
+        if not configs:
+            LOGGER.info("MCP: no servers configured")
+            return
+
+        for server_name, config in configs.items():
+            conn = MCPServerConnection(server_name, config)
+            try:
+                await conn.connect()
+                self._connections[server_name] = conn
+                self._register_tools(conn)
+            except Exception as exc:
+                LOGGER.warning(
+                    "MCP: server '%s' failed to start, skipping: %s",
+                    server_name, exc,
+                )
+
+    def _register_tools(self, conn: MCPServerConnection) -> None:
+        """Register tools from an MCP server into the SAIVerse tool registry."""
+        from tools import register_external_tool
+
+        for mcp_tool in conn.tools:
+            namespaced_name = f"{conn.server_name}__{mcp_tool.name}"
+
+            description = mcp_tool.description or ""
+            prefixed_description = f"[MCP:{conn.server_name}] {description}"
+
+            # MCP inputSchema is JSON Schema, directly maps to ToolSchema.parameters
+            parameters = mcp_tool.inputSchema
+            if not isinstance(parameters, dict):
+                parameters = {"type": "object", "properties": {}}
+
+            schema = ToolSchema(
+                name=namespaced_name,
+                description=prefixed_description,
+                parameters=parameters,
+                result_type="string",
+            )
+
+            # Create async wrapper that delegates to the MCP server
+            wrapper = _make_mcp_tool_wrapper(conn, mcp_tool.name)
+
+            register_external_tool(namespaced_name, schema, wrapper)
+            self._registered_tools.append(namespaced_name)
+
+    async def shutdown_all(self) -> None:
+        """Disconnect all MCP servers and unregister their tools."""
+        from tools import unregister_external_tool
+
+        # Unregister all MCP tools
+        for tool_name in self._registered_tools:
+            unregister_external_tool(tool_name)
+        self._registered_tools.clear()
+
+        # Disconnect all servers
+        for name, conn in self._connections.items():
+            try:
+                await conn.disconnect()
+                LOGGER.info("MCP server '%s' disconnected", name)
+            except Exception as exc:
+                LOGGER.debug("MCP server '%s' disconnect error: %s", name, exc)
+        self._connections.clear()
+
+    async def reconnect_server(self, server_name: str) -> bool:
+        """Reconnect a specific MCP server.
+
+        Returns True if reconnection succeeded.
+        """
+        conn = self._connections.get(server_name)
+        if not conn:
+            LOGGER.warning("MCP: server '%s' not found for reconnect", server_name)
+            return False
+
+        # Unregister existing tools from this server
+        from tools import unregister_external_tool
+        prefix = f"{server_name}__"
+        to_remove = [t for t in self._registered_tools if t.startswith(prefix)]
+        for tool_name in to_remove:
+            unregister_external_tool(tool_name)
+            self._registered_tools.remove(tool_name)
+
+        # Disconnect and reconnect
+        try:
+            await conn.disconnect()
+            await conn.connect()
+            self._register_tools(conn)
+            LOGGER.info("MCP server '%s' reconnected successfully", server_name)
+            return True
+        except Exception as exc:
+            LOGGER.warning("MCP server '%s' reconnect failed: %s", server_name, exc)
+            return False
+
+    def get_registered_tool_names(self) -> List[str]:
+        """Return list of all registered MCP tool names."""
+        return list(self._registered_tools)
+
+    def get_server_status(self) -> List[Dict[str, Any]]:
+        """Return status information for all servers."""
+        statuses = []
+        for name, conn in self._connections.items():
+            statuses.append({
+                "name": name,
+                "transport": conn.transport_type,
+                "connected": conn.connected,
+                "tool_count": len(conn.tools),
+                "tools": [t.name for t in conn.tools],
+            })
+        return statuses
+
+
+def _make_mcp_tool_wrapper(connection: MCPServerConnection, tool_name: str):
+    """Create an async wrapper function for an MCP tool.
+
+    The returned function is a coroutine that can be ``await``-ed in the
+    SEA runtime's async LangGraph nodes.
+    """
+
+    async def _mcp_tool_wrapper(**kwargs: Any) -> str:
+        LOGGER.info(
+            "MCP tool call: %s__%s args=%s",
+            connection.server_name, tool_name, kwargs,
+        )
+        result = await connection.call_tool(tool_name, kwargs)
+        LOGGER.info(
+            "MCP tool result: %s__%s -> %s",
+            connection.server_name, tool_name,
+            result[:200] + "..." if len(result) > 200 else result,
+        )
+        return result
+
+    # Set a useful function name for debugging
+    _mcp_tool_wrapper.__name__ = f"{connection.server_name}__{tool_name}"
+    _mcp_tool_wrapper.__qualname__ = f"mcp.{connection.server_name}.{tool_name}"
+
+    return _mcp_tool_wrapper
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_manager: Optional[MCPClientManager] = None
+
+
+def get_mcp_manager() -> Optional[MCPClientManager]:
+    """Return the global MCPClientManager instance, or None if not initialized."""
+    return _manager
+
+
+async def initialize_mcp() -> Optional[MCPClientManager]:
+    """Initialize MCP client connections.
+
+    Loads configuration, connects to all enabled MCP servers,
+    and registers their tools into the SAIVerse tool system.
+
+    Returns:
+        The MCPClientManager instance, or None if no servers are configured.
+    """
+    global _manager
+
+    if _manager is not None:
+        LOGGER.warning("MCP: already initialized, skipping")
+        return _manager
+
+    mgr = MCPClientManager()
+    await mgr.start_all()
+
+    if not mgr._connections:
+        LOGGER.info("MCP: no servers connected")
+        return None
+
+    _manager = mgr
+    return _manager
+
+
+async def shutdown_mcp() -> None:
+    """Shut down all MCP connections and unregister tools."""
+    global _manager
+
+    if _manager is None:
+        return
+
+    await _manager.shutdown_all()
+    _manager = None
+    LOGGER.info("MCP: shutdown complete")

--- a/tools/mcp_config.py
+++ b/tools/mcp_config.py
@@ -1,0 +1,135 @@
+"""MCP server configuration loader.
+
+Loads MCP server definitions from ``mcp_servers.json`` files found in the
+three-tier priority system (user_data > expansion_data > builtin_data).
+
+Configuration format (Claude Desktop compatible)::
+
+    {
+      "mcpServers": {
+        "server_name": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"],
+          "env": {"KEY": "${ENV_VAR}"},
+          "enabled": true
+        }
+      }
+    }
+
+Transport detection:
+- ``command`` key present → stdio transport
+- ``url`` key present → remote transport (``transport`` field: "streamable_http" or "sse")
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+LOGGER = logging.getLogger(__name__)
+
+_ENV_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _interpolate_env(value: str) -> str:
+    """Replace ``${ENV_VAR}`` placeholders with environment variable values."""
+
+    def _replacer(match: re.Match) -> str:
+        var_name = match.group(1)
+        env_val = os.environ.get(var_name)
+        if env_val is None:
+            LOGGER.warning("MCP config: environment variable '%s' is not set", var_name)
+            return match.group(0)  # keep placeholder as-is
+        return env_val
+
+    return _ENV_VAR_RE.sub(_replacer, value)
+
+
+def _interpolate_env_dict(env: Dict[str, str]) -> Dict[str, str]:
+    """Interpolate environment variables in an env dict."""
+    return {k: _interpolate_env(v) for k, v in env.items()}
+
+
+def _load_single_config(path: Path) -> Dict[str, Dict[str, Any]]:
+    """Load a single mcp_servers.json and return server_name -> config dict."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        LOGGER.warning("MCP config: failed to read %s: %s", path, exc)
+        return {}
+
+    servers = data.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        LOGGER.warning("MCP config: 'mcpServers' in %s is not a dict, skipping", path)
+        return {}
+
+    result: Dict[str, Dict[str, Any]] = {}
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            LOGGER.warning("MCP config: server '%s' in %s has non-dict config, skipping", name, path)
+            continue
+        result[name] = cfg
+
+    return result
+
+
+def load_mcp_configs() -> Dict[str, Dict[str, Any]]:
+    """Load MCP server configurations from all data paths.
+
+    Priority: user_data > expansion_data > builtin_data.
+    Later sources do NOT override earlier ones (higher-priority wins).
+
+    Returns:
+        Dict mapping server_name to its configuration dict.
+        Only enabled servers are included.
+    """
+    from saiverse.data_paths import USER_DATA_DIR, EXPANSION_DATA_DIR, BUILTIN_DATA_DIR
+
+    merged: Dict[str, Dict[str, Any]] = {}
+    config_filename = "mcp_servers.json"
+
+    # 1. User data (highest priority)
+    user_config = USER_DATA_DIR / config_filename
+    for name, cfg in _load_single_config(user_config).items():
+        if name not in merged:
+            merged[name] = cfg
+            LOGGER.debug("MCP config: loaded server '%s' from user_data", name)
+
+    # 2. Expansion data (middle priority) — scan all project subdirs
+    if EXPANSION_DATA_DIR.exists():
+        for project_dir in sorted(EXPANSION_DATA_DIR.iterdir()):
+            if not project_dir.is_dir() or project_dir.name.startswith(("_", ".")):
+                continue
+            exp_config = project_dir / config_filename
+            for name, cfg in _load_single_config(exp_config).items():
+                if name not in merged:
+                    merged[name] = cfg
+                    LOGGER.debug("MCP config: loaded server '%s' from expansion_data/%s", name, project_dir.name)
+
+    # 3. Builtin data (lowest priority)
+    builtin_config = BUILTIN_DATA_DIR / config_filename
+    for name, cfg in _load_single_config(builtin_config).items():
+        if name not in merged:
+            merged[name] = cfg
+            LOGGER.debug("MCP config: loaded server '%s' from builtin_data", name)
+
+    # Filter out disabled servers and interpolate env vars
+    result: Dict[str, Dict[str, Any]] = {}
+    for name, cfg in merged.items():
+        if not cfg.get("enabled", True):
+            LOGGER.info("MCP config: server '%s' is disabled, skipping", name)
+            continue
+
+        # Interpolate environment variables in the env dict
+        if "env" in cfg and isinstance(cfg["env"], dict):
+            cfg["env"] = _interpolate_env_dict(cfg["env"])
+
+        result[name] = cfg
+
+    LOGGER.info("MCP config: loaded %d server(s) from config files", len(result))
+    return result


### PR DESCRIPTION
## Summary
- SAIVerseのペルソナが外部MCPサーバーのツールを使えるようにするMCPクライアント統合
- 設定ファイル(`~/.saiverse/user_data/mcp_servers.json`)でMCPサーバーを定義、起動時に自動接続
- MCPツールは `server__tool` 形式で既存の `TOOL_REGISTRY` に登録され、プレイブックから透過的に利用可能
- stdio / streamable HTTP / SSE の3種トランスポート対応

## Changes
- **New**: `tools/mcp_config.py` — 設定ファイルローダー（3層優先度、`${ENV_VAR}` 展開）
- **New**: `tools/mcp_client.py` — `MCPClientManager` + `MCPServerConnection`（接続管理、ツール発見・登録、実行）
- **New**: `api/routes/mcp.py` — ステータスAPI（`GET /servers`, `GET /tools`, `POST /reconnect`）
- **New**: `docs/features/mcp-integration.md` — セットアップガイド・設定リファレンス
- **Modified**: `tools/__init__.py` — `register_external_tool()` / `unregister_external_tool()` 追加
- **Modified**: `sea/runtime.py` — `asyncio.iscoroutinefunction` チェック追加（4箇所）で非同期MCPツール対応
- **Modified**: `main.py` — 起動時MCP接続 / 終了時切断のライフサイクルフック
- **Modified**: `api/main.py` — MCPルート登録
- **Modified**: `requirements.txt` — `mcp>=1.10.0` 追加

## Test plan
- [ ] MCP設定なしで起動 → 既存動作に影響なし（`MCP: no servers configured` ログ確認）
- [ ] `mcp_servers.json` に `@modelcontextprotocol/server-everything` を設定して起動 → ツール登録確認
- [ ] `GET /api/mcp/servers` / `GET /api/mcp/tools` でステータス確認
- [ ] プレイブックの `available_tools` にMCPツールを指定して実行確認
- [ ] `ruff check` パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)