### PR TITLE
Fix native function calling protocol for tool results

### DIFF
--- a/builtin_data/playbooks/public/agentic_chat_playbook.json
+++ b/builtin_data/playbooks/public/agentic_chat_playbook.json
@@ -8,7 +8,8 @@
             "description": "ユーザーの要求"
         }
     ],
-    "router_callable": true,
+    "router_callable": false,
+    "user_selectable": true,
     "dev_only": true,
     "nodes": [
         {
@@ -26,6 +27,12 @@
             "id": "agent_think",
             "type": "llm",
             "context_profile": "conversation",
+            "speak": true,
+            "memorize": {
+                "tags": [
+                    "conversation"
+                ]
+            },
             "available_tools": [
                 "memory_search_brief",
                 "searxng_search",
@@ -45,7 +52,7 @@
                 "schedule_add",
                 "send_email_to_user"
             ],
-            "action": "必要な情報が不足している場合はツールコールを使い調査を行ってください。これ以上ツールを利用する必要がない時はそのまま通常発話してください。\n\nこれまでのツール呼び出し結果:\n{tool_history}\n\nツールを呼ぶ場合は1回に1つだけ選んでください。",
+            "action": "",
             "output_keys": [
                 {
                     "text": "response_text"
@@ -64,7 +71,7 @@
                 "operator": "eq",
                 "cases": {
                     "True": "exec_tool",
-                    "default": "record"
+                    "default": null
                 }
             }
         },
@@ -100,26 +107,14 @@
             "id": "force_respond",
             "type": "llm",
             "context_profile": "conversation",
-            "action": "ツール呼び出しの上限に達しました。これまでに収集した情報を基に回答を生成してください。\n\n収集情報:\n{tool_history}",
-            "output_key": "response_text",
+            "speak": true,
             "memorize": {
                 "tags": [
-                    "internal",
-                    "agentic_chat"
+                    "conversation"
                 ]
             },
-            "next": "record"
-        },
-        {
-            "id": "record",
-            "type": "memorize",
-            "action": "{response_text}",
-            "role": "assistant",
-            "tags": [
-                "internal",
-                "agentic_chat",
-                "playbook_result"
-            ],
+            "action": "ツール呼び出しの上限に達しました。これまでに収集した情報を基に回答を生成してください。\n\n収集情報:\n{tool_history}",
+            "output_key": "response_text",
             "next": null
         }
     ],

--- a/llm_clients/xai.py
+++ b/llm_clients/xai.py
@@ -517,12 +517,17 @@ class XAIClient(LLMClient):
 
             # --- Tool-aware streaming ---
             if force_tool_choice is None:
-                user_msg = next(
-                    (m["content"] for m in reversed(messages) if m.get("role") == "user"),
-                    "",
-                )
-                decision = route(user_msg, tools_spec)
-                _log.info("Router decision:\n%s", json.dumps(decision, indent=2, ensure_ascii=False))
+                if tools is not None:
+                    # Explicit tools from runtime — let LLM decide natively
+                    pass
+                else:
+                    # Legacy mode (tools=None → OPENAI_TOOLS_SPEC) — use router
+                    user_msg = next(
+                        (m["content"] for m in reversed(messages) if m.get("role") == "user"),
+                        "",
+                    )
+                    decision = route(user_msg, tools_spec)
+                    _log.info("Router decision:\n%s", json.dumps(decision, indent=2, ensure_ascii=False))
 
             chat = self._create_chat(tools_spec=tools_spec)
             for msg in xai_messages:

--- a/manager/state.py
+++ b/manager/state.py
@@ -1,11 +1,16 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
 from saiverse.buildings import Building
+
+
+def _default_developer_mode() -> bool:
+    return os.environ.get("SAIVERSE_DEVELOPER_MODE", "").lower() in ("1", "true", "yes")
 
 
 @dataclass
@@ -60,7 +65,7 @@ class CoreState:
     api_port: int = 0
     autonomous_conversation_running: bool = False
     global_auto_enabled: bool = False  # Global ON/OFF for ConversationManager
-    developer_mode: bool = False  # Developer mode: shows Task, Phenomena, dev_only playbooks
+    developer_mode: bool = field(default_factory=_default_developer_mode)  # Developer mode: shows Task, Phenomena, dev_only playbooks
     current_playbook: Optional[str] = None  # Selected playbook override for Chat Options
     playbook_params: Dict[str, Any] = field(default_factory=dict)  # Parameters for the selected playbook
 


### PR DESCRIPTION
## Summary
- ネイティブ function calling でツール結果が LLM に伝わらず、ペルソナがツール結果を捏造していた問題を修正
- `context_profile` を使うノード（agentic_chat の agent_think 等）が `state["messages"]` ではなく `_intermediate_msgs` を参照するため、両方にツールプロトコルメッセージを追加
- Gemini thinking モデルの `thought_signature` echo back 対応（400 INVALID_ARGUMENT 回避）
- "both" レスポンス（テキスト + ツール呼び出し）のテキストが UI・Building 履歴に残るよう改善
- 画像生成のモデルフォールバックチェーン追加＋SDK 内部リトライ無効化

## Changes
- **sea/runtime.py**: `_lg_llm_node` で tool_calls 付き assistant メッセージを `state["messages"]` と `_intermediate_msgs` の両方に追加。`_lg_tool_call_node` で `_append_tool_result_message` 呼び出し＋ `_intermediate_msgs` 更新。"both" レスポンス時に `streaming_complete` + `_emit_say` でテキスト保持
- **llm_clients/gemini.py**: `_convert_messages` で `tool_calls` → `FunctionCall` 変換、`role:"tool"` → `FunctionResponse` 変換を追加。streaming/同期の両方で `thought_signature` をキャプチャし tool_detection に含める。ストリーミングテキスト蓄積のバグ修正
- **builtin_data/tools/image_generator.py**: モデルフォールバックチェーン実装、`HttpRetryOptions(attempts=1)` で SDK 内部リトライ無効化
- **builtin_data/playbooks/public/agentic_chat_playbook.json**: meta playbook 化、speak/memorize 追加、record ノード削除
- **frontend/src/app/page.tsx**: `streaming_discard` イベント処理追加
- **llm_clients/openai.py, xai.py, manager/state.py**: ツールモード streaming 対応の軽微な調整

## Test plan
- [ ] agentic_chat で画像生成を依頼 → ツール結果の実アイテムIDが使われること確認
- [ ] ツール呼び出し時のテキスト発話が Building 履歴に残ること確認
- [ ] thinking モデル（Gemini Flash 等）で thought_signature エラーが出ないこと確認
- [ ] 画像生成で 504 発生時にフォールバックモデルに切り替わること確認
- [ ] ツール不要の通常会話がストリーミングで正常に表示されること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)