### PR TITLE
Fix Chronicle max_messages being ignored and progress resetting per run

### DIFF
--- a/api/routes/people/arasuji.py
+++ b/api/routes/people/arasuji.py
@@ -4,6 +4,7 @@ from api.deps import get_manager
 from .models import (
     ArasujiStatsResponse, ArasujiListResponse, ArasujiEntryItem, SourceMessageItem,
     GenerateArasujiRequest, GenerationJobStatus, ChronicleCostEstimate,
+    MessagesByIdsRequest,
 )
 import sqlite3
 import logging
@@ -37,6 +38,7 @@ def _create_job(persona_id: str) -> str:
             "error": None,
             "error_code": None,
             "error_detail": None,
+            "error_meta": None,
             "created_at": time.time(),
         }
     return job_id
@@ -473,6 +475,41 @@ def get_arasuji_messages(
     finally:
         conn.close()
 
+@router.post("/{persona_id}/arasuji/messages-by-ids", response_model=List[SourceMessageItem], tags=["Chronicle"])
+def get_messages_by_ids(
+    persona_id: str,
+    request: MessagesByIdsRequest,
+    manager = Depends(get_manager),
+):
+    """Get messages by their IDs (for error investigation)."""
+    from sai_memory.memory.storage import get_message
+
+    if not request.ids:
+        return []
+
+    conn = _get_arasuji_db(persona_id)
+    if not conn:
+        raise HTTPException(status_code=404, detail=f"Memory database not found for {persona_id}")
+
+    try:
+        messages = []
+        for msg_id in request.ids:
+            msg = get_message(conn, msg_id)
+            if msg:
+                messages.append(SourceMessageItem(
+                    id=msg.id,
+                    role=msg.role,
+                    content=msg.content or "",
+                    created_at=msg.created_at,
+                ))
+        messages.sort(key=lambda m: m.created_at)
+        return messages
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to get messages: {e}")
+    finally:
+        conn.close()
+
+
 @router.post("/{persona_id}/arasuji/{entry_id}/regenerate", tags=["Chronicle"])
 async def regenerate_arasuji_entry(
     persona_id: str,
@@ -713,6 +750,7 @@ def _run_chronicle_generation(
             error=e.user_message,
             error_code=e.error_code,
             error_detail=str(e),
+            error_meta=getattr(e, "batch_meta", None),
         )
     except Exception as e:
         LOGGER.exception(f"Chronicle generation failed: {e}")
@@ -803,4 +841,5 @@ async def get_arasuji_generation_status(
         error=job.get("error"),
         error_code=job.get("error_code"),
         error_detail=job.get("error_detail"),
+        error_meta=job.get("error_meta"),
     )

--- a/api/routes/people/arasuji.py
+++ b/api/routes/people/arasuji.py
@@ -678,6 +678,7 @@ def _run_chronicle_generation(
 
         level1_entries, consolidated_entries = generator.generate_unprocessed(
             all_messages,
+            max_messages=max_messages,
             progress_callback=progress_callback,
             batch_callback=batch_callback,
             cancel_check=cancel_check,

--- a/api/routes/people/models.py
+++ b/api/routes/people/models.py
@@ -431,3 +431,9 @@ class GenerationJobStatus(BaseModel):
     error: Optional[str] = None  # エラーメッセージ（ユーザー向け）
     error_code: Optional[str] = None  # エラーコード (payment, authentication, rate_limit, etc.)
     error_detail: Optional[str] = None  # 技術的詳細（開発者向け）
+    error_meta: Optional[dict] = None  # エラー発生バッチのメタデータ (message_ids, start_time, end_time)
+
+
+class MessagesByIdsRequest(BaseModel):
+    """メッセージID指定取得リクエスト"""
+    ids: List[str]

--- a/api/routes/people/models.py
+++ b/api/routes/people/models.py
@@ -434,6 +434,11 @@ class GenerationJobStatus(BaseModel):
     error_meta: Optional[dict] = None  # エラー発生バッチのメタデータ (message_ids, start_time, end_time)
 
 
+class UpdateArasujiEntryRequest(BaseModel):
+    """Chronicleエントリ更新リクエスト"""
+    content: str
+
+
 class MessagesByIdsRequest(BaseModel):
     """メッセージID指定取得リクエスト"""
     ids: List[str]

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1621,31 +1621,24 @@ export default function Home() {
                                             ))}
                                         </div>
                                     )}
-                                    {msg.isError ? (() => {
-                                        const guidanceMap: Record<string, string> = {
-                                            empty_response: 'しばらく時間を置いてから再送信してください。繰り返し発生する場合は、サーバーの障害情報を確認してください。',
-                                            safety_filter: '送信した内容が安全性フィルターに該当した可能性があります。内容を変更して再送信してください。',
-                                            timeout: 'サーバーが混雑している可能性があります。しばらく時間を置いてから再送信してください。',
-                                            rate_limit: 'API利用制限に達しています。しばらく時間を置いてから再送信してください。',
-                                            payment: 'APIキーの残高や支払い設定を確認してください。',
-                                            authentication: 'APIキーの設定を確認してください。',
-                                            server_error: 'LLMサーバーで障害が発生しています。しばらく時間を置いてから再送信してください。',
-                                        };
-                                        const iconMap: Record<string, string> = {
-                                            rate_limit: '⏱️', timeout: '⏰', safety_filter: '🛡️',
-                                            server_error: '🔧', empty_response: '📭',
-                                            authentication: '🔑', payment: '💳',
-                                        };
-                                        const icon = (msg.errorCode && iconMap[msg.errorCode]) || '⚠️';
-                                        const guidance = (msg.errorCode && guidanceMap[msg.errorCode]) || '予期しないエラーが発生しました。問題が続く場合は管理者に連絡してください。';
-                                        return (
+                                    {msg.isError ? (
                                         <div className={styles.errorContent}>
                                             <div className={styles.errorHeader}>
-                                                <span className={styles.errorIcon}>{icon}</span>
+                                                <span className={styles.errorIcon}>
+                                                    {({rate_limit: '⏱️', timeout: '⏰', safety_filter: '🛡️', server_error: '🔧', empty_response: '📭', authentication: '🔑', payment: '💳'} as Record<string, string>)[msg.errorCode || ''] || '⚠️'}
+                                                </span>
                                                 <span className={styles.errorMessage}>{msg.content}</span>
                                             </div>
                                             <div style={{ fontSize: '0.85em', opacity: 0.75, lineHeight: 1.4, marginTop: '4px' }}>
-                                                {guidance}
+                                                {({
+                                                    empty_response: 'しばらく時間を置いてから再送信してください。繰り返し発生する場合は、サーバーの障害情報を確認してください。',
+                                                    safety_filter: '送信した内容が安全性フィルターに該当した可能性があります。内容を変更して再送信してください。',
+                                                    timeout: 'サーバーが混雑している可能性があります。しばらく時間を置いてから再送信してください。',
+                                                    rate_limit: 'API利用制限に達しています。しばらく時間を置いてから再送信してください。',
+                                                    payment: 'APIキーの残高や支払い設定を確認してください。',
+                                                    authentication: 'APIキーの設定を確認してください。',
+                                                    server_error: 'LLMサーバーで障害が発生しています。しばらく時間を置いてから再送信してください。',
+                                                } as Record<string, string>)[msg.errorCode || ''] || '予期しないエラーが発生しました。問題が続く場合は管理者に連絡してください。'}
                                             </div>
                                             {msg.errorDetail && (
                                                 <details className={styles.errorDetails}>
@@ -1653,8 +1646,7 @@ export default function Home() {
                                                     <pre>{msg.errorDetail}</pre>
                                                 </details>
                                             )}
-                                        </div>);
-                                    })()
+                                        </div>
                                     ) : msg.isWarning ? (
                                         <div className={styles.warningContent}>
                                             <span className={styles.warningMessage}>{msg.content}</span>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1621,20 +1621,31 @@ export default function Home() {
                                             ))}
                                         </div>
                                     )}
-                                    {msg.isError ? (
+                                    {msg.isError ? (() => {
+                                        const guidanceMap: Record<string, string> = {
+                                            empty_response: 'しばらく時間を置いてから再送信してください。繰り返し発生する場合は、サーバーの障害情報を確認してください。',
+                                            safety_filter: '送信した内容が安全性フィルターに該当した可能性があります。内容を変更して再送信してください。',
+                                            timeout: 'サーバーが混雑している可能性があります。しばらく時間を置いてから再送信してください。',
+                                            rate_limit: 'API利用制限に達しています。しばらく時間を置いてから再送信してください。',
+                                            payment: 'APIキーの残高や支払い設定を確認してください。',
+                                            authentication: 'APIキーの設定を確認してください。',
+                                            server_error: 'LLMサーバーで障害が発生しています。しばらく時間を置いてから再送信してください。',
+                                        };
+                                        const iconMap: Record<string, string> = {
+                                            rate_limit: '⏱️', timeout: '⏰', safety_filter: '🛡️',
+                                            server_error: '🔧', empty_response: '📭',
+                                            authentication: '🔑', payment: '💳',
+                                        };
+                                        const icon = (msg.errorCode && iconMap[msg.errorCode]) || '⚠️';
+                                        const guidance = (msg.errorCode && guidanceMap[msg.errorCode]) || '予期しないエラーが発生しました。問題が続く場合は管理者に連絡してください。';
+                                        return (
                                         <div className={styles.errorContent}>
                                             <div className={styles.errorHeader}>
-                                                <span className={styles.errorIcon}>
-                                                    {msg.errorCode === 'rate_limit' && '⏱️'}
-                                                    {msg.errorCode === 'timeout' && '⏰'}
-                                                    {msg.errorCode === 'safety_filter' && '🛡️'}
-                                                    {msg.errorCode === 'server_error' && '🔧'}
-                                                    {msg.errorCode === 'empty_response' && '📭'}
-                                                    {msg.errorCode === 'authentication' && '🔑'}
-                                                    {msg.errorCode === 'payment' && '💳'}
-                                                    {(!msg.errorCode || msg.errorCode === 'unknown' || !['rate_limit', 'timeout', 'safety_filter', 'server_error', 'empty_response', 'authentication', 'payment'].includes(msg.errorCode)) && '⚠️'}
-                                                </span>
+                                                <span className={styles.errorIcon}>{icon}</span>
                                                 <span className={styles.errorMessage}>{msg.content}</span>
+                                            </div>
+                                            <div style={{ fontSize: '0.85em', opacity: 0.75, lineHeight: 1.4, marginTop: '4px' }}>
+                                                {guidance}
                                             </div>
                                             {msg.errorDetail && (
                                                 <details className={styles.errorDetails}>
@@ -1642,7 +1653,8 @@ export default function Home() {
                                                     <pre>{msg.errorDetail}</pre>
                                                 </details>
                                             )}
-                                        </div>
+                                        </div>);
+                                    })()
                                     ) : msg.isWarning ? (
                                         <div className={styles.warningContent}>
                                             <span className={styles.warningMessage}>{msg.content}</span>

--- a/frontend/src/components/ChronicleConfirmDialog.module.css
+++ b/frontend/src/components/ChronicleConfirmDialog.module.css
@@ -1,0 +1,171 @@
+.modal {
+    background: #1f2937;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 440px;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1.25rem 1.5rem 1rem;
+}
+
+.icon {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #374151;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #a78bfa;
+}
+
+.headerText h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: #f9fafb;
+    font-weight: 600;
+}
+
+.headerText p {
+    margin: 0.25rem 0 0;
+    font-size: 0.8rem;
+    color: #9ca3af;
+}
+
+.body {
+    padding: 0 1.5rem 1rem;
+}
+
+.info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: #111827;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+}
+
+.infoRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.875rem;
+}
+
+.infoLabel {
+    color: #9ca3af;
+}
+
+.infoValue {
+    color: #f9fafb;
+    font-weight: 500;
+}
+
+.timer {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #6b7280;
+    text-align: right;
+}
+
+.timerWarn {
+    color: #f59e0b;
+}
+
+.actions {
+    padding: 0.75rem 1.5rem 1.25rem;
+    display: flex;
+    gap: 0.5rem;
+}
+
+.generateBtn {
+    flex: 1;
+    padding: 0.625rem 1rem;
+    border-radius: 8px;
+    border: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+    background: #7c3aed;
+    color: #fff;
+}
+
+.generateBtn:hover {
+    background: #6d28d9;
+}
+
+.skipBtn {
+    flex: 1;
+    padding: 0.625rem 1rem;
+    border-radius: 8px;
+    border: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+    background: #374151;
+    color: #d1d5db;
+}
+
+.skipBtn:hover {
+    background: #4b5563;
+}
+
+/* ── Light mode overrides ── */
+
+:global([data-theme="light"]) .modal {
+    background: #ffffff;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+}
+
+:global([data-theme="light"]) .icon {
+    background: #ede9fe;
+    color: #7c3aed;
+}
+
+:global([data-theme="light"]) .headerText h3 {
+    color: #1e293b;
+}
+
+:global([data-theme="light"]) .headerText p {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .info {
+    background: #f8fafc;
+}
+
+:global([data-theme="light"]) .infoLabel {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .infoValue {
+    color: #1e293b;
+}
+
+:global([data-theme="light"]) .timer {
+    color: #94a3b8;
+}
+
+:global([data-theme="light"]) .timerWarn {
+    color: #d97706;
+}
+
+:global([data-theme="light"]) .skipBtn {
+    background: #e2e8f0;
+    color: #475569;
+}
+
+:global([data-theme="light"]) .skipBtn:hover {
+    background: #cbd5e1;
+}

--- a/frontend/src/components/ChronicleConfirmDialog.tsx
+++ b/frontend/src/components/ChronicleConfirmDialog.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { BookOpen } from 'lucide-react';
+import ModalOverlay from './common/ModalOverlay';
+import styles from './ChronicleConfirmDialog.module.css';
+
+export interface ChronicleConfirmData {
+    requestId: string;
+    unprocessedMessages: number;
+    totalMessages: number;
+    estimatedLlmCalls: number;
+    modelName: string;
+    personaName: string;
+}
+
+interface ChronicleConfirmDialogProps {
+    request: ChronicleConfirmData;
+    onRespond: (requestId: string, decision: string) => void;
+}
+
+const TIMEOUT_SEC = 60;
+
+export default function ChronicleConfirmDialog({ request, onRespond }: ChronicleConfirmDialogProps) {
+    const [remaining, setRemaining] = useState(TIMEOUT_SEC);
+
+    useEffect(() => {
+        setRemaining(TIMEOUT_SEC);
+        const interval = setInterval(() => {
+            setRemaining(prev => {
+                if (prev <= 1) {
+                    clearInterval(interval);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+        return () => clearInterval(interval);
+    }, [request.requestId]);
+
+    const respond = useCallback((decision: string) => {
+        onRespond(request.requestId, decision);
+    }, [request.requestId, onRespond]);
+
+    return (
+        <ModalOverlay onClose={() => respond('deny')}>
+            <div className={styles.modal}>
+                <div className={styles.header}>
+                    <div className={styles.icon}>
+                        <BookOpen size={18} />
+                    </div>
+                    <div className={styles.headerText}>
+                        <h3>Chronicle生成の確認</h3>
+                        <p>{request.personaName} の記憶を整理します</p>
+                    </div>
+                </div>
+
+                <div className={styles.body}>
+                    <div className={styles.info}>
+                        <div className={styles.infoRow}>
+                            <span className={styles.infoLabel}>未処理メッセージ</span>
+                            <span className={styles.infoValue}>{request.unprocessedMessages.toLocaleString()} 件</span>
+                        </div>
+                        <div className={styles.infoRow}>
+                            <span className={styles.infoLabel}>推定LLM呼び出し</span>
+                            <span className={styles.infoValue}>{request.estimatedLlmCalls} 回</span>
+                        </div>
+                        <div className={styles.infoRow}>
+                            <span className={styles.infoLabel}>モデル</span>
+                            <span className={styles.infoValue}>{request.modelName}</span>
+                        </div>
+                    </div>
+                    <div className={`${styles.timer} ${remaining <= 10 ? styles.timerWarn : ''}`}>
+                        {remaining > 0 ? `${remaining}秒後に自動スキップ` : 'タイムアウト...'}
+                    </div>
+                </div>
+
+                <div className={styles.actions}>
+                    <button className={styles.generateBtn} onClick={() => respond('allow')}>
+                        生成する
+                    </button>
+                    <button className={styles.skipBtn} onClick={() => respond('deny')}>
+                        スキップ
+                    </button>
+                </div>
+            </div>
+        </ModalOverlay>
+    );
+}

--- a/frontend/src/components/memory/ArasujiViewer.module.css
+++ b/frontend/src/components/memory/ArasujiViewer.module.css
@@ -998,3 +998,84 @@
 :global([data-theme="light"]) .offsetHint {
     color: #64748b;
 }
+
+/* Edit Interface */
+.editInterface {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.editTextarea {
+    width: 100%;
+    min-height: 120px;
+    background-color: #141517;
+    border: 1px solid #444;
+    color: #e0e0e0;
+    padding: 8px;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    resize: vertical;
+}
+
+.editButtons {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.editSaveBtn,
+.editCancelBtn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 12px;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    border: none;
+}
+
+.editSaveBtn {
+    background-color: #1971c2;
+    color: white;
+}
+
+.editSaveBtn:hover {
+    background-color: #1864ab;
+}
+
+.editCancelBtn {
+    background-color: #343a40;
+    color: #ccc;
+}
+
+.editCancelBtn:hover {
+    background-color: #212529;
+}
+
+:global([data-theme="light"]) .editTextarea {
+    background-color: #ffffff;
+    border-color: #cbd5e1;
+    color: #1f2937;
+}
+
+:global([data-theme="light"]) .editSaveBtn {
+    background-color: #2563eb;
+    color: white;
+}
+
+:global([data-theme="light"]) .editSaveBtn:hover {
+    background-color: #1d4ed8;
+}
+
+:global([data-theme="light"]) .editCancelBtn {
+    background-color: #f1f5f9;
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .editCancelBtn:hover {
+    background-color: #e2e8f0;
+}

--- a/frontend/src/components/memory/ArasujiViewer.tsx
+++ b/frontend/src/components/memory/ArasujiViewer.tsx
@@ -160,6 +160,25 @@ export default function ArasujiViewer({ personaId }: ArasujiViewerProps) {
         }
     };
 
+    // Delete a message from the error batch (for removing problematic messages)
+    const deleteErrorBatchMessage = async (messageId: string) => {
+        if (!confirm("このメッセージを削除しますか？この操作は元に戻せません。")) return;
+        try {
+            const res = await fetch(`/api/people/${personaId}/messages/${messageId}`, {
+                method: 'DELETE',
+            });
+            if (res.ok) {
+                setErrorBatchMessages(prev => prev.filter(m => m.id !== messageId));
+            } else {
+                const err = await res.json().catch(() => ({}));
+                alert(`削除に失敗しました: ${err.detail || 'Unknown error'}`);
+            }
+        } catch (e) {
+            console.error("Failed to delete message", e);
+            alert('メッセージの削除中にエラーが発生しました');
+        }
+    };
+
     // Load source messages when a level-1 entry is selected
     useEffect(() => {
         if (selectedEntry && selectedEntry.level === 1 && selectedEntry.source_ids.length > 0) {
@@ -545,6 +564,19 @@ export default function ArasujiViewer({ personaId }: ArasujiViewerProps) {
                                                             <span className={styles.sourceMessageTime}>
                                                                 {new Date(msg.created_at * 1000).toLocaleString()}
                                                             </span>
+                                                            <button
+                                                                onClick={() => deleteErrorBatchMessage(msg.id)}
+                                                                title="このメッセージを削除"
+                                                                style={{
+                                                                    background: 'none', border: 'none', cursor: 'pointer',
+                                                                    opacity: 0.5, padding: '2px', marginLeft: 'auto',
+                                                                    color: 'inherit', display: 'flex', alignItems: 'center',
+                                                                }}
+                                                                onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
+                                                                onMouseLeave={e => (e.currentTarget.style.opacity = '0.5')}
+                                                            >
+                                                                <Trash2 size={13} />
+                                                            </button>
                                                         </div>
                                                         <div className={styles.sourceMessageContent}>
                                                             {msg.content}

--- a/frontend/src/components/memory/ArasujiViewer.tsx
+++ b/frontend/src/components/memory/ArasujiViewer.tsx
@@ -454,28 +454,49 @@ export default function ArasujiViewer({ personaId }: ArasujiViewerProps) {
                         <button onClick={() => setGenerationJob(null)}>×</button>
                     </div>
                 )}
-                {generationJob && generationJob.status === 'failed' && (
-                    <div className={styles.generationError}>
-                        <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', flex: 1 }}>
-                            <span>
-                                {generationJob.error_code === 'payment' && '💳 '}
-                                {generationJob.error_code === 'authentication' && '🔑 '}
-                                {generationJob.error_code === 'rate_limit' && '⏱️ '}
-                                {generationJob.error_code === 'timeout' && '⏰ '}
-                                {generationJob.error_code === 'server_error' && '🔧 '}
-                                {(!generationJob.error_code || !['payment', 'authentication', 'rate_limit', 'timeout', 'server_error'].includes(generationJob.error_code)) && '❌ '}
-                                {generationJob.error || '生成に失敗しました'}
-                            </span>
-                            {generationJob.error_detail && (
-                                <details style={{ fontSize: '0.85em', marginTop: '4px' }}>
-                                    <summary style={{ cursor: 'pointer', opacity: 0.7 }}>Technical Details</summary>
-                                    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: '4px 0', fontSize: '0.9em', opacity: 0.8 }}>{generationJob.error_detail}</pre>
-                                </details>
-                            )}
+                {generationJob && generationJob.status === 'failed' && (() => {
+                    const code = generationJob.error_code;
+                    const iconMap: Record<string, string> = {
+                        payment: '💳',
+                        authentication: '🔑',
+                        rate_limit: '⏱️',
+                        timeout: '⏰',
+                        server_error: '🔧',
+                        empty_response: '📭',
+                        safety_filter: '🛡️',
+                    };
+                    const guidanceMap: Record<string, string> = {
+                        empty_response: 'しばらく時間を置いてから再実行してください。繰り返し発生する場合は、サーバーの障害情報を確認してください。',
+                        safety_filter: '該当メッセージに不適切と判定された内容が含まれている可能性があります。メッセージの内容を確認し、必要に応じて修正・削除してから再実行してください。',
+                        timeout: 'サーバーが混雑している可能性があります。しばらく時間を置いてから再実行してください。',
+                        rate_limit: 'API利用制限に達しています。しばらく時間を置いてから再実行してください。',
+                        payment: 'APIキーの残高や支払い設定を確認してください。',
+                        authentication: 'APIキーの設定を確認してください。',
+                        server_error: 'LLMサーバーで障害が発生しています。しばらく時間を置いてから再実行してください。',
+                    };
+                    const icon = (code && iconMap[code]) || '❌';
+                    const guidance = (code && guidanceMap[code]) || '予期しないエラーが発生しました。Technical Detailsを確認し、問題が続く場合は管理者に連絡してください。';
+                    return (
+                        <div className={styles.generationError}>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', flex: 1 }}>
+                                <span>
+                                    {icon}{' '}
+                                    {generationJob.error || '生成に失敗しました'}
+                                </span>
+                                <span style={{ fontSize: '0.85em', opacity: 0.75, lineHeight: 1.4 }}>
+                                    {guidance}
+                                </span>
+                                {generationJob.error_detail && (
+                                    <details style={{ fontSize: '0.85em', marginTop: '2px' }}>
+                                        <summary style={{ cursor: 'pointer', opacity: 0.7 }}>Technical Details</summary>
+                                        <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: '4px 0', fontSize: '0.9em', opacity: 0.8 }}>{generationJob.error_detail}</pre>
+                                    </details>
+                                )}
+                            </div>
+                            <button onClick={() => setGenerationJob(null)}>×</button>
                         </div>
-                        <button onClick={() => setGenerationJob(null)}>×</button>
-                    </div>
-                )}
+                    );
+                })()}
 
                 {/* Level Filter */}
                 {stats && stats.max_level > 0 && (

--- a/llm_clients/gemini.py
+++ b/llm_clients/gemini.py
@@ -837,6 +837,7 @@ class GeminiClient(LLMClient):
                     last_chunk = None
                     last_finish_reason = None
                     last_safety_ratings = None
+                    prompt_block_reason = None
 
                     for chunk in stream:
                         last_chunk = chunk
@@ -848,6 +849,13 @@ class GeminiClient(LLMClient):
                         last_chunk_time = now
                         saw_any_chunk = True
                         get_llm_logger().debug("Gemini stream chunk:\n%s", chunk)
+
+                        # Check prompt-level block (PROHIBITED_CONTENT etc.)
+                        pf = getattr(chunk, "prompt_feedback", None)
+                        if pf:
+                            br = getattr(pf, "block_reason", None)
+                            if br is not None:
+                                prompt_block_reason = br
 
                         if chunk.candidates:
                             candidate = chunk.candidates[0]
@@ -862,12 +870,35 @@ class GeminiClient(LLMClient):
 
                     if not saw_any_chunk:
                         raise EmptyResponseError("No chunks received from stream")
+
+                    # Prompt-level block: input rejected before generation
+                    if prompt_block_reason:
+                        block_str = str(prompt_block_reason)
+                        _block_usage = getattr(last_chunk, "usage_metadata", None) if last_chunk else None
+                        logging.warning(
+                            "[gemini] Prompt blocked: block_reason=%s, prompt_tokens=%s",
+                            block_str,
+                            getattr(_block_usage, "prompt_token_count", None) if _block_usage else None,
+                        )
+                        raise SafetyFilterError(
+                            f"Prompt blocked by Gemini: {block_str}",
+                            user_message=(
+                                f"入力内容がGeminiの安全性フィルターによりブロックされました（{block_str}）。"
+                                "該当メッセージの内容を確認してください。"
+                            ),
+                        )
+
                     if not all_parts:
+                        # Log usage even for empty responses (did tokens get consumed?)
+                        _empty_usage = getattr(last_chunk, "usage_metadata", None) if last_chunk else None
                         logging.warning(
                             "[gemini] Stream had chunks but no content parts. "
-                            "finish_reason=%s, safety_ratings=%s",
+                            "finish_reason=%s, safety_ratings=%s, "
+                            "prompt_tokens=%s, total_tokens=%s",
                             last_finish_reason,
                             [str(r) for r in (last_safety_ratings or [])],
+                            getattr(_empty_usage, "prompt_token_count", None) if _empty_usage else None,
+                            getattr(_empty_usage, "total_token_count", None) if _empty_usage else None,
                         )
                         if last_finish_reason and "SAFETY" in str(last_finish_reason).upper():
                             blocked = [
@@ -964,6 +995,25 @@ class GeminiClient(LLMClient):
                         output_tokens=getattr(usage, "candidates_token_count", 0) or 0,
                         cached_tokens=cached,
                     )
+
+                # Check prompt-level block (PROHIBITED_CONTENT etc.)
+                pf = getattr(resp, "prompt_feedback", None)
+                if pf:
+                    br = getattr(pf, "block_reason", None)
+                    if br is not None:
+                        block_str = str(br)
+                        logging.warning(
+                            "[gemini] Prompt blocked (non-streaming): block_reason=%s, prompt_tokens=%s",
+                            block_str,
+                            getattr(usage, "prompt_token_count", None) if usage else None,
+                        )
+                        raise SafetyFilterError(
+                            f"Prompt blocked by Gemini: {block_str}",
+                            user_message=(
+                                f"入力内容がGeminiの安全性フィルターによりブロックされました（{block_str}）。"
+                                "該当メッセージの内容を確認してください。"
+                            ),
+                        )
 
                 if not resp.candidates:
                     logging.warning("[gemini] No candidates (attempt %d/%d)", attempt + 1, max_retries)

--- a/llm_clients/llama_cpp.py
+++ b/llm_clients/llama_cpp.py
@@ -11,8 +11,8 @@ from .base import LLMClient
 
 logger = logging.getLogger(__name__)
 
-# Retry configuration (fewer retries for local models)
-MAX_RETRIES = 2
+# Retry configuration
+MAX_RETRIES = 3
 INITIAL_BACKOFF = 0.5  # seconds
 
 

--- a/sai_memory/arasuji/generator.py
+++ b/sai_memory/arasuji/generator.py
@@ -921,6 +921,12 @@ class ArasujiGenerator:
                 e.user_message = (
                     f"メッセージ {i+1}〜{i+len(batch)} の処理中: {e.user_message}"
                 )
+                # Attach batch metadata for frontend navigation
+                e.batch_meta = {
+                    "message_ids": [m.id for m in batch],
+                    "start_time": min(m.created_at for m in batch),
+                    "end_time": max(m.created_at for m in batch),
+                }
                 raise
             if not entry:
                 raise RuntimeError(

--- a/sai_memory/arasuji/generator.py
+++ b/sai_memory/arasuji/generator.py
@@ -918,33 +918,20 @@ class ArasujiGenerator:
 
             LOGGER.info(f"Processing messages {i+1}-{i+len(batch)} of {total}")
 
-            # Generate level-1 arasuji with retry
-            max_retries = 3
-            entry = None
-            for attempt in range(max_retries):
-                entry = generate_level1_arasuji(
-                    self.client,
-                    self.conn,
-                    batch,
-                    dry_run=dry_run,
-                    include_timestamp=self.include_timestamp,
-                    memopedia_context=self.memopedia_context,
-                    debug_log_path=self.debug_log_path,
-                    persona_id=self.persona_id,
-                )
-                if entry:
-                    break
-                LOGGER.warning(
-                    f"Level-1 generation failed (attempt {attempt + 1}/{max_retries}) "
-                    f"for messages {i+1}-{i+len(batch)}"
-                )
-                if attempt < max_retries - 1:
-                    time.sleep(2 ** attempt)
-            else:
-                # All retries failed — abort generation
+            # Generate level-1 arasuji (retries are handled inside each LLM client)
+            entry = generate_level1_arasuji(
+                self.client,
+                self.conn,
+                batch,
+                dry_run=dry_run,
+                include_timestamp=self.include_timestamp,
+                memopedia_context=self.memopedia_context,
+                debug_log_path=self.debug_log_path,
+                persona_id=self.persona_id,
+            )
+            if not entry:
                 raise RuntimeError(
-                    f"Level-1 generation failed after {max_retries} attempts "
-                    f"for messages {i+1}-{i+len(batch)}"
+                    f"Level-1 generation failed for messages {i+1}-{i+len(batch)}"
                 )
 
             level1_entries.append(entry)

--- a/sai_memory/arasuji/storage.py
+++ b/sai_memory/arasuji/storage.py
@@ -275,6 +275,29 @@ def mark_consolidated(
     conn.commit()
 
 
+def update_entry_content(
+    conn: sqlite3.Connection,
+    entry_id: str,
+    content: str,
+) -> bool:
+    """Update the content of an arasuji entry.
+
+    Args:
+        conn: Database connection
+        entry_id: ID of the entry to update
+        content: New content text
+
+    Returns:
+        True if the entry was found and updated, False otherwise
+    """
+    cur = conn.execute(
+        "UPDATE arasuji_entries SET content = ? WHERE id = ?",
+        (content, entry_id),
+    )
+    conn.commit()
+    return cur.rowcount > 0
+
+
 def get_all_entries_ordered(
     conn: sqlite3.Connection,
     *,
@@ -648,7 +671,7 @@ def find_covering_entry(
         SELECT id, level, content, source_ids_json, start_time, end_time,
                source_count, message_count, parent_id, is_consolidated, created_at
         FROM arasuji_entries
-        WHERE level = ? AND start_time <= ? AND end_time >= ?
+        WHERE level = ? AND start_time <= ? AND end_time > ?
         ORDER BY start_time ASC
         LIMIT 1
         """,

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -243,6 +243,7 @@ class TestLLMClients(unittest.TestCase):
 
         # Non-tool mode uses streaming, so mock generate_content_stream
         mock_chunk = MagicMock()
+        mock_chunk.prompt_feedback = None
         mock_candidate = MagicMock()
         mock_candidate.content.parts = [
             MagicMock(text="Test Gemini response", function_call=None, thought=False),
@@ -373,6 +374,7 @@ class TestLLMClients(unittest.TestCase):
 
         # Paid client streaming succeeds
         mock_chunk = MagicMock()
+        mock_chunk.prompt_feedback = None
         cand = MagicMock()
         cand.content.parts = [MagicMock(text="OK", function_call=None, thought=False)]
         mock_chunk.candidates = [cand]
@@ -484,6 +486,7 @@ class TestLLMClients(unittest.TestCase):
 
         # Schema mode with tools=[] goes through non-tool streaming path
         mock_chunk = MagicMock()
+        mock_chunk.prompt_feedback = None
         mock_candidate = MagicMock()
         mock_candidate.content.parts = [MagicMock(text='{"key":"value"}', function_call=None, thought=False)]
         mock_chunk.candidates = [mock_candidate]


### PR DESCRIPTION
## Summary
- **`max_messages` が無視されていたバグを修正**: UIで「最大500メッセージ」と設定しても、バックエンドでパラメータが使われておらず全メッセージが処理されていた。`generate_unprocessed()` に `max_messages` パラメータを追加し、qualifying runs の合計がこの上限を超えないように制限
- **プログレス表示がrun単位でリセットされるUX問題を修正**: 未処理メッセージが複数の連続run（既に処理済みのメッセージで分断されたグループ）に分かれる場合、各runの先頭でプログレスが `0/N` にリセットされ「エンドレスで生成し続けている」ように見えていた。run内のローカル進捗をグローバルオフセットでラップし、全run通算の `M/Total` として表示するように変更

## Test plan
- [ ] Chronicle生成をmax_messages=100で実行し、100件を超えるメッセージが処理されないことを確認
- [ ] 未処理メッセージが複数runに分かれる場合、プログレスがリセットせず連続カウントになることを確認
- [ ] max_messages未指定（metabolism自動トリガー）の場合、全メッセージが処理されることを確認
- [ ] キャンセル機能が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)