### PR TITLE
Add Chronicle全削除 and Memopedia全削除 buttons to debug tab

### DIFF
--- a/api/routes/people/arasuji.py
+++ b/api/routes/people/arasuji.py
@@ -428,6 +428,28 @@ def delete_arasuji_entry(persona_id: str, entry_id: str, manager = Depends(get_m
     finally:
         conn.close()
 
+@router.delete("/{persona_id}/arasuji", tags=["Chronicle"])
+def delete_all_arasuji_entries(persona_id: str, manager=Depends(get_manager)):
+    """Delete ALL Chronicle entries and reset progress."""
+    from sai_memory.arasuji.storage import clear_all_entries
+
+    conn = _get_arasuji_db(persona_id)
+    if not conn:
+        raise HTTPException(status_code=404, detail=f"Memory database not found for {persona_id}")
+
+    try:
+        deleted_count = clear_all_entries(conn)
+        return {
+            "success": True,
+            "deleted_count": deleted_count,
+            "message": f"Deleted {deleted_count} Chronicle entries",
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to delete Chronicle entries: {e}")
+    finally:
+        conn.close()
+
+
 @router.get("/{persona_id}/arasuji/{entry_id}/messages", response_model=List[SourceMessageItem], tags=["Chronicle"])
 def get_arasuji_messages(
     persona_id: str,

--- a/api/routes/people/memopedia.py
+++ b/api/routes/people/memopedia.py
@@ -146,6 +146,22 @@ def delete_memopedia_page(persona_id: str, page_id: str, manager = Depends(get_m
             raise HTTPException(status_code=500, detail=f"Memopedia error: {e}")
 
 
+@router.delete("/{persona_id}/memopedia/pages", tags=["Memopedia"])
+def delete_all_memopedia_pages(persona_id: str, manager=Depends(get_manager)):
+    """Delete ALL non-root Memopedia pages (and their edit history)."""
+    with get_adapter(persona_id, manager) as adapter:
+        try:
+            memopedia = _get_memopedia(adapter)
+            deleted_count = memopedia.clear_all_pages()
+            return {
+                "success": True,
+                "deleted_count": deleted_count,
+                "message": f"Deleted {deleted_count} Memopedia pages",
+            }
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to delete Memopedia pages: {e}")
+
+
 @router.post("/{persona_id}/memopedia/pages")
 def create_memopedia_page(
     persona_id: str,

--- a/frontend/src/components/memory/MemoryRecall.module.css
+++ b/frontend/src/components/memory/MemoryRecall.module.css
@@ -324,6 +324,123 @@
     color: #ccc;
 }
 
+/* Danger Zone */
+.dangerZone {
+    margin-top: 3rem;
+    padding: 1.25rem;
+    border: 1px solid rgba(250, 82, 82, 0.3);
+    border-radius: 8px;
+    background-color: rgba(250, 82, 82, 0.05);
+}
+
+.dangerTitle {
+    margin: 0 0 0.5rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fa5252;
+}
+
+.dangerDescription {
+    margin: 0 0 1rem 0;
+    font-size: 0.85rem;
+    color: #888;
+}
+
+.dangerButtons {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.dangerButton {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 1rem;
+    background-color: transparent;
+    border: 1px solid rgba(250, 82, 82, 0.4);
+    border-radius: 6px;
+    color: #fa5252;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.dangerButton:hover:not(:disabled) {
+    background-color: rgba(250, 82, 82, 0.1);
+    border-color: #fa5252;
+}
+
+.dangerButton:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.confirmGroup {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.confirmText {
+    font-size: 0.85rem;
+    color: #ffc9c9;
+}
+
+.confirmYes {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 0.75rem;
+    background-color: #fa5252;
+    border: none;
+    border-radius: 6px;
+    color: #fff;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.confirmYes:hover:not(:disabled) {
+    background-color: #e03131;
+}
+
+.confirmYes:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.confirmNo {
+    padding: 0.4rem 0.75rem;
+    background-color: transparent;
+    border: 1px solid #444;
+    border-radius: 6px;
+    color: #aaa;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.confirmNo:hover:not(:disabled) {
+    border-color: #666;
+    color: #ccc;
+}
+
+.confirmNo:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.deleteResult {
+    margin-top: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: 6px;
+    font-size: 0.85rem;
+    color: #ccc;
+}
+
 /* Light Mode Overrides */
 :global([data-theme="light"]) .container {
     color: #1f2937;
@@ -442,4 +559,54 @@
 :global([data-theme="light"]) .clearDateBtn:hover {
     border-color: #cbd5e1;
     color: #1f2937;
+}
+
+:global([data-theme="light"]) .dangerZone {
+    border-color: rgba(220, 38, 38, 0.3);
+    background-color: rgba(220, 38, 38, 0.03);
+}
+
+:global([data-theme="light"]) .dangerTitle {
+    color: #dc2626;
+}
+
+:global([data-theme="light"]) .dangerDescription {
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .dangerButton {
+    border-color: rgba(220, 38, 38, 0.4);
+    color: #dc2626;
+}
+
+:global([data-theme="light"]) .dangerButton:hover:not(:disabled) {
+    background-color: rgba(220, 38, 38, 0.05);
+    border-color: #dc2626;
+}
+
+:global([data-theme="light"]) .confirmText {
+    color: #dc2626;
+}
+
+:global([data-theme="light"]) .confirmYes {
+    background-color: #dc2626;
+}
+
+:global([data-theme="light"]) .confirmYes:hover:not(:disabled) {
+    background-color: #b91c1c;
+}
+
+:global([data-theme="light"]) .confirmNo {
+    border-color: #e2e8f0;
+    color: #64748b;
+}
+
+:global([data-theme="light"]) .confirmNo:hover:not(:disabled) {
+    border-color: #cbd5e1;
+    color: #1f2937;
+}
+
+:global([data-theme="light"]) .deleteResult {
+    background-color: rgba(0, 0, 0, 0.03);
+    color: #374151;
 }


### PR DESCRIPTION
Add bulk delete functionality to the memory modal's debug tab:
- Backend: DELETE /api/people/{id}/arasuji (clears all Chronicle entries + progress)
- Backend: DELETE /api/people/{id}/memopedia/pages (clears all non-root Memopedia pages)
- Frontend: Danger Zone section with confirmation flow for both operations
- Both dark and light mode CSS support

https://claude.ai/code/session_0169Jos21SZ335CsRDFAAep3