### PR TITLE
Fix runtime split parameter mismatches breaking context preview

### DIFF
--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -44,7 +44,6 @@ from sea.runtime_state import (
     update_router_selection,
 )
 
-from . import runtime_llm as runtime_llm_module
 from .runtime_emitters import RuntimeEmitters
 from .runtime_utils import _format, _is_llm_streaming_enabled
 LOGGER = logging.getLogger(__name__)
@@ -1585,9 +1584,16 @@ class SEARuntime:
         persona: Any,
         building_id: str,
         user_input: str,
-        playbook_name: Optional[str] = None,
+        meta_playbook: Optional[str] = None,
+        image_count: int = 0,
+        document_count: int = 0,
     ) -> Dict[str, Any]:
-        return preview_context_impl(self, persona, building_id, user_input, playbook_name=playbook_name)
+        return preview_context_impl(
+            self, persona, building_id, user_input,
+            meta_playbook=meta_playbook,
+            image_count=image_count,
+            document_count=document_count,
+        )
 
     def _enrich_history_with_attachments(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Enrich history messages with attachment context.

--- a/sea/runtime_engine.py
+++ b/sea/runtime_engine.py
@@ -216,8 +216,10 @@ class RuntimeEngine:
                 log_sea_trace(playbook.name, node_id, "EXEC", f"→ {sub_name} (input=\"{str(sub_input)}\")")
 
             try:
+                cancellation_token = state.get("_cancellation_token")
                 sub_outputs = await asyncio.to_thread(
-                    self.runtime._run_playbook, sub_pb, persona, eff_bid, sub_input, auto_mode, True, state, event_callback
+                    self.runtime._run_playbook, sub_pb, persona, eff_bid, sub_input, auto_mode, True, state, event_callback,
+                    cancellation_token=cancellation_token,
                 )
             except Exception as exc:
                 LOGGER.exception("SEA LangGraph exec sub-playbook failed")

--- a/sea/runtime_nodes.py
+++ b/sea/runtime_nodes.py
@@ -162,7 +162,7 @@ def lg_subplay_node(runtime: Any, node_def: Any, persona: Any, building_id: str,
         if execution == "inline":
             log_sea_trace(playbook.name, node_id, "SUBPLAY", f"→ {sub_name} (input=\"{str(sub_input)}\")")
         try:
-            sub_outputs = runtime._run_playbook(sub_pb, persona, eff_bid, sub_input, auto_mode, True, state, event_callback)
+            sub_outputs = runtime._run_playbook(sub_pb, persona, eff_bid, sub_input, auto_mode, True, state, event_callback, cancellation_token=cancellation_token)
         except LLMError:
             LOGGER.exception("[sea][subplay] LLM error in subplaybook '%s'", sub_name)
             if execution == "subagent" and subagent_thread_id:

--- a/tests/sea/test_runtime_regression.py
+++ b/tests/sea/test_runtime_regression.py
@@ -73,9 +73,9 @@ def test_preview_context_delegates_to_preview_context_impl(monkeypatch: pytest.M
 
     monkeypatch.setattr("sea.runtime.preview_context_impl", _fake_preview)
 
-    result = runtime.preview_context(persona, "b1", "hello", playbook_name="meta_user")
+    result = runtime.preview_context(persona, "b1", "hello", meta_playbook="meta_user")
 
-    assert result == {"ok": True, "kwargs": {"playbook_name": "meta_user"}}
+    assert result == {"ok": True, "kwargs": {"meta_playbook": "meta_user", "image_count": 0, "document_count": 0}}
 
 
 def test_select_llm_client_raises_llmerror_when_client_unset() -> None:


### PR DESCRIPTION
## Summary
- **コンテキストプレビューが「ペルソナがいません」と表示されるバグを修正**: `SEARuntime.preview_context()` ラッパーのパラメータ名不一致 (`playbook_name` → `meta_playbook`) と欠落パラメータ (`image_count`, `document_count`) により、呼び出し時に `TypeError` が発生していた。`except Exception` で握り潰されていたため、空の結果が返りUIにエラー表示されていた
- **サブPlaybook実行時の `cancellation_token` 転送を追加**: `lg_subplay_node` と `lg_exec_node` から `_run_playbook` を呼ぶ際に `cancellation_token` が渡されておらず、サブPlaybook内での早期キャンセルチェックが効いていなかった
- **未使用インポート `runtime_llm_module` を削除**
- **テストのパラメータ名を実際のシグネチャに合わせて修正**

## Root Cause
ランタイム分割リファクタ (96a7afa) で `preview_context` の実装が `sea/runtime_context.py` に移動された際、`sea/runtime.py` に残ったラッパーメソッドのシグネチャが更新されなかった。

## Test plan
- [x] `python -m pytest tests/sea/test_runtime_regression.py` — 14/14 passed
- [x] コンテキストプレビューをUIから開き、ペルソナのコンテキスト情報が表示されることを確認
- [x] サブPlaybook実行中にストップボタンでキャンセルが効くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)