### PR TITLE
Fix building history loss on schedule execution and API restart

### DIFF
--- a/saiverse/schedule_manager.py
+++ b/saiverse/schedule_manager.py
@@ -307,6 +307,11 @@ class ScheduleManager:
             )
             LOGGER.info("[ScheduleManager] Schedule submitted to PulseController")
 
+            # Building履歴をディスクに保存（in-memory → log.json）
+            self.manager._save_building_histories()
+            persona._save_session_metadata()
+            LOGGER.debug("[ScheduleManager] Building histories and session metadata saved after schedule execution")
+
             # 実行後の状態更新
             self._update_schedule_after_execution(schedule, session)
 


### PR DESCRIPTION
## Summary
- **ScheduleManager**: スケジュール実行後に `_save_building_histories()` が呼ばれていなかったため、スケジュール起動のペルソナ発言がlog.jsonに保存されなかった。SAIMemoryには `memorize` 経由で保存されるためメモリ側には残るが、Building履歴だけが欠落する状態だった
- **APIリスタート**: `os.execv()` がPythonのクリーンアップを一切実行せずにプロセスを置換するため、`shutdown()` で行われるBuilding履歴保存・セッションメタデータ保存・バックグラウンドスレッド停止等が全てスキップされていた。リスタート前に `manager.shutdown()` を明示的に呼ぶように修正
- **handle_user_input_stream**: `_save_building_histories()` が `try/finally` の外にあったため、GeneratorExitで到達しない可能性があった。`finally` ブロック内に移動

## Test plan
- [x] APIリスタート時にshutdown処理が完了してからプロセス置換されることをログで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)