### PR TITLE
Add in-app announcements from GitHub Gist

### DIFF
--- a/frontend/src/app/announcements/page.module.css
+++ b/frontend/src/app/announcements/page.module.css
@@ -1,0 +1,145 @@
+.container {
+    height: 100dvh;
+    background-color: #1a1a1a;
+    color: #fff;
+    padding: 1rem;
+    overflow-y: auto;
+    box-sizing: border-box;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid #333;
+}
+
+.backButton {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: transparent;
+    border: 1px solid #444;
+    color: #ccc;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.backButton:hover {
+    background: #333;
+    color: #fff;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.loading {
+    text-align: center;
+    color: #888;
+    padding: 3rem;
+}
+
+.empty {
+    text-align: center;
+    color: #888;
+    padding: 3rem;
+    font-size: 0.95rem;
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.card {
+    background: #242424;
+    border: 1px solid #333;
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    transition: border-color 0.2s;
+}
+
+.card:hover {
+    border-color: #555;
+}
+
+.cardHeader {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.severityIcon {
+    flex-shrink: 0;
+}
+
+.severityInfo {
+    color: #60a5fa;
+}
+
+.severityWarning {
+    color: #fbbf24;
+}
+
+.severityCritical {
+    color: #f87171;
+}
+
+.cardTitle {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+    flex: 1;
+}
+
+.cardDate {
+    font-size: 0.8rem;
+    color: #888;
+    flex-shrink: 0;
+}
+
+.cardContent {
+    font-size: 0.9rem;
+    color: #ccc;
+    line-height: 1.6;
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.cardLink {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-top: 0.5rem;
+    color: #60a5fa;
+    font-size: 0.85rem;
+    text-decoration: none;
+}
+
+.cardLink:hover {
+    text-decoration: underline;
+}
+
+/* Severity-based left border accent */
+.cardInfo {
+    border-left: 3px solid #3b82f6;
+}
+
+.cardWarning {
+    border-left: 3px solid #f59e0b;
+}
+
+.cardCritical {
+    border-left: 3px solid #ef4444;
+}

--- a/frontend/src/app/announcements/page.tsx
+++ b/frontend/src/app/announcements/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { ArrowLeft, Info, AlertTriangle, AlertCircle, ExternalLink } from 'lucide-react';
+import styles from './page.module.css';
+
+interface Announcement {
+    id: string;
+    date: string;
+    title: string;
+    content: string;
+    severity: 'info' | 'warning' | 'critical';
+    link?: string;
+}
+
+/** Compute a simple hash string from announcements content for unread detection. */
+function computeAnnouncementsHash(announcements: Announcement[]): string {
+    const raw = JSON.stringify(announcements);
+    // Simple djb2 hash → hex string
+    let hash = 5381;
+    for (let i = 0; i < raw.length; i++) {
+        hash = ((hash << 5) + hash + raw.charCodeAt(i)) | 0;
+    }
+    return (hash >>> 0).toString(16);
+}
+
+function SeverityIcon({ severity }: { severity: string }) {
+    switch (severity) {
+        case 'critical':
+            return <AlertCircle size={18} className={`${styles.severityIcon} ${styles.severityCritical}`} />;
+        case 'warning':
+            return <AlertTriangle size={18} className={`${styles.severityIcon} ${styles.severityWarning}`} />;
+        default:
+            return <Info size={18} className={`${styles.severityIcon} ${styles.severityInfo}`} />;
+    }
+}
+
+function severityCardClass(severity: string): string {
+    switch (severity) {
+        case 'critical': return styles.cardCritical;
+        case 'warning': return styles.cardWarning;
+        default: return styles.cardInfo;
+    }
+}
+
+export default function AnnouncementsPage() {
+    const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        fetch('/api/system/announcements')
+            .then(res => res.ok ? res.json() : null)
+            .then(data => {
+                if (data?.announcements) {
+                    // Sort by date descending (newest first)
+                    const sorted = [...data.announcements].sort(
+                        (a: Announcement, b: Announcement) => b.date.localeCompare(a.date)
+                    );
+                    setAnnouncements(sorted);
+
+                    // Mark as read: save hash to localStorage
+                    const hash = computeAnnouncementsHash(sorted);
+                    localStorage.setItem('saiverse_announcements_hash', hash);
+                }
+            })
+            .catch(() => { /* ignore */ })
+            .finally(() => setLoading(false));
+    }, []);
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.header}>
+                <button
+                    className={styles.backButton}
+                    onClick={() => { window.location.href = '/'; }}
+                >
+                    <ArrowLeft size={16} />
+                    戻る
+                </button>
+                <h1 className={styles.title}>お知らせ</h1>
+                <div style={{ width: '80px' }} />
+            </div>
+
+            {loading && <div className={styles.loading}>読み込み中...</div>}
+
+            {!loading && announcements.length === 0 && (
+                <div className={styles.empty}>お知らせはありません</div>
+            )}
+
+            {!loading && announcements.length > 0 && (
+                <div className={styles.list}>
+                    {announcements.map(item => (
+                        <div
+                            key={item.id}
+                            className={`${styles.card} ${severityCardClass(item.severity)}`}
+                        >
+                            <div className={styles.cardHeader}>
+                                <SeverityIcon severity={item.severity} />
+                                <h2 className={styles.cardTitle}>{item.title}</h2>
+                                <span className={styles.cardDate}>{item.date}</span>
+                            </div>
+                            <p className={styles.cardContent}>{item.content}</p>
+                            {item.link && (
+                                <a
+                                    href={item.link}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className={styles.cardLink}
+                                >
+                                    詳細を見る <ExternalLink size={14} />
+                                </a>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -210,6 +210,23 @@
     background: rgba(0, 0, 0, 0.05);
 }
 
+.bellWrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.bellDot {
+    position: absolute;
+    top: -1px;
+    right: -1px;
+    width: 8px;
+    height: 8px;
+    background: #ef4444;
+    border-radius: 50%;
+}
+
 .chatArea {
     flex: 1;
     overflow-y: auto;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react';
 import styles from './Sidebar.module.css';
-import { Settings, Zap, BarChart2, UserPlus, Plus, X, HelpCircle, Navigation } from 'lucide-react';
+import { Settings, Zap, BarChart2, UserPlus, Plus, X, HelpCircle, Navigation, Bell } from 'lucide-react';
 import GlobalSettingsModal from './GlobalSettingsModal';
 import UserProfileModal from './UserProfileModal';
 import PersonaWizard from './PersonaWizard';
@@ -312,6 +312,17 @@ export default function Sidebar({ onMove, isOpen, onOpen, onClose, refreshTrigge
                             </span>
                         </div>
                     )}
+                    <div
+                        className={styles.buildingItem}
+                        onClick={() => {
+                            window.location.href = '/announcements';
+                            if (onClose) onClose();
+                        }}
+                    >
+                        <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                            <Bell size={16} /> お知らせ
+                        </span>
+                    </div>
                     <div
                         className={styles.buildingItem}
                         onClick={() => {


### PR DESCRIPTION
## Summary
- GitHub Gist からお知らせを取得してアプリ内に表示する機能を追加
- バージョンに関係なく最新情報をユーザーに届けられるようになる（v0.2.7 のアップデート不具合のような状況への対策）
- 未読検知はコンテンツハッシュ方式（追加・編集・削除すべて検知）

## Changes
- **Backend**: `GET /api/system/announcements` エンドポイント（30分キャッシュ、CDNキャッシュバスティング付き）
- **Frontend**: `/announcements` ページ（severity別カード表示）
- **Sidebar**: システムセクションに「お知らせ」リンク追加
- **Main page**: 未読時のみベルアイコン+赤ドットバッジ表示（30分ポーリング + タブ復帰時チェック）

## Data source
- Gist: https://gist.github.com/maha0525/5e4c1aacf9d9550c5a46ca9d847ae559
- 環境変数 `SAIVERSE_ANNOUNCEMENTS_URL` で上書き可能

## Test plan
- [x] Gist からお知らせ取得・表示を確認
- [x] 未読バッジの表示・既読後の消去を確認
- [x] Gist 更新後にバッジが再表示されることを確認
- [x] CDN キャッシュバスティングの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)