### PR TITLE
Fix building history loss on autonomous pulse and self-update exit

### DIFF
--- a/saiverse/conversation_manager.py
+++ b/saiverse/conversation_manager.py
@@ -124,9 +124,13 @@ class ConversationManager:
                 self._current_speaker_index = (self._current_speaker_index + 1) % len(ai_occupants)
                 return
 
-            # SEA経由で自律パルスを実行（履歴保存はSEA内部で行われる）
+            # SEA経由で自律パルスを実行
             logging.info(f"[ConvManager] Triggering SEA auto for '{speaker_persona.persona_name}' (mode={mode}, proxy={getattr(speaker_persona,'is_proxy',False)}) in '{self.building_id}'.")
             self.saiverse_manager.run_sea_auto(speaker_persona, self.building_id, all_occupants)
+
+            # Building履歴をディスクに保存（in-memory → log.json）
+            self.saiverse_manager._save_building_histories()
+            speaker_persona._save_session_metadata()
 
             # 次の発話者のためにインデックスを進める
             self._current_speaker_index = (self._current_speaker_index + 1) % len(ai_occupants)


### PR DESCRIPTION
## Summary
- **ConversationManager自律パルス**: `run_sea_auto()` の後に `_save_building_histories()` が呼ばれていなかった。autoモードのペルソナが自律会話するたびにメモリ上にのみ履歴が蓄積され、サーバー再起動で全消失する状態だった
- **セルフアップデート終了**: `/api/system/update` が `os._exit(0)` でプロセスを終了する際、`manager.shutdown()` を呼んでいなかった。Building履歴・セッションメタデータの保存やバックグラウンドスレッドの停止が全てスキップされていた

#185 で修正したScheduleManagerおよびAPIリスタートと同種の問題。Building履歴のディスク保存漏れを網羅的に監査して発見した。

## Test plan
- [ ] autoモードのペルソナが自律会話した後、サーバー再起動しても履歴が保持されることを確認
- [ ] セルフアップデート実行時にshutdownログが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)