### PR TITLE
Upgrade image generation to Gemini 3.1 Flash (nano_banana_2)

### DIFF
--- a/builtin_data/playbooks/public/generate_image_playbook.json
+++ b/builtin_data/playbooks/public/generate_image_playbook.json
@@ -31,12 +31,11 @@
                     "model": {
                         "type": "string",
                         "enum": [
-                            "nano_banana",
-                            "nano_banana_pro",
+                            "nano_banana_2",
                             "gpt_image_1_5",
                             "grok_imagine"
                         ],
-                        "description": "使用するモデル。nano_banana(高速), nano_banana_pro(高品質), gpt_image_1_5(最高品質), grok_imagine(xAI Grok Imagine Pro)。デフォルトはnano_banana_pro"
+                        "description": "使用するモデル。nano_banana_2(高速・高品質, Gemini 3.1 Flash), gpt_image_1_5(最高品質, OpenAI), grok_imagine(xAI Grok Imagine Pro)。デフォルトはnano_banana_2"
                     },
                     "quality": {
                         "type": "string",
@@ -54,7 +53,16 @@
                             "16:9",
                             "9:16",
                             "4:3",
-                            "3:4"
+                            "3:4",
+                            "2:3",
+                            "3:2",
+                            "4:5",
+                            "5:4",
+                            "1:4",
+                            "4:1",
+                            "1:8",
+                            "8:1",
+                            "21:9"
                         ],
                         "description": "アスペクト比。デフォルトは1:1"
                     },

--- a/tests/test_image_generator.py
+++ b/tests/test_image_generator.py
@@ -13,7 +13,7 @@ generate_image = _mod.generate_image
 
 class TestImageGenerator(unittest.TestCase):
     @patch.object(_mod, 'store_image_bytes')
-    @patch.object(_mod, '_generate_with_nano_banana_pro')
+    @patch.object(_mod, '_generate_with_nano_banana_2')
     def test_generate_image(self, mock_gen, mock_store):
         # Mock generation backend to return image bytes
         mock_gen.return_value = (b'imgdata', 'image/png')
@@ -39,11 +39,12 @@ class TestImageGenerator(unittest.TestCase):
         mock_gen.assert_called_once()
         temp_path.unlink(missing_ok=True)
 
-    @patch.object(_mod, '_generate_with_nano_banana_pro')
-    def test_generate_image_error_returns_error_text(self, mock_gen):
-        # When generation fails, should return error text without raising
-        mock_gen.side_effect = RuntimeError("No candidates")
-
+    @patch.object(_mod, '_generate_with_grok_imagine', side_effect=RuntimeError("No key"))
+    @patch.object(_mod, '_generate_with_gpt_image', side_effect=RuntimeError("No key"))
+    @patch.object(_mod, '_generate_with_nano_banana_pro', side_effect=RuntimeError("No candidates"))
+    @patch.object(_mod, '_generate_with_nano_banana_2', side_effect=RuntimeError("No candidates"))
+    def test_generate_image_error_returns_error_text(self, mock_nb2, mock_nbp, mock_gpt, mock_grok):
+        # When all backends fail, should return error text without raising
         with patch('tools.context.get_active_persona_id', return_value=None), \
              patch('tools.context.get_active_manager', return_value=None):
             text, info, path, metadata = generate_image('nothing')


### PR DESCRIPTION
## Summary
- 画像生成のデフォルトバックエンドを Gemini 2.5 Flash → **Gemini 3.1 Flash Image Preview** (`nano_banana_2`) にアップグレード
- 3 Pro とほぼ同等の品質を約1/3のコストで実現できるため、デフォルトモデルを変更
- `nano_banana_pro` (Gemini 3 Pro) はツールコード上には残しつつ、Playbook の選択肢からは削除
- 解像度制御 (`image_size`: 512px/1K/2K/4K) とアスペクト比 14種 を新たにサポート

## Changes
- `nano_banana` → `nano_banana_2` にリネーム（関数名・enum・型定義・フォールバック順すべて）
- `_generate_with_nano_banana_2()` に `quality` → `image_size` マッピングを追加
- アスペクト比を 5種 → 14種 に拡張 (`2:3`, `3:2`, `4:5`, `5:4`, `1:4`, `4:1`, `1:8`, `8:1`, `21:9` 追加)
- Playbook の model enum から `nano_banana_pro` を削除
- テストをデフォルトモデル変更・フォールバック挙動に合わせて更新

## Test plan
- [x] `python -m pytest tests/test_image_generator.py` — 全3テスト通過
- [x] `ruff check builtin_data/tools/image_generator.py` — lint通過
- [ ] 実環境で `nano_banana_2` による画像生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)