### PR TITLE
Fix scheduled playbook_params lost during input_schema resolution

### DIFF
--- a/sea/runtime_graph.py
+++ b/sea/runtime_graph.py
@@ -86,6 +86,15 @@ def compile_with_langgraph(
             value = parent[param_name]
             LOGGER.debug("[sea][LangGraph] Fallback: using parent value for %s: %s", param_name, str(value)[:120] if value else "(empty)")
 
+        # Override: explicitly passed initial_params (e.g. from schedule playbook_params)
+        # take precedence over default source resolution.  This ensures that
+        # scheduled execution with selected_playbook="send_email_to_user" is not
+        # overwritten by the generic "input" source fallback.
+        _ip = parent.get("_initial_params")
+        if isinstance(_ip, dict) and param_name in _ip and _ip[param_name] is not None:
+            value = _ip[param_name]
+            LOGGER.debug("[sea][LangGraph] Override from _initial_params for %s: %s", param_name, str(value)[:120])
+
         inherited_vars[param_name] = value
 
     # Inherit pulse_usage_accumulator from parent_state if it exists (for sub-playbook calls)


### PR DESCRIPTION
## Summary
- スケジュール実行時に `playbook_params` で渡した `selected_playbook` が消失し、意図したプレイブックが実行されない不具合を修正
- `input_schema` のソース解決で `source` 未指定パラメータが `user_input`（スケジュールプロンプト）に解決され、`_initial_params` の正しい値が上書きされていた
- `_initial_params` で明示的に渡されたパラメータがソース解決より優先されるように修正

## Root Cause
`runtime_graph.py` の `compile_with_langgraph()` で `input_schema` を処理する際：
1. `selected_playbook` パラメータは `source` 未定義 → デフォルトで `source_key = "input"` 
2. `value = user_input` → スケジュールプロンプト全文（truthy）
3. フォールバック `if not value` が発動せず、`parent["selected_playbook"]` の正しい値を取得できない
4. `inherited_vars` に既にキーがあるため `forwarded_params` にも入らず、値が完全に消失
5. `exec` ノードが無効なプレイブック名で実行 → `error_next` → `sub_speak` にフォールバック

## Test plan
- [ ] スケジュールで `meta_user_manual` + `selected_playbook: send_email_to_user` を設定し、発火時に `send_email_to_user` が実行されることを確認
- [ ] 通常のユーザーチャットで `meta_user_manual` のドロップダウンからプレイブック選択が正常に動作することを確認
- [ ] `playbook_params` なしのスケジュール実行（自動ルーティング）が影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)