### PR TITLE
Add pyproject.toml for PyPI package registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ temp/
 %temp%/
 nul
 
+# PyPI build artifacts
+dist/
+*.egg-info/
+
 # Local Claude Code preferences
 CLAUDE.local.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "saiverse"
+dynamic = ["version"]
+description = "Multi-agent AI system where autonomous AI personas inhabit a virtual world"
+readme = "README.md"
+license = "AGPL-3.0-or-later"
+requires-python = ">=3.11"
+authors = [
+    { name = "maha0525" },
+]
+keywords = ["ai", "multi-agent", "llm", "autonomous-agents", "virtual-world"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Web Environment",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.urls]
+Homepage = "https://github.com/maha0525/SAIVerse"
+Repository = "https://github.com/maha0525/SAIVerse"
+Issues = "https://github.com/maha0525/SAIVerse/issues"
+
+# Tool configs (merged from discord_gateway/pyproject.toml)
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "B", "UP"]
+ignore = ["E501", "UP017"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "-ra"
+
+[tool.setuptools]
+packages = ["saiverse"]
+
+[tool.setuptools.dynamic]
+version = { file = "VERSION" }


### PR DESCRIPTION
## Summary
- PyPIに「saiverse」パッケージ名を登録するための `pyproject.toml` を追加
- `dist/` と `*.egg-info/` を `.gitignore` に追加
- `discord_gateway/pyproject.toml` にあった ruff/pytest 設定をルートに統合

## Background
PyPIでの名前確保が目的。パッケージは https://pypi.org/project/saiverse/0.2.7/ に登録済み。

## Test plan
- [ ] `python -m build --sdist` でビルドが通ること
- [ ] 既存の `ruff check` / `pytest` が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)