### PR TITLE
Fix attached images not displaying until page reload

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -527,6 +527,7 @@ export default function Home() {
                             id: entry.msg.id,
                             avatar: entry.msg.avatar || local.avatar,
                             sender: entry.msg.sender || local.sender,
+                            images: entry.msg.images || local.images,
                             llm_usage: entry.msg.llm_usage || local.llm_usage,
                             llm_usage_total: entry.msg.llm_usage_total || local.llm_usage_total,
                             timestamp: entry.msg.timestamp || local.timestamp,
@@ -1024,6 +1025,9 @@ export default function Home() {
             id: tempId, role: 'user', content: inputValue,
             sender: userDisplayNameRef.current || undefined,
             avatar: userAvatarRef.current || undefined,
+            images: attachments
+                .filter(a => a.type === 'image')
+                .map(a => ({ url: `data:${a.mimeType};base64,${a.base64}`, mime_type: a.mimeType })),
         };
         setMessages(prev => [...prev, userMsg]);
         setInputValue('');


### PR DESCRIPTION
## Summary
- 画像添付してチャット送信した直後、ユーザーメッセージに画像が表示されないバグを修正
- 楽観的更新時に `images` フィールドが欠落していたのが原因
- base64 DataURIで即座に表示し、サーバー同期後にサーバーURLへ切り替え

## Changes
- **Optimistic update** (`page.tsx:1025`): `attachments` から画像をフィルタして `MessageImage[]` を生成
- **syncAfterResponse** (`page.tsx:530`): サーバーからの `images` をローカルメッセージにマージ

## Test plan
- [ ] 画像を添付してメッセージ送信 → 送信直後にユーザーメッセージ内に画像が表示されること
- [ ] ページリロード後も画像が表示されること（従来通り）
- [ ] 画像なしメッセージの送信が影響を受けないこと
- [ ] 複数画像添付時も全て表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)