### PR TITLE
Refactor playbook state management: function call model

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -303,7 +303,7 @@ class SendMessageRequest(BaseModel):
     attachment: Optional[str] = None  # Base64 encoded file (legacy, single attachment)
     attachments: Optional[List[AttachmentData]] = None  # New: multiple attachments
     meta_playbook: Optional[str] = None
-    playbook_params: Optional[Dict[str, Any]] = None  # Parameters for meta playbook
+    args: Optional[Dict[str, Any]] = None  # Arguments for meta playbook
     metadata: Optional[Dict[str, Any]] = None
 
 def _store_uploaded_attachment(base64_data: str) -> Optional[Dict[str, str]]:
@@ -560,7 +560,7 @@ def send_message(req: SendMessageRequest, manager = Depends(get_manager)):
                 req.message,
                 metadata=metadata,
                 meta_playbook=req.meta_playbook,
-                playbook_params=req.playbook_params,
+                args=req.args,
                 building_id=building_id,
             )
             

--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -478,28 +478,28 @@ def set_x_polling(req: XPollingRequest, manager=Depends(get_manager)):
 
 class PlaybookOverrideRequest(BaseModel):
     playbook: Optional[str] = None
-    playbook_params: Optional[Dict[str, Any]] = None
+    args: Optional[Dict[str, Any]] = None
 
 
 @router.get("/playbook")
 def get_current_playbook(manager = Depends(get_manager)):
-    """Get current playbook override and parameters."""
+    """Get current playbook override and args."""
     return {
         "playbook": manager.state.current_playbook,
-        "playbook_params": manager.state.playbook_params,
+        "args": manager.state.playbook_args,
     }
 
 
 @router.post("/playbook")
 def set_playbook(req: PlaybookOverrideRequest, manager = Depends(get_manager)):
-    """Set playbook override and parameters."""
+    """Set playbook override and args."""
     manager.state.current_playbook = req.playbook if req.playbook else None
-    # Update playbook_params if provided, reset if playbook changed to None
-    if req.playbook_params is not None:
-        manager.state.playbook_params = req.playbook_params
+    # Update playbook_args if provided, reset if playbook changed to None
+    if req.args is not None:
+        manager.state.playbook_args = req.args
     elif req.playbook is None:
-        # Reset params when playbook is cleared
-        manager.state.playbook_params = {}
+        # Reset args when playbook is cleared
+        manager.state.playbook_args = {}
 
     # Persist to DB so it survives server restart
     from database.session import SessionLocal
@@ -522,7 +522,7 @@ def set_playbook(req: PlaybookOverrideRequest, manager = Depends(get_manager)):
     return {
         "success": True,
         "playbook": manager.state.current_playbook,
-        "playbook_params": manager.state.playbook_params,
+        "args": manager.state.playbook_args,
     }
 
 

--- a/api/routes/people/models.py
+++ b/api/routes/people/models.py
@@ -268,7 +268,7 @@ class ScheduleItem(BaseModel):
     interval_seconds: Optional[int] = None
     last_executed_at: Optional[datetime] = None
     completed: bool
-    playbook_params: Optional[dict] = None  # Playbook parameters (e.g., {"selected_playbook": "xxx"})
+    args: Optional[dict] = None  # Playbook arguments (e.g., {"selected_playbook": "xxx"})
 
 class CreateScheduleRequest(BaseModel):
     schedule_type: str # periodic, oneshot, interval
@@ -283,8 +283,8 @@ class CreateScheduleRequest(BaseModel):
     scheduled_datetime: Optional[str] = None # "YYYY-MM-DD HH:MM" (in persona TZ)
     # interval
     interval_seconds: Optional[int] = None
-    # playbook params
-    playbook_params: Optional[dict] = None  # Playbook parameters (e.g., {"selected_playbook": "xxx"})
+    # playbook args
+    args: Optional[dict] = None  # Playbook arguments (e.g., {"selected_playbook": "xxx"})
 
 class UpdateScheduleRequest(BaseModel):
     schedule_type: Optional[str] = None
@@ -296,7 +296,7 @@ class UpdateScheduleRequest(BaseModel):
     time_of_day: Optional[str] = None
     scheduled_datetime: Optional[str] = None  # "YYYY-MM-DD HH:MM" (in persona TZ)
     interval_seconds: Optional[int] = None
-    playbook_params: Optional[dict] = None  # Playbook parameters (e.g., {"selected_playbook": "xxx"})
+    args: Optional[dict] = None  # Playbook arguments (e.g., {"selected_playbook": "xxx"})
 
 
 # -----------------------------------------------------------------------------

--- a/api/routes/people/schedule.py
+++ b/api/routes/people/schedule.py
@@ -48,11 +48,11 @@ def list_schedules(persona_id: str, manager = Depends(get_manager)):
                 except Exception:
                     _log.warning("Failed to parse DAYS_OF_WEEK for schedule %d", s.SCHEDULE_ID, exc_info=True)
             
-            # Parse playbook_params JSON
-            playbook_params = None
+            # Parse args from DB column PLAYBOOK_PARAMS
+            parsed_args = None
             if s.PLAYBOOK_PARAMS:
                 try:
-                    playbook_params = json.loads(s.PLAYBOOK_PARAMS)
+                    parsed_args = json.loads(s.PLAYBOOK_PARAMS)
                 except Exception:
                     _log.warning("Failed to parse PLAYBOOK_PARAMS for schedule %d", s.SCHEDULE_ID, exc_info=True)
 
@@ -69,7 +69,7 @@ def list_schedules(persona_id: str, manager = Depends(get_manager)):
                 interval_seconds=s.INTERVAL_SECONDS,
                 last_executed_at=s.LAST_EXECUTED_AT,
                 completed=s.COMPLETED,
-                playbook_params=playbook_params
+                args=parsed_args
             ))
         return results
     finally:
@@ -91,7 +91,7 @@ def create_schedule(
             DESCRIPTION=req.description,
             PRIORITY=req.priority,
             ENABLED=req.enabled,
-            PLAYBOOK_PARAMS=json.dumps(req.playbook_params) if req.playbook_params else None,
+            PLAYBOOK_PARAMS=json.dumps(req.args) if req.args else None,
         )
 
         if req.schedule_type == "periodic":
@@ -172,8 +172,8 @@ def update_schedule(
             schedule.PRIORITY = req.priority
         if req.enabled is not None:
             schedule.ENABLED = req.enabled
-        if req.playbook_params is not None:
-            schedule.PLAYBOOK_PARAMS = json.dumps(req.playbook_params) if req.playbook_params else None
+        if req.args is not None:
+            schedule.PLAYBOOK_PARAMS = json.dumps(req.args) if req.args else None
 
         # Update type-specific fields based on schedule type
         schedule_type = req.schedule_type if req.schedule_type is not None else schedule.SCHEDULE_TYPE

--- a/builtin_data/phenomena/inject_persona_event.py
+++ b/builtin_data/phenomena/inject_persona_event.py
@@ -23,7 +23,7 @@ def inject_persona_event(
     persona_id: str,
     event_description: str,
     meta_playbook: Optional[str] = None,
-    playbook_params_json: Optional[str] = None,
+    args_json: Optional[str] = None,
     event_type: Optional[str] = None,
     _manager: Any = None,
     **_kwargs: Any,
@@ -38,7 +38,7 @@ def inject_persona_event(
         persona_id: Target persona ID.
         event_description: Human-readable description (becomes user_input).
         meta_playbook: Meta playbook to use (default: "meta_user").
-        playbook_params_json: JSON string of playbook params (incl. selected_playbook).
+        args_json: JSON string of playbook args (incl. selected_playbook).
         event_type: Event type tag for persona_event_log.
         _manager: SAIVerseManager reference (injected by PhenomenonManager).
     """
@@ -55,7 +55,7 @@ def inject_persona_event(
             persona_id=persona_id,
             content=event_description,
             event_type=event_type,
-            payload=playbook_params_json,
+            payload=args_json,
         )
         LOGGER.info(
             "[inject_persona_event] Recorded event for %s (type=%s)",
@@ -90,24 +90,24 @@ def inject_persona_event(
         )
         return f"error: persona {persona_id} has no building"
 
-    # Parse playbook params
-    playbook_params = None
-    if playbook_params_json:
+    # Parse playbook args
+    playbook_args = None
+    if args_json:
         try:
-            playbook_params = json.loads(playbook_params_json)
+            playbook_args = json.loads(args_json)
         except (json.JSONDecodeError, TypeError):
             LOGGER.warning(
-                "[inject_persona_event] Failed to parse playbook_params_json: %s",
-                playbook_params_json,
+                "[inject_persona_event] Failed to parse args_json: %s",
+                args_json,
             )
 
     # Build enriched user input with <system> tag
-    # Extract author info from playbook_params for richer context
+    # Extract author info from playbook_args for richer context
     extra_lines = []
-    if playbook_params:
-        author_username = playbook_params.get("trigger_author_username")
-        author_name = playbook_params.get("trigger_author_name")
-        mention_text = playbook_params.get("trigger_mention_text")
+    if playbook_args:
+        author_username = playbook_args.get("trigger_author_username")
+        author_name = playbook_args.get("trigger_author_name")
+        mention_text = playbook_args.get("trigger_mention_text")
         if author_username or author_name:
             who = author_name or author_username
             if author_username:
@@ -128,15 +128,15 @@ def inject_persona_event(
 {event_description}
 </system>"""
 
-    # When playbook_params has selected_playbook, use meta_user_manual
+    # When playbook_args has selected_playbook, use meta_user_manual
     # which skips the LLM router and goes directly to exec(selected_playbook).
-    # The trigger params (trigger_tweet_id, etc.) are forwarded to the sub-playbook
-    # via the _initial_params mechanism in the runtime.
-    if playbook_params and "selected_playbook" in playbook_params:
+    # The trigger args (trigger_tweet_id, etc.) are forwarded to the sub-playbook
+    # via the _args mechanism in the runtime.
+    if playbook_args and "selected_playbook" in playbook_args:
         effective_playbook = "meta_user_manual"
         LOGGER.info(
             "[inject_persona_event] Using meta_user_manual with selected_playbook='%s'",
-            playbook_params["selected_playbook"],
+            playbook_args["selected_playbook"],
         )
     else:
         effective_playbook = meta_playbook or "meta_user"
@@ -148,11 +148,11 @@ def inject_persona_event(
             user_input=user_input,
             metadata={"source": "external_event", "event_type": event_type},
             meta_playbook=effective_playbook,
-            playbook_params=playbook_params,
+            args=playbook_args,
         )
         LOGGER.info(
-            "[inject_persona_event] Submitted to PulseController: persona=%s, playbook=%s, params=%s",
-            persona_id, effective_playbook, playbook_params,
+            "[inject_persona_event] Submitted to PulseController: persona=%s, playbook=%s, args=%s",
+            persona_id, effective_playbook, playbook_args,
         )
         return "ok"
     except Exception:
@@ -183,9 +183,9 @@ def schema() -> PhenomenonSchema:
                     "type": "string",
                     "description": "使用するメタPlaybook名（デフォルト: meta_user）",
                 },
-                "playbook_params_json": {
+                "args_json": {
                     "type": "string",
-                    "description": "Playbook実行パラメータ（JSON文字列）",
+                    "description": "Playbook実行引数（JSON文字列）",
                 },
                 "event_type": {
                     "type": "string",

--- a/builtin_data/playbooks/public/create_building_playbook.json
+++ b/builtin_data/playbooks/public/create_building_playbook.json
@@ -75,7 +75,9 @@
             "id": "generate_interior_image",
             "type": "subplay",
             "playbook": "generate_image",
-            "input_template": "Building interior image: {building_plan.interior_prompt}\n\nGenerate an interior scene image for a building. The image should capture the atmosphere and visual style of the space. Use 16:9 aspect ratio for a wide interior view.",
+            "args": {
+                "input": "Building interior image: {building_plan.interior_prompt}\n\nGenerate an interior scene image for a building. The image should capture the atmosphere and visual style of the space. Use 16:9 aspect ratio for a wide interior view."
+            },
             "propagate_output": false,
             "next": "create_with_image"
         },

--- a/builtin_data/playbooks/public/deep_research_playbook.json
+++ b/builtin_data/playbooks/public/deep_research_playbook.json
@@ -71,7 +71,9 @@
             "id": "exec_search",
             "type": "subplay",
             "playbook": "web_search_step",
-            "input_template": "## 調査トピック\n{research_topic}\n\n## 調査指示\n{research_plan.directives}\n\n## 検索のヒント\n{research_plan.search_hints}\n\n## 参考資料\n{reference_content}",
+            "args": {
+                "input": "## 調査トピック\n{research_topic}\n\n## 調査指示\n{research_plan.directives}\n\n## 検索のヒント\n{research_plan.search_hints}\n\n## 参考資料\n{reference_content}"
+            },
             "propagate_output": true,
             "execution": "subagent",
             "subagent_chronicle": true,

--- a/builtin_data/playbooks/public/detail_recall_playbook.json
+++ b/builtin_data/playbooks/public/detail_recall_playbook.json
@@ -5,13 +5,11 @@
     "input_schema": [
         {
             "name": "summary_uuid",
-            "description": "UUID from a previous summary to recall details from",
-            "source": null
+            "description": "UUID from a previous summary to recall details from"
         },
         {
             "name": "recall_request",
-            "description": "User's request for what to recall (e.g., 'show me more before that')",
-            "source": null
+            "description": "User's request for what to recall (e.g., 'show me more before that')"
         }
     ],
     "output_schema": [

--- a/builtin_data/playbooks/public/memory_research.json
+++ b/builtin_data/playbooks/public/memory_research.json
@@ -320,7 +320,12 @@
             "id": "exec_research",
             "type": "subplay",
             "playbook": "research_task",
-            "input_template": "{current_task.objective}",
+            "args": {
+                "objective": "{current_task.objective}",
+                "context_refs": "{current_task.context_refs}",
+                "depth": "{current_task.depth}",
+                "task_index": "{task_index}"
+            },
             "propagate_output": false,
             "execution": "subagent",
             "subagent_chronicle": true,

--- a/builtin_data/playbooks/public/meta_agentic.json
+++ b/builtin_data/playbooks/public/meta_agentic.json
@@ -35,7 +35,13 @@
             "id": "router",
             "type": "subplay",
             "playbook": "sub_router_user",
-            "input_template": "{input}",
+            "args": {
+                "input": "{input}",
+                "available_playbooks": "{available_playbooks}",
+                "meta_playbook_name": "{meta_playbook_name}",
+                "meta_playbook_description": "{meta_playbook_description}",
+                "executed_playbooks": "{executed_playbooks}"
+            },
             "propagate_output": false,
             "next": "check_early_exit"
         },
@@ -83,7 +89,10 @@
             "id": "finalize",
             "type": "subplay",
             "playbook": "sub_speak",
-            "input_template": "{input}",
+            "args": {
+                "input": "{input}",
+                "metadata": "{metadata}"
+            },
             "propagate_output": true,
             "next": null
         }

--- a/builtin_data/playbooks/public/meta_auto.json
+++ b/builtin_data/playbooks/public/meta_auto.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "Trigger input (usually empty)",
-            "source": null
+            "description": "Trigger input (usually empty)"
         }
     ],
     "output_schema": null,
@@ -24,7 +23,7 @@
             "id": "detect_situation",
             "type": "subplay",
             "playbook": "sub_detect_situation_change",
-            "input_template": "",
+            "args": {},
             "propagate_output": false,
             "next": "finalize"
         },
@@ -32,7 +31,7 @@
             "id": "finalize",
             "type": "subplay",
             "playbook": "sub_finalize_auto",
-            "input_template": "",
+            "args": {"input": "{last}"},
             "propagate_output": false,
             "next": null
         }

--- a/builtin_data/playbooks/public/meta_auto_full.json
+++ b/builtin_data/playbooks/public/meta_auto_full.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "Trigger input (usually empty)",
-            "source": null
+            "description": "Trigger input (usually empty)"
         }
     ],
     "output_schema": null,
@@ -58,7 +57,7 @@
             "id": "execute_phase",
             "type": "subplay",
             "playbook": "sub_execute_phase",
-            "input_template": "",
+            "args": {"task_summary": "{task_summary}"},
             "propagate_output": false,
             "next": "finalize"
         },
@@ -74,7 +73,7 @@
             "id": "detect_situation",
             "type": "subplay",
             "playbook": "sub_detect_situation_change",
-            "input_template": "",
+            "args": {},
             "propagate_output": false,
             "next": "react_check"
         },
@@ -117,7 +116,7 @@
             "id": "reaction",
             "type": "subplay",
             "playbook": "sub_reaction",
-            "input_template": "",
+            "args": {"trigger": "{react_decision.reaction_trigger}"},
             "propagate_output": false,
             "next": "finalize"
         },
@@ -125,7 +124,7 @@
             "id": "generate_want",
             "type": "subplay",
             "playbook": "sub_generate_want",
-            "input_template": "",
+            "args": {},
             "propagate_output": false,
             "next": "route_want"
         },
@@ -157,7 +156,7 @@
             "id": "finalize",
             "type": "subplay",
             "playbook": "sub_finalize_auto",
-            "input_template": "",
+            "args": {"input": "{last}"},
             "propagate_output": false,
             "next": null
         }

--- a/builtin_data/playbooks/public/meta_exec_speak.json
+++ b/builtin_data/playbooks/public/meta_exec_speak.json
@@ -4,13 +4,11 @@
     "input_schema": [
         {
             "name": "selected_playbook",
-            "description": "Name of the playbook to execute",
-            "source": "parent.selected_playbook"
+            "description": "Name of the playbook to execute"
         },
         {
             "name": "selected_args",
-            "description": "Arguments for the playbook",
-            "source": "parent.selected_args"
+            "description": "Arguments for the playbook"
         }
     ],
     "output_schema": null,
@@ -28,7 +26,7 @@
             "id": "finalize",
             "type": "subplay",
             "playbook": "sub_speak",
-            "input_template": "{input}",
+            "args": {"input": "{input}"},
             "propagate_output": true,
             "next": null
         }

--- a/builtin_data/playbooks/public/meta_simple_speak.json
+++ b/builtin_data/playbooks/public/meta_simple_speak.json
@@ -15,7 +15,7 @@
             "id": "speak",
             "type": "subplay",
             "playbook": "sub_speak",
-            "input_template": "{input}",
+            "args": {"input": "{input}", "metadata": "{metadata}"},
             "propagate_output": true,
             "next": null
         }

--- a/builtin_data/playbooks/public/meta_user.json
+++ b/builtin_data/playbooks/public/meta_user.json
@@ -34,7 +34,13 @@
             "id": "router",
             "type": "subplay",
             "playbook": "sub_router_user",
-            "input_template": "{input}",
+            "args": {
+                "input": "{input}",
+                "available_playbooks": "{available_playbooks}",
+                "meta_playbook_name": "{meta_playbook_name}",
+                "meta_playbook_description": "{meta_playbook_description}",
+                "executed_playbooks": "{executed_playbooks}"
+            },
             "propagate_output": false,
             "next": "check_early_exit"
         },
@@ -62,7 +68,10 @@
             "id": "finalize",
             "type": "subplay",
             "playbook": "sub_speak",
-            "input_template": "{input}",
+            "args": {
+                "input": "{input}",
+                "metadata": "{metadata}"
+            },
             "propagate_output": true,
             "next": null
         }

--- a/builtin_data/playbooks/public/meta_user_manual.json
+++ b/builtin_data/playbooks/public/meta_user_manual.json
@@ -5,8 +5,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "User input",
-            "source": null
+            "description": "User input"
         },
         {
             "name": "selected_playbook",
@@ -57,7 +56,13 @@
             "id": "router",
             "type": "subplay",
             "playbook": "sub_router_user",
-            "input_template": "{input}",
+            "args": {
+                "input": "{input}",
+                "available_playbooks": "{available_playbooks}",
+                "meta_playbook_name": "{meta_playbook_name}",
+                "meta_playbook_description": "{meta_playbook_description}",
+                "executed_playbooks": "{executed_playbooks}"
+            },
             "propagate_output": false,
             "next": "check_early_exit"
         },
@@ -85,7 +90,10 @@
             "id": "finalize",
             "type": "subplay",
             "playbook": "sub_speak",
-            "input_template": "{input}",
+            "args": {
+                "input": "{input}",
+                "metadata": "{metadata}"
+            },
             "propagate_output": true,
             "next": null
         }

--- a/builtin_data/playbooks/public/novel_writing.json
+++ b/builtin_data/playbooks/public/novel_writing.json
@@ -5,8 +5,7 @@
     "input_schema": [
         {
             "name": "theme",
-            "description": "小説のテーマやお題（例：「雨の日の出会い」「猫と魔法使い」）",
-            "source": "input"
+            "description": "小説のテーマやお題（例：「雨の日の出会い」「猫と魔法使い」）"
         }
     ],
     "output_schema": [

--- a/builtin_data/playbooks/public/research_task.json
+++ b/builtin_data/playbooks/public/research_task.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "調査目的"
         },
         {
             "name": "context_refs",
             "param_type": "string",
-            "source": "parent.context_refs",
             "description": "コンマ区切りのSAIVerse URI群（手がかり情報）"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "調査深度: shallow/normal/deep"
         },
         {
             "name": "task_index",
             "param_type": "number",
-            "source": "parent.task_index",
             "description": "タスク番号"
         }
     ],
@@ -125,6 +121,12 @@
             "id": "exec_source",
             "type": "exec",
             "playbook_source": "selected_playbook",
+            "args": {
+                "objective": "{objective}",
+                "context_text": "{context_text}",
+                "depth": "{depth}",
+                "max_iterations": "{max_iterations}"
+            },
             "next": "check_result"
         },
         {

--- a/builtin_data/playbooks/public/schedule_management_playbook.json
+++ b/builtin_data/playbooks/public/schedule_management_playbook.json
@@ -71,7 +71,7 @@
             "id": "prepare_add",
             "type": "llm",
             "context_profile": "conversation",
-            "action": "schedule_addツールの引数を決定してください。\n\n### スケジュールタイプ：\n- periodic: 定期実行（曜日と時刻を指定）\n- oneshot: 単発実行（日時を指定）\n- interval: 一定間隔実行（秒数を指定）\n\n### メタプレイブック：\n- 通常は「meta_user」を指定してください。\n- 特定のPlaybookを直接実行したい場合は「meta_user_manual」を指定し、playbook_paramsでselected_playbookを設定してください。\n  例: meta_playbook=\"meta_user_manual\", playbook_params={\"selected_playbook\": \"send_email_to_user\"}\n\n### 現在の日時：\nリアルタイム情報（会話コンテキスト内）に記載されている現在時刻を参照してください。\n\n### 注意：\n- 日時や時刻はペルソナのタイムゾーンで指定してください\n- descriptionフィールドには、実行時にAIに伝えたい内容を書いてください（例：「まはーさんに今日のタスクを報告して」）",
+            "action": "schedule_addツールの引数を決定してください。\n\n### スケジュールタイプ：\n- periodic: 定期実行（曜日と時刻を指定）\n- oneshot: 単発実行（日時を指定）\n- interval: 一定間隔実行（秒数を指定）\n\n### メタプレイブック：\n- 通常は「meta_user」を指定してください。\n- 特定のPlaybookを直接実行したい場合は「meta_user_manual」を指定し、argsでselected_playbookを設定してください。\n  例: meta_playbook=\"meta_user_manual\", args={\"selected_playbook\": \"send_email_to_user\"}\n\n### 現在の日時：\nリアルタイム情報（会話コンテキスト内）に記載されている現在時刻を参照してください。\n\n### 注意：\n- 日時や時刻はペルソナのタイムゾーンで指定してください\n- descriptionフィールドには、実行時にAIに伝えたい内容を書いてください（例：「まはーさんに今日のタスクを報告して」）",
             "next": "record_add_params",
             "response_schema": {
                 "type": "object",
@@ -89,9 +89,9 @@
                         "type": "string",
                         "description": "実行するメタプレイブック名（通常は meta_user、特定のPlaybook指定時は meta_user_manual）"
                     },
-                    "playbook_params": {
+                    "args": {
                         "type": "object",
-                        "description": "Playbookパラメータ。meta_user_manual使用時にselected_playbookで実行するサブPlaybookを指定",
+                        "description": "Playbook引数。meta_user_manual使用時にselected_playbookで実行するサブPlaybookを指定",
                         "properties": {
                             "selected_playbook": {
                                 "type": "string",
@@ -155,7 +155,7 @@
             "args_input": {
                 "schedule_type": "add_params.schedule_type",
                 "meta_playbook": "add_params.meta_playbook",
-                "playbook_params": "add_params.playbook_params",
+                "args": "add_params.args",
                 "description": "add_params.description",
                 "days_of_week": "add_params.days_of_week",
                 "time_of_day": "add_params.time_of_day",

--- a/builtin_data/playbooks/public/source_chronicle.json
+++ b/builtin_data/playbooks/public/source_chronicle.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "What to find"
         },
         {
             "name": "context_text",
             "param_type": "string",
-            "source": "parent.context_text",
             "description": "Pre-resolved context from URIs"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "shallow/normal/deep"
         },
         {
             "name": "max_iterations",
             "param_type": "number",
-            "source": "parent.max_iterations",
             "description": "Max search iterations"
         }
     ],

--- a/builtin_data/playbooks/public/source_document.json
+++ b/builtin_data/playbooks/public/source_document.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "What to find"
         },
         {
             "name": "context_text",
             "param_type": "string",
-            "source": "parent.context_text",
             "description": "Pre-resolved context from URIs"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "shallow/normal/deep"
         },
         {
             "name": "max_iterations",
             "param_type": "number",
-            "source": "parent.max_iterations",
             "description": "Max search iterations"
         }
     ],

--- a/builtin_data/playbooks/public/source_memopedia.json
+++ b/builtin_data/playbooks/public/source_memopedia.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "What to find"
         },
         {
             "name": "context_text",
             "param_type": "string",
-            "source": "parent.context_text",
             "description": "Pre-resolved context from URIs"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "shallow/normal/deep"
         },
         {
             "name": "max_iterations",
             "param_type": "number",
-            "source": "parent.max_iterations",
             "description": "Max search iterations"
         }
     ],

--- a/builtin_data/playbooks/public/source_messagelog.json
+++ b/builtin_data/playbooks/public/source_messagelog.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "What to find"
         },
         {
             "name": "context_text",
             "param_type": "string",
-            "source": "parent.context_text",
             "description": "Pre-resolved context from URIs"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "shallow/normal/deep"
         },
         {
             "name": "max_iterations",
             "param_type": "number",
-            "source": "parent.max_iterations",
             "description": "Max search iterations"
         }
     ],

--- a/builtin_data/playbooks/public/source_pdf.json
+++ b/builtin_data/playbooks/public/source_pdf.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "What to find"
         },
         {
             "name": "context_text",
             "param_type": "string",
-            "source": "parent.context_text",
             "description": "Pre-resolved context from URIs"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "shallow/normal/deep"
         },
         {
             "name": "max_iterations",
             "param_type": "number",
-            "source": "parent.max_iterations",
             "description": "Max search iterations"
         }
     ],

--- a/builtin_data/playbooks/public/source_web.json
+++ b/builtin_data/playbooks/public/source_web.json
@@ -5,25 +5,21 @@
         {
             "name": "objective",
             "param_type": "string",
-            "source": "parent.objective",
             "description": "What to find"
         },
         {
             "name": "context_text",
             "param_type": "string",
-            "source": "parent.context_text",
             "description": "Pre-resolved context from URIs"
         },
         {
             "name": "depth",
             "param_type": "string",
-            "source": "parent.depth",
             "description": "shallow/normal/deep"
         },
         {
             "name": "max_iterations",
             "param_type": "number",
-            "source": "parent.max_iterations",
             "description": "Max search iterations"
         }
     ],

--- a/builtin_data/playbooks/public/sub_detect_situation_change.json
+++ b/builtin_data/playbooks/public/sub_detect_situation_change.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "Trigger input (usually empty)",
-            "source": null
+            "description": "Trigger input (usually empty)"
         }
     ],
     "output_schema": [

--- a/builtin_data/playbooks/public/sub_execute_phase.json
+++ b/builtin_data/playbooks/public/sub_execute_phase.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "task_summary",
-            "description": "現在のタスク情報",
-            "source": "parent.task_summary"
+            "description": "現在のタスク情報"
         }
     ],
     "router_callable": false,

--- a/builtin_data/playbooks/public/sub_finalize_auto.json
+++ b/builtin_data/playbooks/public/sub_finalize_auto.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "これまでの処理結果",
-            "source": "parent.last"
+            "description": "これまでの処理結果"
         }
     ],
     "router_callable": false,

--- a/builtin_data/playbooks/public/sub_generate_want.json
+++ b/builtin_data/playbooks/public/sub_generate_want.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "コンテキスト情報",
-            "source": "parent.situation"
+            "description": "コンテキスト情報"
         }
     ],
     "router_callable": false,

--- a/builtin_data/playbooks/public/sub_perceive.json
+++ b/builtin_data/playbooks/public/sub_perceive.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "Trigger input (usually empty for autonomous mode)",
-            "source": null
+            "description": "Trigger input (usually empty for autonomous mode)"
         }
     ],
     "output_schema": [

--- a/builtin_data/playbooks/public/sub_reaction.json
+++ b/builtin_data/playbooks/public/sub_reaction.json
@@ -4,8 +4,7 @@
     "input_schema": [
         {
             "name": "trigger",
-            "description": "リアクションのトリガー情報",
-            "source": "parent.react_decision.reaction_trigger"
+            "description": "リアクションのトリガー情報"
         }
     ],
     "router_callable": false,

--- a/builtin_data/playbooks/public/sub_router_auto.json
+++ b/builtin_data/playbooks/public/sub_router_auto.json
@@ -4,43 +4,35 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "Trigger input",
-            "source": null
+            "description": "Trigger input"
         },
         {
             "name": "messages",
-            "description": "Conversation context messages",
-            "source": "parent.messages"
+            "description": "Conversation context messages"
         },
         {
             "name": "situation_snapshot",
-            "description": "Current situation snapshot",
-            "source": "parent.situation_snapshot"
+            "description": "Current situation snapshot"
         },
         {
             "name": "task_summary",
-            "description": "Current task summary",
-            "source": "parent.task_summary"
+            "description": "Current task summary"
         },
         {
             "name": "available_playbooks",
-            "description": "JSON list of available playbooks",
-            "source": "parent.available_playbooks"
+            "description": "JSON list of available playbooks"
         },
         {
             "name": "meta_playbook_name",
-            "description": "Name of the current meta playbook",
-            "source": "parent.meta_playbook_name"
+            "description": "Name of the current meta playbook"
         },
         {
             "name": "meta_playbook_description",
-            "description": "Description of the current meta playbook",
-            "source": "parent.meta_playbook_description"
+            "description": "Description of the current meta playbook"
         },
         {
             "name": "executed_playbooks",
-            "description": "List of playbooks already executed in this run",
-            "source": "parent.executed_playbooks"
+            "description": "List of playbooks already executed in this run"
         }
     ],
     "output_schema": [

--- a/builtin_data/playbooks/public/sub_router_user.json
+++ b/builtin_data/playbooks/public/sub_router_user.json
@@ -8,23 +8,19 @@
         },
         {
             "name": "available_playbooks",
-            "description": "JSON list of available playbooks",
-            "source": "parent.available_playbooks"
+            "description": "JSON list of available playbooks"
         },
         {
             "name": "meta_playbook_name",
-            "description": "Name of the current meta playbook being executed",
-            "source": "parent.meta_playbook_name"
+            "description": "Name of the current meta playbook being executed"
         },
         {
             "name": "meta_playbook_description",
-            "description": "Description of the current meta playbook",
-            "source": "parent.meta_playbook_description"
+            "description": "Description of the current meta playbook"
         },
         {
             "name": "executed_playbooks",
-            "description": "List of playbooks already executed in this meta playbook run",
-            "source": "parent.executed_playbooks"
+            "description": "List of playbooks already executed in this meta playbook run"
         }
     ],
     "output_schema": [

--- a/builtin_data/playbooks/public/sub_speak.json
+++ b/builtin_data/playbooks/public/sub_speak.json
@@ -8,8 +8,7 @@
         },
         {
             "name": "metadata",
-            "description": "Optional metadata from tool execution (e.g., media attachments)",
-            "source": "parent.metadata"
+            "description": "Optional metadata from tool execution (e.g., media attachments)"
         }
     ],
     "router_callable": false,

--- a/builtin_data/playbooks/public/wait.json
+++ b/builtin_data/playbooks/public/wait.json
@@ -5,8 +5,7 @@
     "input_schema": [
         {
             "name": "input",
-            "description": "Reason for waiting (optional)",
-            "source": null
+            "description": "Reason for waiting (optional)"
         }
     ],
     "output_schema": [],

--- a/builtin_data/tools/schedule_add.py
+++ b/builtin_data/tools/schedule_add.py
@@ -30,8 +30,8 @@ def schedule_add(
     scheduled_datetime: Optional[str] = None,
     # interval用
     interval_seconds: Optional[int] = None,
-    # playbook params
-    playbook_params: Optional[Dict[str, Any]] = None,
+    # playbook args
+    args: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     新しいスケジュールを追加する。
@@ -46,7 +46,7 @@ def schedule_add(
         time_of_day: 実行時刻 (periodic用、"HH:MM"形式、例: "09:00")
         scheduled_datetime: 実行日時 (oneshot用、"YYYY-MM-DD HH:MM"形式、ペルソナのタイムゾーンで指定)
         interval_seconds: 実行間隔（秒）(interval用)
-        playbook_params: Playbookパラメータ（例: {"selected_playbook": "send_email_to_user"}）
+        args: Playbook引数（例: {"selected_playbook": "send_email_to_user"}）
 
     Returns:
         str: 実行結果メッセージ
@@ -94,7 +94,7 @@ def schedule_add(
             DESCRIPTION=description,
             PRIORITY=priority,
             ENABLED=enabled,
-            PLAYBOOK_PARAMS=json.dumps(playbook_params) if playbook_params else None,
+            PLAYBOOK_PARAMS=json.dumps(args) if args else None,
         )
 
         # スケジュールタイプごとの設定
@@ -206,9 +206,9 @@ def schema() -> ToolSchema:
                     "type": "integer",
                     "description": "実行間隔（interval用、秒単位）。例: 600で10分ごと",
                 },
-                "playbook_params": {
+                "args": {
                     "type": "object",
-                    "description": "Playbookパラメータ。meta_playbookがmeta_user_manualの場合、selected_playbookで実行するサブPlaybookを指定できる。例: {\"selected_playbook\": \"send_email_to_user\"}",
+                    "description": "Playbook引数。meta_playbookがmeta_user_manualの場合、selected_playbookで実行するサブPlaybookを指定できる。例: {\"selected_playbook\": \"send_email_to_user\"}",
                 },
             },
             "required": ["schedule_type", "meta_playbook"],

--- a/builtin_data/tools/schedule_list.py
+++ b/builtin_data/tools/schedule_list.py
@@ -106,7 +106,7 @@ def schedule_list() -> str:
                     last_exec_local = last_exec_utc.astimezone(persona_tz)
                     detail += f" (最終実行: {last_exec_local.strftime('%Y-%m-%d %H:%M')})"
 
-            # Parse playbook_params
+            # Parse args from DB column PLAYBOOK_PARAMS
             params_str = "(なし)"
             if s.PLAYBOOK_PARAMS:
                 try:

--- a/docs/intent/playbook_state_management.md
+++ b/docs/intent/playbook_state_management.md
@@ -1,0 +1,195 @@
+# Intent: プレイブック State 管理の再設計
+
+## これは何か
+
+プレイブックの実行時に使われる state（データの入れ物）の組み立て方と、プレイブックへのデータ受け渡し方式の再設計。
+
+## なぜ必要か
+
+### 現状の問題
+
+#### 1. playbook_params の居場所がない
+
+UIやスケジュールから明示的に渡されるパラメータ（`playbook_params`）が、state の中に独立した居場所を持たない。`parent` dict に直接マージされた上で `_initial_params` にもコピーされ、同じデータが2箇所に存在する。さらに `input_schema` のソース解決が誤った値で上書きし、`forwarded_params` のセーフティネットも `inherited_vars` チェックで無効化され、正しい値にたどり着く経路が全て塞がれるバグが発生した（PR #190）。
+
+#### 2. source 未指定のフォールバックが誤っている
+
+`input_schema` の `source` フィールドが未指定の場合、一律 `user_input` にフォールバックする。これは `input` パラメータ（ユーザー発言を受け取る）にたまたま正しく動作するだけで、`selected_playbook` のように全く別の意味を持つパラメータにも同じデフォルトが適用されてしまう。
+
+そもそも `selected_playbook` に `source` が指定されていない理由は、「`playbook_params` から取る」に相当する source タイプが存在しないため。指定したくても指定する手段がない。
+
+#### 3. 子が親のスコープを直接参照する設計
+
+子プレイブックの `input_schema` で `source: "parent.X"` と書くことで、親 state のキーを参照する仕組みになっている。これは関数呼び出しではなくクロージャに近い。親がキーを設定し忘れてもサイレントに空文字列になるだけでエラーにならず、子プレイブックがどの親プレイブックのどのキーに依存しているかを把握するには子側の定義を読む必要がある。
+
+#### 4. state が flat な dict で名前衝突する
+
+システム変数（`messages`, `persona_obj` 等）とプレイブックのノードが使う変数（`last`, `selected_playbook` 等）と `playbook_params` の値が全て同じ flat な dict に混在する。同じキー名が衝突した場合の優先順位は `**dict` の展開順序という暗黙的なルールで決まる。
+
+## 新しい設計
+
+### 原則: 関数呼び出しモデル
+
+プレイブックの呼び出しを **関数呼び出し** として統一的に扱う:
+
+- **プレイブックの `input_schema`** = 関数のシグネチャ（受け取るパラメータの定義）
+- **呼び出し元の `args`** = 関数呼び出し時の引数（呼び出し元が何を渡すか明示）
+
+プレイブックは「自分が何を受け取るか」だけを宣言し、「どこから来るか」は呼び出し元が決める。
+
+この原則は、呼び出し元が外部（UI、スケジュール、X連携）であっても、内部（親プレイブックの exec/subplay ノード）であっても同じ。
+
+```
+// 外部からの呼び出し（UI / スケジュール / X連携）
+run_meta_user(
+    playbook: "meta_user_manual",
+    args: {"selected_playbook": "send_email_to_user"}
+)
+
+// 内部からの呼び出し（親プレイブックの exec ノード）
+{
+    "type": "exec",
+    "playbook_source": "selected_playbook",
+    "args": {"objective": "{objective}", "depth": "{depth}"}
+}
+```
+
+同じ `args` の仕組み。渡された引数は `input_schema` で解決され、state のプレフィックスなし領域に入る。
+
+### state の名前空間分離
+
+`_` プレフィックスのキーはシステム変数として予約し、プレイブックのノードからは触らない:
+
+```python
+state = {
+    # システム変数（自動引継ぎ、ノードは触らない）
+    "_messages": [...],
+    "_persona_obj": ...,
+    "_pulse_id": "...",
+    "_pulse_type": "schedule",
+    "_cancellation_token": ...,
+    "_pulse_usage_accumulator": {...},
+    "_activity_trace": [...],
+
+    # プレイブックのノードが自由に使う領域
+    # args で渡された値もここに入る
+    "last": "...",
+    "selected_playbook": "...",
+    "research_result": {...},
+}
+```
+
+### args によるデータ渡し
+
+プレイブックへのデータ渡しは、呼び出し元が `args` で明示的に行う。
+
+#### 外部からの呼び出し
+
+`run_meta_user()` 等のエントリーポイントが `args` を受け取り、プレイブックの `input_schema` に基づいて state に展開する:
+
+```python
+# 現在の playbook_params は args に統合
+runtime.run_meta_user(
+    persona, user_input, building_id,
+    meta_playbook="meta_user_manual",
+    args={"selected_playbook": "send_email_to_user"},
+)
+```
+
+#### 内部からの呼び出し（exec / subplay ノード）
+
+親プレイブックのノードが `args` フィールドで子プレイブックに渡す引数を明示する:
+
+```json
+{
+    "id": "exec_source",
+    "type": "exec",
+    "playbook_source": "selected_playbook",
+    "args": {
+        "objective": "{objective}",
+        "context_text": "{resolved_context}",
+        "depth": "{depth}",
+        "max_iterations": "{max_iterations_value}"
+    },
+    "next": "check_result"
+}
+```
+
+#### 子プレイブックの input_schema
+
+受け取るパラメータの定義のみ。値の取得先は宣言しない:
+
+```json
+{
+    "input_schema": [
+        {"name": "objective", "description": "調査目的"},
+        {"name": "context_text", "description": "コンテキスト"},
+        {"name": "depth", "description": "調査深度"},
+        {"name": "max_iterations", "description": "最大イテレーション数"}
+    ]
+}
+```
+
+### user_input の扱い
+
+`user_input` はシステム変数には入れない。ランタイムが会話履歴への追加とコンテキスト構築に使うだけで、state には関与しない。
+
+プレイブックがユーザー入力を必要とする場合は、呼び出し元が `args` で明示的に渡す。他のパラメータと同じ扱い。
+
+## 廃止するもの
+
+| 廃止対象 | 理由 |
+|----------|------|
+| `source` フィールド | 子が親のスコープを参照する仕組み。args で置き換え |
+| `input_template` | テキスト結合による暗黙的なデータ渡し。args で置き換え |
+| `_initial_params` | playbook_params の二重コピー。args に統合 |
+| `forwarded_params` | `_initial_params` 透過転送の仕組み。不要になる |
+| `parent.update(initial_params)` | parent dict への直接マージ。不要になる |
+| `source` 未指定 → `user_input` フォールバック | `input` パラメータ専用ロジックの誤った汎用化 |
+| `playbook_params` 引数名 | `args` に統合（外部・内部で同じ仕組み） |
+
+## 守るべき不変条件
+
+### 1. 名前空間の分離
+
+`_` プレフィックスのキーはシステム予約。プレイブックのノード定義（set, LLM, tool 等）からシステム変数を直接変更してはならない。ランタイムだけがシステム変数を管理する。
+
+### 2. 関数呼び出しの統一性
+
+プレイブックへのデータ渡しは、呼び出し元が外部（UI、スケジュール、X連携）であっても内部（exec/subplay ノード）であっても、同じ `args` の仕組みで行う。特別な経路や名前空間を設けない。
+
+### 3. 関数呼び出しの明示性
+
+プレイブックが使うデータは、呼び出し元の `args` で全て明示的に渡す。プレイブックが呼び出し元のスコープを暗黙的に参照する経路を作らない。
+
+### 4. システム変数の自動引継ぎ
+
+`_` プレフィックスのシステム変数は、サブプレイブック呼び出し時に自動的に引き継がれる。プレイブック定義で個別に宣言する必要はない。
+
+## 具体的な変更対象
+
+### ランタイム
+
+- `sea/runtime_graph.py`: `compile_with_langgraph()` の initial_state 組み立てを再設計。`inherited_vars` / `forwarded_params` ロジックを廃止し、名前空間分離 + args 解決に置き換え
+- `sea/runtime_runner.py`: `parent.update(initial_params)` / `_initial_params` コピーを廃止。`args` を `input_schema` に基づいて state に展開する仕組みに変更
+- `sea/runtime.py`: `run_meta_user()` / `run_meta_auto()` の `playbook_params` 引数を `args` にリネーム
+- `sea/runtime_engine.py`: exec ノードの `args` フィールド処理を実装
+- `sea/runtime_nodes.py`: subplay ノードの `args` フィールド処理を実装、`input_template` を廃止
+- `sea/playbook_models.py`: `InputParam` から `source` フィールドを削除。exec/subplay ノード定義に `args` フィールドを追加
+
+### プレイブック JSON
+
+以下のプレイブックの `input_schema` から `source` フィールドを削除し、呼び出し元に `args` を追加:
+
+- `sub_router_user.json`: `source: "parent.*"` を5箇所削除 → 呼び出し元（meta_agentic, meta_user, meta_user_manual）の subplay ノードに args 追加
+- `sub_speak.json`: `source: "parent.metadata"` を削除 → 呼び出し元の subplay ノードに args 追加
+- `source_messagelog/web/memopedia/chronicle/document/pdf.json`: `source: "parent.*"` を各4箇所削除 → research_task の exec ノードに args 追加
+- `meta_exec_speak.json`: `source: "parent.*"` を削除 → 呼び出し元に args 追加
+- subplay ノードの `input_template` を全て `args` に置き換え
+
+### エントリーポイント
+
+- `sea/runtime.py`: `run_meta_user()` の `playbook_params` 引数を `args` にリネーム
+- `sea/pulse_controller.py`: `submit_user()` / `submit_schedule()` の `playbook_params` を `args` にリネーム
+- `saiverse/schedule_manager.py`: `playbook_params` → `args` に合わせて変更
+- API 層 (`api/`): フロントエンドからのリクエストパラメータ名を合わせて変更

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -237,7 +237,7 @@ export default function Home() {
     }, [inputValue, adjustTextareaHeight]);
     const [isPeopleModalOpen, setIsPeopleModalOpen] = useState(false);
     const [selectedPlaybook, setSelectedPlaybook] = useState<string | null>('meta_user');
-    const [playbookParams, setPlaybookParams] = useState<Record<string, any>>({});
+    const [playbookArgs, setPlaybookArgs] = useState<Record<string, any>>({});
     const [selectedModel, setSelectedModel] = useState<string>(''); // Model ID selected in Chat Options
     const [selectedModelDisplayName, setSelectedModelDisplayName] = useState<string>(''); // Model display name
     const [isDragOver, setIsDragOver] = useState(false); // Drag & drop state
@@ -620,8 +620,8 @@ export default function Home() {
                     if (data.playbook) {
                         setSelectedPlaybook(data.playbook);
                     }
-                    if (data.playbook_params && Object.keys(data.playbook_params).length > 0) {
-                        setPlaybookParams(data.playbook_params);
+                    if (data.args && Object.keys(data.args).length > 0) {
+                        setPlaybookArgs(data.args);
                     }
                 }
             })
@@ -1035,11 +1035,11 @@ export default function Home() {
 
         const currentAttachments = attachments;
         const currentPlaybook = selectedPlaybook;
-        const currentPlaybookParams = playbookParams;
+        const currentPlaybookArgs = playbookArgs;
 
         setAttachments([]);
-        // Reset playbook params after sending
-        setPlaybookParams({});
+        // Reset playbook args after sending
+        setPlaybookArgs({});
 
         try {
             const res = await fetch('/api/chat/send', {
@@ -1055,7 +1055,7 @@ export default function Home() {
                         mime_type: a.mimeType
                     })) : undefined,
                     meta_playbook: currentPlaybook,
-                    playbook_params: Object.keys(currentPlaybookParams).length > 0 ? currentPlaybookParams : undefined
+                    args: Object.keys(currentPlaybookArgs).length > 0 ? currentPlaybookArgs : undefined
                 })
             });
 
@@ -1923,8 +1923,8 @@ export default function Home() {
                         <ToolModeSelector
                             selectedPlaybook={selectedPlaybook}
                             onPlaybookChange={setSelectedPlaybook}
-                            playbookParams={playbookParams}
-                            onPlaybookParamsChange={setPlaybookParams}
+                            playbookArgs={playbookArgs}
+                            onPlaybookArgsChange={setPlaybookArgs}
                         />
                     </div>
 

--- a/frontend/src/components/ScheduleModal.tsx
+++ b/frontend/src/components/ScheduleModal.tsx
@@ -33,7 +33,7 @@ interface ScheduleItem {
     scheduled_datetime: string | null;
     interval_seconds: number | null;
     completed: boolean;
-    playbook_params: Record<string, any> | null;
+    args: Record<string, any> | null;
 }
 
 interface ScheduleModalProps {
@@ -68,7 +68,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
     const [formInterval, setFormInterval] = useState(600);
 
     // Playbook Parameters
-    const [formPlaybookParams, setFormPlaybookParams] = useState<Record<string, any>>({});
+    const [formPlaybookArgs, setFormPlaybookArgs] = useState<Record<string, any>>({});
     const [playbookParamSpecs, setPlaybookParamSpecs] = useState<PlaybookParam[]>([]);
 
     useEffect(() => {
@@ -84,7 +84,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
             fetchPlaybookParams(formPlaybook);
         } else {
             setPlaybookParamSpecs([]);
-            setFormPlaybookParams({});
+            setFormPlaybookArgs({});
         }
     }, [formPlaybook]);
 
@@ -141,7 +141,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
         setFormTime('09:00');
         setFormDateTime('');
         setFormInterval(600);
-        setFormPlaybookParams({});
+        setFormPlaybookArgs({});
         setPlaybookParamSpecs([]);
     };
 
@@ -155,7 +155,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
         setFormDays(s.days_of_week || []);
         setFormTime(s.time_of_day || '09:00');
         setFormInterval(s.interval_seconds || 600);
-        setFormPlaybookParams(s.playbook_params || {});
+        setFormPlaybookArgs(s.args || {});
 
         // Convert UTC datetime to local format for oneshot
         if (s.scheduled_datetime) {
@@ -179,7 +179,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
     };
 
     const handlePlaybookParamChange = (paramName: string, value: any) => {
-        setFormPlaybookParams(prev => ({ ...prev, [paramName]: value }));
+        setFormPlaybookArgs(prev => ({ ...prev, [paramName]: value }));
     };
 
     const handleSave = async () => {
@@ -189,7 +189,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
             description: formDesc,
             priority: formPriority,
             enabled: formEnabled,
-            playbook_params: Object.keys(formPlaybookParams).length > 0 ? formPlaybookParams : null
+            args: Object.keys(formPlaybookArgs).length > 0 ? formPlaybookArgs : null
         };
 
         if (formType === 'periodic') {
@@ -255,7 +255,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
         return '?';
     };
 
-    const formatPlaybookParams = (params: Record<string, any> | null) => {
+    const formatPlaybookArgs = (params: Record<string, any> | null) => {
         if (!params || Object.keys(params).length === 0) return '-';
         return Object.entries(params)
             .map(([k, v]) => `${k}: ${v}`)
@@ -303,7 +303,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
                                                 <td>{s.description}</td>
                                                 <td>{formatDetail(s)}</td>
                                                 <td style={{ fontSize: '0.85em', maxWidth: '150px', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                                                    {formatPlaybookParams(s.playbook_params)}
+                                                    {formatPlaybookArgs(s.args)}
                                                 </td>
                                                 <td>
                                                     <span className={s.enabled ? styles.enabled : styles.disabled}>
@@ -365,7 +365,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
                                     value={formPlaybook}
                                     onChange={e => {
                                         setFormPlaybook(e.target.value);
-                                        setFormPlaybookParams({}); // Reset params when playbook changes
+                                        setFormPlaybookArgs({}); // Reset params when playbook changes
                                     }}
                                 >
                                     {playbooks.length === 0 && (
@@ -400,7 +400,7 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
                                                 {param.resolved_options && param.resolved_options.length > 0 ? (
                                                     <select
                                                         className={styles.select}
-                                                        value={formPlaybookParams[param.name] ?? param.default ?? ''}
+                                                        value={formPlaybookArgs[param.name] ?? param.default ?? ''}
                                                         onChange={e => handlePlaybookParamChange(param.name, e.target.value || null)}
                                                     >
                                                         <option value="">{param.required ? '（選択...）' : '（自動）'}</option>
@@ -411,21 +411,21 @@ export default function ScheduleModal({ isOpen, onClose, personaId }: ScheduleMo
                                                 ) : param.param_type === 'boolean' ? (
                                                     <input
                                                         type="checkbox"
-                                                        checked={formPlaybookParams[param.name] ?? param.default ?? false}
+                                                        checked={formPlaybookArgs[param.name] ?? param.default ?? false}
                                                         onChange={e => handlePlaybookParamChange(param.name, e.target.checked)}
                                                     />
                                                 ) : param.param_type === 'number' ? (
                                                     <input
                                                         type="number"
                                                         className={styles.input}
-                                                        value={formPlaybookParams[param.name] ?? param.default ?? ''}
+                                                        value={formPlaybookArgs[param.name] ?? param.default ?? ''}
                                                         onChange={e => handlePlaybookParamChange(param.name, parseFloat(e.target.value))}
                                                     />
                                                 ) : (
                                                     <input
                                                         type="text"
                                                         className={styles.input}
-                                                        value={formPlaybookParams[param.name] ?? param.default ?? ''}
+                                                        value={formPlaybookArgs[param.name] ?? param.default ?? ''}
                                                         onChange={e => handlePlaybookParamChange(param.name, e.target.value)}
                                                         placeholder={param.description}
                                                     />

--- a/frontend/src/components/ToolModeSelector.tsx
+++ b/frontend/src/components/ToolModeSelector.tsx
@@ -48,15 +48,15 @@ interface SubPlaybookOption {
 interface ToolModeSelectorProps {
     selectedPlaybook: string | null;
     onPlaybookChange: (id: string | null) => void;
-    playbookParams: Record<string, any>;
-    onPlaybookParamsChange: (params: Record<string, any>) => void;
+    playbookArgs: Record<string, any>;
+    onPlaybookArgsChange: (params: Record<string, any>) => void;
 }
 
 export default function ToolModeSelector({
     selectedPlaybook,
     onPlaybookChange,
-    playbookParams,
-    onPlaybookParamsChange,
+    playbookArgs,
+    onPlaybookArgsChange,
 }: ToolModeSelectorProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [isSubOpen, setIsSubOpen] = useState(false);
@@ -122,7 +122,7 @@ export default function ToolModeSelector({
             await fetch('/api/config/playbook', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ playbook: playbookId, playbook_params: params }),
+                body: JSON.stringify({ playbook: playbookId, args: params }),
             });
         } catch (e) {
             console.error("Failed to save tool mode", e);
@@ -132,7 +132,7 @@ export default function ToolModeSelector({
     const handleModeChange = (mode: ToolMode) => {
         onPlaybookChange(mode.id);
         const newParams: Record<string, any> = {};
-        onPlaybookParamsChange(newParams);
+        onPlaybookArgsChange(newParams);
         setIsOpen(false);
         // Reset sub-playbook cache when switching modes
         if (mode.id !== 'meta_user_manual') {
@@ -143,13 +143,13 @@ export default function ToolModeSelector({
     };
 
     const handleSubPlaybookChange = (value: string | null) => {
-        const newParams = { ...playbookParams, selected_playbook: value || '' };
-        onPlaybookParamsChange(newParams);
+        const newParams = { ...playbookArgs, selected_playbook: value || '' };
+        onPlaybookArgsChange(newParams);
         setIsSubOpen(false);
         syncToServer(selectedPlaybook, newParams);
     };
 
-    const selectedSubPlaybook = playbookParams?.selected_playbook || null;
+    const selectedSubPlaybook = playbookArgs?.selected_playbook || null;
     const selectedSubLabel = selectedSubPlaybook
         ? subPlaybooks.find(s => s.value === selectedSubPlaybook)?.label || selectedSubPlaybook
         : null;

--- a/manager/runtime.py
+++ b/manager/runtime.py
@@ -414,13 +414,13 @@ class RuntimeService(
 
     def handle_user_input_stream(
         self, message: str, metadata: Optional[Dict[str, Any]] = None, meta_playbook: Optional[str] = None,
-        playbook_params: Optional[Dict[str, Any]] = None, building_id: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None, building_id: Optional[str] = None,
     ) -> Iterator[str]:
         logging.debug(
-            "[runtime] handle_user_input_stream called (metadata_present=%s, meta_playbook=%s, playbook_params=%s, building_id=%s)",
+            "[runtime] handle_user_input_stream called (metadata_present=%s, meta_playbook=%s, args=%s, building_id=%s)",
             bool(metadata),
             meta_playbook,
-            bool(playbook_params),
+            bool(args),
             building_id,
         )
         if not message or not str(message).strip():
@@ -483,7 +483,7 @@ class RuntimeService(
                         persona, building_id, message,
                         metadata=metadata,
                         meta_playbook=meta_playbook,
-                        playbook_params=playbook_params,
+                        args=args,
                         event_callback=_enrich_event
                     )
                     # Check stop event after each persona completes

--- a/manager/state.py
+++ b/manager/state.py
@@ -72,7 +72,7 @@ class CoreState:
     developer_mode: bool = field(default_factory=_default_developer_mode)  # Developer mode: shows Task, Phenomena, dev_only playbooks
     x_polling_enabled: bool = field(default_factory=_default_x_polling_enabled)  # X mention polling (default OFF)
     current_playbook: Optional[str] = None  # Selected playbook override for Chat Options
-    playbook_params: Dict[str, Any] = field(default_factory=dict)  # Parameters for the selected playbook
+    playbook_args: Dict[str, Any] = field(default_factory=dict)  # Arguments for the selected playbook
 
     # Cache settings for Anthropic prompt caching
     cache_enabled: bool = True  # Whether prompt caching is enabled

--- a/phenomena/triggers.py
+++ b/phenomena/triggers.py
@@ -68,7 +68,7 @@ TRIGGER_SCHEMAS: Dict[TriggerType, Dict[str, str]] = {
         "author_username": "メンション送信者のユーザー名",
         "author_name": "メンション送信者の表示名",
         "mention_text": "メンション本文",
-        "playbook_params_json": "Playbook実行パラメータ（JSON文字列）",
+        "args_json": "Playbook実行引数（JSON文字列）",
     },
     TriggerType.EXTERNAL_WEBHOOK: {
         "source": "Webhookの送信元",

--- a/saiverse/integrations/x_mentions.py
+++ b/saiverse/integrations/x_mentions.py
@@ -127,8 +127,8 @@ class XMentionIntegration(BaseIntegration):
             if max_id is None or tweet_id > max_id:
                 max_id = tweet_id
 
-            # Build playbook params for mechanical propagation
-            playbook_params = {
+            # Build playbook args for mechanical propagation
+            playbook_args = {
                 "selected_playbook": "x_reply",
                 "trigger_tweet_id": tweet_id,
                 "trigger_author_username": mention.get("author_username", ""),
@@ -144,8 +144,8 @@ class XMentionIntegration(BaseIntegration):
                     "author_username": mention.get("author_username", ""),
                     "author_name": mention.get("author_name", ""),
                     "mention_text": mention.get("text", ""),
-                    "playbook_params_json": json.dumps(
-                        playbook_params, ensure_ascii=False
+                    "args_json": json.dumps(
+                        playbook_args, ensure_ascii=False
                     ),
                 },
             )

--- a/saiverse/saiverse_manager.py
+++ b/saiverse/saiverse_manager.py
@@ -372,7 +372,7 @@ class SAIVerseManager(
         except Exception as exc:
             logging.exception("SEA auto run failed: %s", exc)
 
-    def run_sea_user(self, persona, building_id: str, user_input: str, metadata: Optional[Dict[str, Any]] = None, meta_playbook: Optional[str] = None, playbook_params: Optional[Dict[str, Any]] = None, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None) -> List[str]:
+    def run_sea_user(self, persona, building_id: str, user_input: str, metadata: Optional[Dict[str, Any]] = None, meta_playbook: Optional[str] = None, args: Optional[Dict[str, Any]] = None, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None) -> List[str]:
         """Run user input via PulseController."""
         try:
             result = self.pulse_controller.submit_user(
@@ -381,7 +381,7 @@ class SAIVerseManager(
                 user_input=user_input,
                 metadata=metadata,
                 meta_playbook=meta_playbook,
-                playbook_params=playbook_params,
+                args=args,
                 event_callback=event_callback,
             )
             return result if result else []
@@ -671,11 +671,11 @@ class SAIVerseManager(
 
     def handle_user_input_stream(
         self, message: str, metadata: Optional[Dict[str, Any]] = None, meta_playbook: Optional[str] = None,
-        playbook_params: Optional[Dict[str, Any]] = None, building_id: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None, building_id: Optional[str] = None,
     ) -> Iterator[str]:
         yield from self.runtime.handle_user_input_stream(
             message, metadata=metadata, meta_playbook=meta_playbook,
-            playbook_params=playbook_params, building_id=building_id,
+            args=args, building_id=building_id,
         )
 
     def cancel_active_generation(self) -> bool:

--- a/saiverse/schedule_manager.py
+++ b/saiverse/schedule_manager.py
@@ -256,21 +256,21 @@ class ScheduleManager:
         persona_id = schedule.PERSONA_ID
         meta_playbook = schedule.META_PLAYBOOK
 
-        # Parse playbook_params from JSON
-        playbook_params = None
+        # Parse args from DB column PLAYBOOK_PARAMS
+        schedule_args = None
         if schedule.PLAYBOOK_PARAMS:
             try:
-                playbook_params = json.loads(schedule.PLAYBOOK_PARAMS)
+                schedule_args = json.loads(schedule.PLAYBOOK_PARAMS)
             except Exception as e:
                 LOGGER.warning("[ScheduleManager] Failed to parse PLAYBOOK_PARAMS for schedule %d: %s", schedule.SCHEDULE_ID, e)
 
         LOGGER.info(
-            "[ScheduleManager] Executing schedule %d for persona %s (type=%s, playbook=%s, params=%s)",
+            "[ScheduleManager] Executing schedule %d for persona %s (type=%s, playbook=%s, args=%s)",
             schedule.SCHEDULE_ID,
             persona_id,
             schedule.SCHEDULE_TYPE,
             meta_playbook,
-            playbook_params,
+            schedule_args,
         )
 
         # ペルソナを取得
@@ -291,11 +291,11 @@ class ScheduleManager:
         # メタプレイブックを実行（PulseController経由）
         try:
             LOGGER.info(
-                "[ScheduleManager] Submitting schedule via PulseController: playbook=%s, building=%s, prompt_length=%d, params=%s",
+                "[ScheduleManager] Submitting schedule via PulseController: playbook=%s, building=%s, prompt_length=%d, args=%s",
                 meta_playbook,
                 building_id,
                 len(user_input),
-                playbook_params,
+                schedule_args,
             )
             self.manager.pulse_controller.submit_schedule(
                 persona_id=persona_id,
@@ -303,7 +303,7 @@ class ScheduleManager:
                 user_input=user_input,
                 metadata={"schedule_id": schedule.SCHEDULE_ID, "schedule_type": schedule.SCHEDULE_TYPE},
                 meta_playbook=meta_playbook,
-                playbook_params=playbook_params,
+                args=schedule_args,
             )
             LOGGER.info("[ScheduleManager] Schedule submitted to PulseController")
 

--- a/sea/playbook_models.py
+++ b/sea/playbook_models.py
@@ -228,7 +228,11 @@ class SubPlayNodeDef(BaseModel):
     id: str
     type: Literal[NodeType.SUBPLAY]
     playbook: str = Field(description="Name of the sub-playbook to execute")
-    input_template: Optional[str] = Field(default="{input}", description="Template for the input passed to the sub-playbook")
+    args: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Args to pass to the sub-playbook. Values are template strings "
+                    "resolved against current state (e.g., '{objective}')."
+    )
     propagate_output: bool = Field(default=False, description="If true, append sub-playbook outputs to parent outputs")
     execution: Optional[str] = Field(
         default="inline",
@@ -270,6 +274,12 @@ class ExecNodeDef(BaseModel):
     playbook_source: str = Field(
         default="selected_playbook",
         description="State variable name containing the playbook name to execute."
+    )
+    args: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Static args to pass to the sub-playbook. Values are template strings "
+                    "resolved against current state (e.g., '{objective}'). "
+                    "These are merged with dynamic args from args_source (args_source takes precedence)."
     )
     args_source: Optional[str] = Field(
         default="selected_args",
@@ -360,10 +370,6 @@ NodeDef = Union[
 class InputParam(BaseModel):
     name: str
     description: str
-    source: Optional[str] = Field(
-        default=None,
-        description="Optional parent state key (e.g., 'parent.input', 'router.query'). If not specified, defaults to 'input'."
-    )
 
     # Type and validation
     param_type: str = Field(

--- a/sea/pulse_controller.py
+++ b/sea/pulse_controller.py
@@ -73,7 +73,7 @@ class ExecutionRequest:
     user_input: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
     meta_playbook: Optional[str] = None
-    playbook_params: Optional[Dict[str, Any]] = None  # Parameters for meta playbook
+    args: Optional[Dict[str, Any]] = None  # Arguments for meta playbook
     event_callback: Optional[Callable[[Dict[str, Any]], None]] = None
     pulse_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     cancellation_token: CancellationToken = field(default_factory=CancellationToken)
@@ -307,7 +307,7 @@ class PulseController:
                 building_id=request.building_id,
                 metadata=request.metadata,
                 meta_playbook=request.meta_playbook,
-                playbook_params=request.playbook_params,
+                args=request.args,
                 event_callback=request.event_callback,
                 cancellation_token=request.cancellation_token,
                 pulse_type=request.type,
@@ -399,7 +399,7 @@ class PulseController:
         user_input: str,
         metadata: Optional[Dict[str, Any]] = None,
         meta_playbook: Optional[str] = None,
-        playbook_params: Optional[Dict[str, Any]] = None,
+        args: Optional[Dict[str, Any]] = None,
         event_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> Optional[List[str]]:
         """Submit a user input request."""
@@ -410,7 +410,7 @@ class PulseController:
             user_input=user_input,
             metadata=metadata,
             meta_playbook=meta_playbook,
-            playbook_params=playbook_params,
+            args=args,
             event_callback=event_callback,
         )
         return self.submit(request)
@@ -422,7 +422,7 @@ class PulseController:
         user_input: str,
         metadata: Optional[Dict[str, Any]] = None,
         meta_playbook: Optional[str] = None,
-        playbook_params: Optional[Dict[str, Any]] = None,
+        args: Optional[Dict[str, Any]] = None,
     ) -> Optional[List[str]]:
         """Submit a scheduled execution request."""
         request = ExecutionRequest(
@@ -432,7 +432,7 @@ class PulseController:
             user_input=user_input,
             metadata=metadata,
             meta_playbook=meta_playbook,
-            playbook_params=playbook_params,
+            args=args,
         )
         return self.submit(request)
     

--- a/sea/runtime_graph.py
+++ b/sea/runtime_graph.py
@@ -61,45 +61,24 @@ def compile_with_langgraph(
             user_message=f"プレイブック '{playbook.name}' のグラフ構築に失敗しました。",
         )
 
-    # Process input_schema to inherit variables from parent_state.
-    # source_key (from param.source) is the primary resolution mechanism.
-    # param_name in parent is a fallback for when source_key yields nothing.
+    # Resolve input_schema parameters from _args (function call model).
+    # _args is set by the caller (run_playbook, or exec/subplay node args).
+    args_dict = parent.get("_args") or {}
     inherited_vars = {}
     for param in playbook.input_schema:
         param_name = param.name
-        source_key = param.source if param.source else "input"
 
-        # Primary: resolve based on source_key
-        if source_key == "input":
-            value = user_input or ""
-        elif source_key.startswith("parent."):
-            actual_key = source_key[7:]  # strip "parent."
-            value = runtime._resolve_state_value(parent, actual_key)
-            if value is None:
-                value = ""
-            LOGGER.debug("[sea][LangGraph] Resolved %s from parent.%s: %s", param_name, actual_key, str(value)[:120] if value else "(empty)")
+        if param_name in args_dict:
+            value = args_dict[param_name]
+            LOGGER.debug("[sea][LangGraph] Resolved %s from args: %s", param_name, str(value)[:120] if value else "(empty)")
         else:
-            value = parent.get(source_key, "")
-
-        # Fallback: if source_key resolution yielded nothing, check parent by param name
-        if not value and param_name in parent and parent[param_name] is not None:
-            value = parent[param_name]
-            LOGGER.debug("[sea][LangGraph] Fallback: using parent value for %s: %s", param_name, str(value)[:120] if value else "(empty)")
-
-        # Override: explicitly passed initial_params (e.g. from schedule playbook_params)
-        # take precedence over default source resolution.  This ensures that
-        # scheduled execution with selected_playbook="send_email_to_user" is not
-        # overwritten by the generic "input" source fallback.
-        _ip = parent.get("_initial_params")
-        if isinstance(_ip, dict) and param_name in _ip and _ip[param_name] is not None:
-            value = _ip[param_name]
-            LOGGER.debug("[sea][LangGraph] Override from _initial_params for %s: %s", param_name, str(value)[:120])
+            value = param.default if param.default is not None else ""
 
         inherited_vars[param_name] = value
 
-    # Inherit pulse_usage_accumulator from parent_state if it exists (for sub-playbook calls)
+    # Inherit _pulse_usage_accumulator from parent_state if it exists (for sub-playbook calls)
     # This ensures usage is accumulated across all LLM calls in the entire pulse chain
-    parent_accumulator = parent.get("pulse_usage_accumulator")
+    parent_accumulator = parent.get("_pulse_usage_accumulator")
     if parent_accumulator:
         # Use the same accumulator (reference) to accumulate across sub-playbooks
         usage_accumulator = parent_accumulator
@@ -125,43 +104,22 @@ def compile_with_langgraph(
     # Inherit cancellation token from parent state if not explicitly provided
     effective_cancellation_token = cancellation_token or parent.get("_cancellation_token")
 
-    # Forward initial_params into the LangGraph state so that exec nodes
-    # can pass them to sub-playbooks.  This enables meta playbooks (e.g.
-    # meta_user_manual) to relay trigger-specific params (trigger_tweet_id,
-    # etc.) without declaring each one in their own input_schema.
-    forwarded_params = {}
-    _ip = parent.get("_initial_params")
-    if _ip and isinstance(_ip, dict):
-        reserved = {
-            "messages", "inputs", "context", "last", "outputs",
-            "persona_obj", "pulse_id", "pulse_type",
-            "_cancellation_token", "pulse_usage_accumulator",
-            "_activity_trace", "_intermediate_msgs",
-        }
-        for k, v in _ip.items():
-            if k not in reserved and k not in inherited_vars:
-                forwarded_params[k] = v
-        if forwarded_params:
-            LOGGER.debug(
-                "[sea][LangGraph] Forwarding initial_params to state: %s",
-                list(forwarded_params.keys()),
-            )
-
     initial_state = {
-        "messages": list(base_messages),
-        "inputs": {"input": user_input or ""},
-        "context": {},
-        "last": user_input or "",
-        "outputs": _lg_outputs,
-        "persona_obj": persona,
-        "pulse_id": pulse_id,
-        "pulse_type": pulse_type,  # user/schedule/auto
+        # System variables (_ prefix, auto-inherited, nodes don't touch)
+        "_messages": list(base_messages),
+        "_context": {},
+        "_outputs": _lg_outputs,
+        "_persona_obj": persona,
+        "_pulse_id": pulse_id,
+        "_pulse_type": pulse_type,  # user/schedule/auto
         "_cancellation_token": effective_cancellation_token,  # For node-level cancellation checks
-        "pulse_usage_accumulator": usage_accumulator,  # Inherit from parent or create new
+        "_pulse_usage_accumulator": usage_accumulator,  # Inherit from parent or create new
         "_activity_trace": activity_trace,  # Shared trace of exec/tool activities
         "_intermediate_msgs": [],  # Track intermediate node outputs for profile-based context
-        **forwarded_params,  # Forward initial_params (trigger data etc.)
-        **inherited_vars,  # Add inherited variables from input_schema (takes precedence)
+        # Playbook variables (no prefix)
+        "last": user_input or "",
+        "input": user_input or "",
+        **inherited_vars,  # Add resolved parameters from args/input_schema
     }
 
     # Execute compiled playbook

--- a/sea/runtime_nodes.py
+++ b/sea/runtime_nodes.py
@@ -49,7 +49,7 @@ def lg_tool_call_node(runtime: Any, node_def: Any, persona: Any, playbook: Any, 
                 state[output_key] = error_msg
             return state
 
-        persona_obj = state.get("persona_obj") or persona
+        persona_obj = state.get("_persona_obj") or persona
         persona_id = getattr(persona_obj, "persona_id", "unknown")
         try:
             persona_dir = getattr(persona_obj, "persona_log_path", None)
@@ -144,10 +144,23 @@ def lg_subplay_node(runtime: Any, node_def: Any, persona: Any, building_id: str,
             return state
         from .runtime_utils import _format as runtime_format
 
-        template = getattr(node_def, "input_template", "{input}") or "{input}"
-        variables = dict(state)
-        variables.update({"input": state.get("inputs", {}).get("input", ""), "last": state.get("last", "")})
-        sub_input = runtime_format(template, variables)
+        # Build child args from node_def.args, resolving template strings against current state
+        node_args = getattr(node_def, "args", None)
+        if node_args and isinstance(node_args, dict):
+            state_vars = {k: v for k, v in state.items() if not k.startswith("_")}
+            child_args = {}
+            for key, tmpl in node_args.items():
+                if isinstance(tmpl, str):
+                    child_args[key] = runtime_format(tmpl, state_vars)
+                else:
+                    child_args[key] = tmpl
+            sub_input = child_args.get("input") or child_args.get("query") or ""
+            state["_args"] = child_args
+        else:
+            # No args specified — pass input from state
+            sub_input = state.get("input", "") or state.get("last", "")
+            state["_args"] = {"input": sub_input} if sub_input else None
+
         eff_bid = runtime._effective_building_id(persona, building_id)
         execution = getattr(node_def, "execution", "inline") or "inline"
         subagent_thread_id = None

--- a/sea/runtime_runner.py
+++ b/sea/runtime_runner.py
@@ -29,17 +29,12 @@ def run_playbook(
     parent = parent_state or {}
 
     if initial_params:
-        LOGGER.debug("[sea] _run_playbook merging initial_params: %s", list(initial_params.keys()))
-        parent.update(initial_params)
-        # Preserve the original initial_params so compile_with_langgraph can
-        # forward them into the LangGraph state even when the playbook's
-        # input_schema doesn't explicitly declare them.  This allows meta
-        # playbooks (e.g. meta_user_manual) to pass trigger params through
-        # to sub-playbooks without needing to know every possible key.
-        parent["_initial_params"] = dict(initial_params)
+        LOGGER.debug("[sea] _run_playbook received args: %s", list(initial_params.keys()))
+        # Store args for compile_with_langgraph to resolve via input_schema
+        parent["_args"] = dict(initial_params)
     LOGGER.debug("[sea] _run_playbook called for %s, parent_state keys: %s", playbook.name, list(parent.keys()) if parent else "(none)")
-    if "pulse_id" in parent:
-        pulse_id = str(parent["pulse_id"])
+    if "_pulse_id" in parent:
+        pulse_id = str(parent["_pulse_id"])
     else:
         pulse_id = str(uuid.uuid4())
 

--- a/tests/sea/test_runtime_engine.py
+++ b/tests/sea/test_runtime_engine.py
@@ -24,7 +24,7 @@ def test_lg_tool_node_delegates_to_engine() -> None:
     node = runtime._lg_tool_node(node_def, persona, playbook)
     result = asyncio.run(node({}))
 
-    runtime._runtime_engine.lg_tool_node.assert_called_once_with(node_def, persona, playbook, None)
+    runtime._runtime_engine.lg_tool_node.assert_called_once_with(node_def, persona, playbook, None, auto_mode=False)
     assert result == expected
 
 


### PR DESCRIPTION
## Summary

プレイブックの state 管理を全面再設計。スケジュール実行時に `playbook_params` の `selected_playbook` が消失するバグ（#190）の根本原因を解消。

- **関数呼び出しモデル導入**: `input_schema` = シグネチャ、呼び出し元の `args` = 引数。暗黙的な `source` 解決を廃止し、明示的な args 渡しに統一
- **名前空間分離**: システム変数に `_` プレフィックス（`_messages`, `_persona_obj`, `_pulse_id` 等）を付与し、プレイブック変数と衝突しない設計に
- **API統一**: `playbook_params` → `args` にリネーム（API/Manager/Runtime/Frontend全層）
- **レガシー削除**: `InputParam.source`, `SubPlayNodeDef.input_template`, `forwarded_params`, `_initial_params` を全て削除

### 変更の7フェーズ

| Phase | 内容 | ファイル数 |
|-------|------|-----------|
| 1 | Model層に `args` フィールド追加 | 1 |
| 2 | システム変数 `_` プレフィックス化 | 5 |
| 3 | args 解決の新メカニズム | 2 |
| 4 | exec/subplay ノードの args 対応 | 2 |
| 5 | プレイブック JSON 移行（30ファイル） | 30 |
| 6 | `playbook_params` → `args` リネーム | 17 |
| 7 | レガシーコード削除 | 5 |

### DB変更
- DB列 `PLAYBOOK_PARAMS` はリネームなし（migration不要）。コード側の読み書き境界でマッピング

## Test plan

- [x] `python -m pytest tests/` — 143 passed, 0 failed
- [x] `ruff check` — clean
- [x] `python scripts/import_all_playbooks.py --force` — 51 playbooks updated
- [x] 動作確認: ディープリサーチプレイブック正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)