### PR TITLE
Add per-model image size/count limits with dynamic UI control

### DIFF
--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -75,6 +75,8 @@ class ModelConfigResponse(BaseModel):
     metabolism_enabled: bool = True
     metabolism_keep_messages: Optional[int] = None
     metabolism_keep_messages_model_default: Optional[int] = None
+    max_image_embeds: Optional[int] = None
+    max_image_embeds_model_default: Optional[int] = None
 
 @router.get("/models", response_model=List[ModelInfo])
 def get_models():
@@ -258,6 +260,8 @@ def get_current_config(manager = Depends(get_manager)):
             "metabolism_enabled": getattr(manager, "metabolism_enabled", True),
             "metabolism_keep_messages": getattr(manager, "metabolism_keep_messages_override", None),
             "metabolism_keep_messages_model_default": None,
+            "max_image_embeds": getattr(manager, "max_image_embeds_override", None),
+            "max_image_embeds_model_default": None,
         }
 
     # Get param specs
@@ -297,13 +301,17 @@ def get_current_config(manager = Depends(get_manager)):
         current_values.update(manager.model_parameter_overrides)
 
     # Max history messages
-    from saiverse.model_configs import get_default_max_history_messages, get_metabolism_keep_messages
+    from saiverse.model_configs import get_default_max_history_messages, get_metabolism_keep_messages, get_max_image_embeds
     override = getattr(manager, "max_history_messages_override", None)
     model_default = get_default_max_history_messages(current_model)
 
     # Metabolism settings
     metab_override = getattr(manager, "metabolism_keep_messages_override", None)
     metab_model_default = get_metabolism_keep_messages(current_model)
+
+    # Image embeds
+    img_embeds_override = getattr(manager, "max_image_embeds_override", None)
+    img_embeds_model_default = get_max_image_embeds(current_model)
 
     return {
         "current_model": current_model,
@@ -314,6 +322,8 @@ def get_current_config(manager = Depends(get_manager)):
         "metabolism_enabled": getattr(manager, "metabolism_enabled", True),
         "metabolism_keep_messages": metab_override if metab_override is not None else metab_model_default,
         "metabolism_keep_messages_model_default": metab_model_default,
+        "max_image_embeds": img_embeds_override if img_embeds_override is not None else img_embeds_model_default,
+        "max_image_embeds_model_default": img_embeds_model_default,
     }
 
 @router.post("/model")
@@ -369,13 +379,17 @@ def set_model(req: UpdateModelRequest, manager = Depends(get_manager)):
         current_values.update(manager.model_parameter_overrides)
 
     # Max history messages (reset override on model change)
-    from saiverse.model_configs import get_default_max_history_messages, get_metabolism_keep_messages
+    from saiverse.model_configs import get_default_max_history_messages, get_metabolism_keep_messages, get_max_image_embeds
     manager.max_history_messages_override = None
     model_default = get_default_max_history_messages(current_model)
 
     # Metabolism (reset override on model change)
     manager.metabolism_keep_messages_override = None
     metab_model_default = get_metabolism_keep_messages(current_model)
+
+    # Image embeds (reset override on model change)
+    manager.max_image_embeds_override = None
+    img_embeds_model_default = get_max_image_embeds(current_model)
 
     return {
         "success": True,
@@ -388,6 +402,8 @@ def set_model(req: UpdateModelRequest, manager = Depends(get_manager)):
         "metabolism_enabled": getattr(manager, "metabolism_enabled", True),
         "metabolism_keep_messages": metab_model_default,
         "metabolism_keep_messages_model_default": metab_model_default,
+        "max_image_embeds": img_embeds_model_default,
+        "max_image_embeds_model_default": img_embeds_model_default,
     }
 
 @router.post("/parameters")
@@ -737,6 +753,58 @@ def set_metabolism_settings(req: MetabolismConfigRequest, manager=Depends(get_ma
         "enabled": getattr(manager, "metabolism_enabled", True),
         "keep_messages": getattr(manager, "metabolism_keep_messages_override", None),
     }
+
+
+class MaxImageEmbedsRequest(BaseModel):
+    value: Optional[int] = None
+
+
+@router.get("/max-image-embeds")
+def get_max_image_embeds_setting(manager=Depends(get_manager)):
+    """Get current max image embeds setting."""
+    from saiverse.model_configs import get_max_image_embeds
+
+    override = getattr(manager, "max_image_embeds_override", None)
+    current_model = manager.model or None
+    model_default = get_max_image_embeds(current_model) if current_model else None
+
+    return {
+        "value": override if override is not None else model_default,
+        "override": override,
+        "model_default": model_default,
+    }
+
+
+@router.post("/max-image-embeds")
+def set_max_image_embeds(req: MaxImageEmbedsRequest, manager=Depends(get_manager)):
+    """Set session override for max image embeds.
+
+    Send {"value": null} to clear the override and use the model default.
+    Send {"value": 0} to disable image embedding entirely.
+    """
+    if req.value is not None and req.value < 0:
+        raise HTTPException(status_code=400, detail="value must be >= 0 or null")
+    manager.max_image_embeds_override = req.value
+
+    # Determine effective value (override or model default)
+    effective = req.value
+    if effective is None:
+        from saiverse.model_configs import get_max_image_embeds
+        current_model = manager.model or None
+        if current_model:
+            effective = get_max_image_embeds(current_model)
+
+    # Apply to all active persona LLM clients
+    for persona in manager.personas.values():
+        client = getattr(persona, "_llm_client", None)
+        if client is not None and hasattr(client, "max_image_embeds"):
+            client.max_image_embeds = effective
+            _log.info(
+                "Updated max_image_embeds=%s on LLM client for persona '%s'",
+                effective, getattr(persona, "persona_id", "?"),
+            )
+
+    return {"success": True, "value": req.value}
 
 
 @router.get("/startup-warnings")

--- a/builtin_data/models/openrouter-kimi-k2.5.json
+++ b/builtin_data/models/openrouter-kimi-k2.5.json
@@ -10,6 +10,8 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": true,
+  "max_image_bytes": 7500000,
+  "max_image_embeds": 4,
   "reasoning_passback_field": "reasoning_details",
   "request_kwargs": {
     "extra_body": {

--- a/builtin_data/models/openrouter-qwen3.5-397b-a17b.json
+++ b/builtin_data/models/openrouter-qwen3.5-397b-a17b.json
@@ -11,6 +11,8 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": true,
+  "max_image_bytes": 7500000,
+  "max_image_embeds": 4,
   "reasoning_passback_field": "reasoning_details",
   "request_kwargs": {
     "extra_body": {

--- a/builtin_data/models/openrouter-qwen3.5-plus-2026-02-15.json
+++ b/builtin_data/models/openrouter-qwen3.5-plus-2026-02-15.json
@@ -11,6 +11,8 @@
   "api_key_env": "OPENROUTER_API_KEY",
   "convert_system_to_user": true,
   "supports_images": true,
+  "max_image_bytes": 7500000,
+  "max_image_embeds": 4,
   "reasoning_passback_field": "reasoning_details",
   "request_kwargs": {
     "extra_body": {

--- a/builtin_data/models/openrouter-z-ai-glm-4.6v.json
+++ b/builtin_data/models/openrouter-z-ai-glm-4.6v.json
@@ -10,6 +10,8 @@
   "base_url": "https://openrouter.ai/api/v1",
   "api_key_env": "OPENROUTER_API_KEY",
   "supports_images": true,
+  "max_image_bytes": 7500000,
+  "max_image_embeds": 4,
   "convert_system_to_user": true,
   "parameters": {
     "temperature": {

--- a/frontend/src/components/ChatOptions.tsx
+++ b/frontend/src/components/ChatOptions.tsx
@@ -53,6 +53,8 @@ export default function ChatOptions({ isOpen, onClose, currentModel: propCurrent
     const [metabolismEnabled, setMetabolismEnabled] = useState<boolean>(true);
     const [metabolismKeepMessages, setMetabolismKeepMessages] = useState<number | null>(null);
     const [metabolismKeepMessagesDefault, setMetabolismKeepMessagesDefault] = useState<number | null>(null);
+    const [maxImageEmbeds, setMaxImageEmbeds] = useState<number | null>(null);
+    const [maxImageEmbedsDefault, setMaxImageEmbedsDefault] = useState<number | null>(null);
     const [historySettingsOpen, setHistorySettingsOpen] = useState(false);
     const [modelParamsOpen, setModelParamsOpen] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -108,6 +110,8 @@ export default function ChatOptions({ isOpen, onClose, currentModel: propCurrent
                     setMetabolismEnabled(config.metabolism_enabled ?? true);
                     setMetabolismKeepMessages(config.metabolism_keep_messages ?? null);
                     setMetabolismKeepMessagesDefault(config.metabolism_keep_messages_model_default ?? null);
+                    setMaxImageEmbeds(config.max_image_embeds ?? null);
+                    setMaxImageEmbedsDefault(config.max_image_embeds_model_default ?? null);
                 } catch (e) { console.error("Failed to parse config response", e); failures.push('config'); }
             } else {
                 const reason = results[1].status === 'rejected' ? results[1].reason : `HTTP ${results[1].value.status}`;
@@ -165,6 +169,8 @@ export default function ChatOptions({ isOpen, onClose, currentModel: propCurrent
                 setMetabolismEnabled(data.metabolism_enabled ?? true);
                 setMetabolismKeepMessages(data.metabolism_keep_messages ?? null);
                 setMetabolismKeepMessagesDefault(data.metabolism_keep_messages_model_default ?? null);
+                setMaxImageEmbeds(data.max_image_embeds ?? null);
+                setMaxImageEmbedsDefault(data.max_image_embeds_model_default ?? null);
             }
 
             // Refetch cache config since it depends on selected model
@@ -244,6 +250,24 @@ export default function ChatOptions({ isOpen, onClose, currentModel: propCurrent
             });
         } catch (e) {
             console.error("Failed to update metabolism keep_messages", e);
+        }
+    };
+
+    const handleMaxImageEmbedsInput = (value: string) => {
+        const numValue = value === '' ? null : parseInt(value, 10);
+        if (numValue !== null && (isNaN(numValue) || numValue < 0)) return;
+        setMaxImageEmbeds(numValue);
+    };
+
+    const handleMaxImageEmbedsCommit = async () => {
+        try {
+            await fetch('/api/config/max-image-embeds', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value: maxImageEmbeds })
+            });
+        } catch (e) {
+            console.error("Failed to update max image embeds", e);
         }
     };
 
@@ -411,6 +435,27 @@ export default function ChatOptions({ isOpen, onClose, currentModel: propCurrent
                                                 </span>
                                             </div>
                                         )}
+                                        <div className={styles.formGroup}>
+                                            <label>
+                                                画像埋め込み上限
+                                                {maxImageEmbedsDefault != null && (
+                                                    <span className={styles.hint}> （モデルデフォルト: {maxImageEmbedsDefault}）</span>
+                                                )}
+                                            </label>
+                                            <input
+                                                type="number"
+                                                className={styles.input}
+                                                min={0}
+                                                max={50}
+                                                value={maxImageEmbeds ?? ''}
+                                                placeholder={maxImageEmbedsDefault ? `（自動: ${maxImageEmbedsDefault}）` : '（無制限）'}
+                                                onChange={(e) => handleMaxImageEmbedsInput(e.target.value)}
+                                                onBlur={() => handleMaxImageEmbedsCommit()}
+                                            />
+                                            <span className={styles.hint}>
+                                                LLMに送信する画像の最大枚数。超過分はテキスト要約に置換されます。0で全画像をテキスト化。空欄で無制限。
+                                            </span>
+                                        </div>
                                         {cacheConfig.supported && (
                                             <>
                                                 <div className={styles.formGroup}>

--- a/llm_clients/anthropic.py
+++ b/llm_clients/anthropic.py
@@ -61,10 +61,10 @@ class AnthropicClient(LLMClient):
         self.client = Anthropic(api_key=api_key)
         self.model = model
 
-        # Anthropic has a 5MB limit for images
-        self.max_image_bytes = 5 * 1024 * 1024
-
         cfg = config or {}
+
+        # Anthropic has a 5MB limit for images (configurable via model config)
+        self.max_image_bytes = cfg.get("max_image_bytes", 5 * 1024 * 1024)
 
         # Extended thinking configuration
         self._thinking_config: Optional[Dict[str, Any]] = None

--- a/llm_clients/factory.py
+++ b/llm_clients/factory.py
@@ -64,6 +64,14 @@ def get_llm_client(model: str, provider: str, context_length: int, config: Dict 
             if isinstance(request_kwargs, dict):
                 extra_kwargs["request_kwargs"] = request_kwargs
 
+            max_image_bytes = config.get("max_image_bytes")
+            if isinstance(max_image_bytes, int) and max_image_bytes > 0:
+                extra_kwargs["max_image_bytes"] = max_image_bytes
+
+            max_image_embeds = config.get("max_image_embeds")
+            if isinstance(max_image_embeds, int) and max_image_embeds > 0:
+                extra_kwargs["max_image_embeds"] = max_image_embeds
+
             # Convert system messages to user messages if needed for compatibility
             convert_system = config.get("convert_system_to_user")
             if isinstance(convert_system, bool):
@@ -102,6 +110,14 @@ def get_llm_client(model: str, provider: str, context_length: int, config: Dict 
             request_kwargs = config.get("request_kwargs")
             if isinstance(request_kwargs, dict):
                 extra_kwargs["request_kwargs"] = request_kwargs
+
+            max_image_bytes = config.get("max_image_bytes")
+            if isinstance(max_image_bytes, int) and max_image_bytes > 0:
+                extra_kwargs["max_image_bytes"] = max_image_bytes
+
+            max_image_embeds = config.get("max_image_embeds")
+            if isinstance(max_image_embeds, int) and max_image_embeds > 0:
+                extra_kwargs["max_image_embeds"] = max_image_embeds
 
             convert_system = config.get("convert_system_to_user")
             if isinstance(convert_system, bool):

--- a/llm_clients/gemini.py
+++ b/llm_clients/gemini.py
@@ -257,6 +257,9 @@ class GeminiClient(LLMClient):
         self.free_client, self.paid_client, self.client = build_gemini_clients(prefer_paid=prefer_paid)
         self.model = model
 
+        # Image size limit (raw bytes, before base64 encoding)
+        self.max_image_bytes: Optional[int] = cfg.get("max_image_bytes")
+
         # Request parameters (temperature, top_p, etc.)
         self._request_params: Dict[str, Any] = {}
 
@@ -662,13 +665,23 @@ class GeminiClient(LLMClient):
                     parts.append(types.Part(text=text_content))
                 for attachment in selected_attachments:
                     data, effective_mime = load_image_bytes_for_llm(
-                        attachment["path"], attachment["mime_type"]
+                        attachment["path"], attachment["mime_type"],
+                        max_bytes=self.max_image_bytes,
                     )
                     if not data or not effective_mime:
                         logging.warning(
                             "Failed to load image for Gemini payload: %s", attachment["uri"]
                         )
                         continue
+                    logging.debug(
+                        "[gemini] image att=%s orig_mime=%s effective_mime=%s "
+                        "raw_bytes=%d magic=%s",
+                        attachment.get("uri"),
+                        attachment.get("mime_type"),
+                        effective_mime,
+                        len(data),
+                        data[:8].hex(),
+                    )
                     parts.append(types.Part.from_bytes(data=data, mime_type=effective_mime))
                 if not parts:
                     parts.append(types.Part(text=""))

--- a/llm_clients/openai.py
+++ b/llm_clients/openai.py
@@ -84,12 +84,13 @@ def _convert_to_llm_error(err: Exception, context: str = "API call") -> LLMError
     return openai_errors.convert_to_llm_error(err, context)
 
 
-def _prepare_openai_messages(messages: List[Any], supports_images: bool, max_image_bytes: Optional[int] = None, convert_system_to_user: bool = False, reasoning_passback_field: Optional[str] = None) -> List[Any]:
+def _prepare_openai_messages(messages: List[Any], supports_images: bool, max_image_bytes: Optional[int] = None, max_image_embeds: Optional[int] = None, convert_system_to_user: bool = False, reasoning_passback_field: Optional[str] = None) -> List[Any]:
     """Backward-compatible wrapper for OpenAI message preparation."""
     return prepare_openai_messages(
         messages=messages,
         supports_images=supports_images,
         max_image_bytes=max_image_bytes,
+        max_image_embeds=max_image_embeds,
         convert_system_to_user=convert_system_to_user,
         reasoning_passback_field=reasoning_passback_field,
     )
@@ -171,6 +172,7 @@ class OpenAIClient(LLMClient):
         api_key_env: Optional[str] = None,
         request_kwargs: Optional[Dict[str, Any]] = None,
         max_image_bytes: Optional[int] = None,
+        max_image_embeds: Optional[int] = None,
         convert_system_to_user: bool = False,
         structured_output_backend: Optional[str] = None,
         structured_output_mode: Optional[str] = None,
@@ -193,6 +195,7 @@ class OpenAIClient(LLMClient):
         self.model = model
         self._request_kwargs: Dict[str, Any] = dict(request_kwargs or {})
         self.max_image_bytes = max_image_bytes
+        self.max_image_embeds = max_image_embeds
         self.convert_system_to_user = convert_system_to_user
         self.structured_output_backend = structured_output_backend
         self.structured_output_mode = structured_output_mode or "native"
@@ -311,6 +314,7 @@ class OpenAIClient(LLMClient):
                         effective_messages,
                         self.supports_images,
                         self.max_image_bytes,
+                        self.max_image_embeds,
                         self.convert_system_to_user,
                         self.reasoning_passback_field,
                     ),
@@ -401,6 +405,7 @@ class OpenAIClient(LLMClient):
                         messages,
                         self.supports_images,
                         self.max_image_bytes,
+                        self.max_image_embeds,
                         self.convert_system_to_user,
                         self.reasoning_passback_field,
                     ),
@@ -751,7 +756,7 @@ class OpenAIClient(LLMClient):
                 resp = openai_runtime.call_with_retry(
                     lambda: self._create_completion(
                         model=self.model,
-                        messages=_prepare_openai_messages(effective_messages, self.supports_images, self.max_image_bytes, self.convert_system_to_user, self.reasoning_passback_field),
+                        messages=_prepare_openai_messages(effective_messages, self.supports_images, self.max_image_bytes, self.max_image_embeds, self.convert_system_to_user, self.reasoning_passback_field),
                         n=1,
                         **req_kwargs,
                     ),
@@ -786,7 +791,7 @@ class OpenAIClient(LLMClient):
             resp = openai_runtime.call_with_retry(
                 lambda: self._create_completion(
                     model=self.model,
-                    messages=_prepare_openai_messages(messages, self.supports_images, self.max_image_bytes, self.convert_system_to_user, self.reasoning_passback_field),
+                    messages=_prepare_openai_messages(messages, self.supports_images, self.max_image_bytes, self.max_image_embeds, self.convert_system_to_user, self.reasoning_passback_field),
                     tools=tools_spec,
                     tool_choice=force_tool_choice,
                     stream=True,

--- a/llm_clients/openai_message_preparer.py
+++ b/llm_clients/openai_message_preparer.py
@@ -33,9 +33,10 @@ def is_empty_message(msg: Dict[str, Any]) -> bool:
 
 def scan_message_metadata(
     messages: List[Any],
+    max_image_embeds_override: Optional[int] = None,
 ) -> Tuple[Dict[int, List[Dict[str, Any]]], Set[int], Set[int], Optional[Set[Tuple[int, int]]]]:
     """Build metadata-derived caches for attachment and summary handling."""
-    max_image_embeds = parse_attachment_limit("OPENAI")
+    max_image_embeds = max_image_embeds_override if max_image_embeds_override is not None else parse_attachment_limit("OPENAI")
     attachment_cache: Dict[int, List[Dict[str, Any]]] = {}
     skip_summary_indices: Set[int] = set()
     exempt_indices: Set[int] = set()
@@ -115,6 +116,17 @@ def build_message_content_with_attachments(
                 )
                 if data and effective_mime:
                     b64 = base64.b64encode(data).decode("ascii")
+                    magic = data[:8].hex()
+                    logging.debug(
+                        "[openai_prep] image att=%s orig_mime=%s effective_mime=%s "
+                        "raw_bytes=%d b64_len=%d magic=%s",
+                        att.get("uri") or att.get("path"),
+                        att.get("mime_type"),
+                        effective_mime,
+                        len(data),
+                        len(b64),
+                        magic,
+                    )
                     parts.append(
                         {
                             "type": "image_url",
@@ -153,11 +165,14 @@ def prepare_openai_messages(
     messages: List[Any],
     supports_images: bool,
     max_image_bytes: Optional[int] = None,
+    max_image_embeds: Optional[int] = None,
     convert_system_to_user: bool = False,
     reasoning_passback_field: Optional[str] = None,
 ) -> List[Any]:
     """Prepare messages for OpenAI-compatible APIs by removing internal-only fields."""
-    attachment_cache, skip_summary_indices, _, allowed_attachment_keys = scan_message_metadata(messages)
+    attachment_cache, skip_summary_indices, _, allowed_attachment_keys = scan_message_metadata(
+        messages, max_image_embeds_override=max_image_embeds,
+    )
 
     prepared: List[Any] = []
     seen_non_system = False

--- a/manager/initialization.py
+++ b/manager/initialization.py
@@ -182,6 +182,7 @@ class InitializationMixin:
         self.max_history_messages_override: Optional[int] = None
         self.metabolism_enabled: bool = True
         self.metabolism_keep_messages_override: Optional[int] = None
+        self.max_image_embeds_override: Optional[int] = None
         self.startup_warnings: List[Dict[str, str]] = []
 
     def _update_timezone_cache(self, tz_name: Optional[str]) -> None:

--- a/saiverse/logging_config.py
+++ b/saiverse/logging_config.py
@@ -158,7 +158,8 @@ def configure_logging(level_name: Optional[str] = None) -> Path:
     _configure_error_logger()
 
     # Suppress overly verbose HTTP library debug logging (base64 request bodies)
-    for noisy_logger in ("httpcore", "httpx", "anthropic._base_client"):
+    # Also suppress PIL.TiffImagePlugin which dumps EXIF tag details at DEBUG
+    for noisy_logger in ("httpcore", "httpx", "openai._base_client", "anthropic._base_client", "PIL.TiffImagePlugin"):
         logging.getLogger(noisy_logger).setLevel(max(level, logging.INFO))
 
     _initialized = True

--- a/saiverse/model_configs.py
+++ b/saiverse/model_configs.py
@@ -121,6 +121,18 @@ def get_metabolism_keep_messages(model: str) -> int | None:
     return None
 
 
+def get_max_image_embeds(model: str) -> int | None:
+    """Get the maximum number of image embeds for a model.
+
+    Returns None if not configured (no limit on image embeds).
+    """
+    config = MODEL_CONFIGS.get(model, {})
+    val = config.get("max_image_embeds")
+    if val is not None:
+        return int(val)
+    return None
+
+
 def get_model_display_name(model: str) -> str:
     """Get display name for a model, falling back to model ID if not set."""
     config = MODEL_CONFIGS.get(model, {})


### PR DESCRIPTION
## Summary
- OpenRouter経由でAlibaba（Qwen）プロバイダーに大量の画像を送信すると「base64 decode fail」エラーが発生する問題を修正
- モデルコンフィグに `max_image_bytes`（個別画像のリサイズ上限）と `max_image_embeds`（埋め込み画像数の上限）を追加
- チャットオプションの「データ送信量の管理」セクションで `max_image_embeds` を動的に変更可能に
- `openai._base_client` と `PIL.TiffImagePlugin` のDEBUGログ抑制（base64ペイロードとEXIFタグがbackend.logに出力される問題）

## Test plan
- [x] OpenRouterのQwenモデルで画像付きメッセージを送信し、base64 decode failが発生しないことを確認
- [x] チャットオプション > データ送信量の管理 > 画像埋め込み上限の表示・変更が正常に動作することを確認
- [ ] モデル切替時にoverrideがリセットされ、モデルデフォルト値に戻ることを確認
- [ ] 画像なしモデルでも設定UIがエラーなく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)