### PR TITLE
Fix playbook TOOL node results missing from speak context

### DIFF
--- a/sea/pulse_context.py
+++ b/sea/pulse_context.py
@@ -88,11 +88,21 @@ class PulseContext:
         msgs: List[Dict[str, Any]] = []
         for entry in self.logs:
             if entry.role == "tool" and entry.tool_call_id:
+                # LLM function-calling tool result (has matching assistant tool_calls)
                 msg: Dict[str, Any] = {
                     "role": "tool",
                     "tool_call_id": entry.tool_call_id,
                     "name": entry.tool_name or "",
                     "content": entry.content,
+                }
+            elif entry.role == "tool" and not entry.tool_call_id:
+                # Playbook-defined TOOL node result (no function-calling pair).
+                # Emit as user message so LLM APIs accept it (tool role requires
+                # tool_call_id).  Wrap in <system> tag for context.
+                tool_label = entry.tool_name or "tool"
+                msg = {
+                    "role": "user",
+                    "content": f"<system>[{tool_label}] {entry.content}</system>",
                 }
             elif entry.role == "assistant" and entry.tool_calls:
                 msg = {


### PR DESCRIPTION
## Summary
- Playbook-defined TOOL nodes (e.g., send_email) logged results with `role="tool"` but no `tool_call_id`
- `get_protocol_messages()` only included tool entries with `tool_call_id`, silently dropping these results
- The speak node then saw an assistant message as the last entry and returned empty responses
- Now emits `tool_call_id`-less tool entries as user role messages wrapped in `<system>` tags

## Test plan
- [x] Execute send_email playbook and verify speak node generates a non-empty response after tool execution
- [x] Verify function-calling tool results (with tool_call_id) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)