### PR TITLE
Add GPT-5.4 mini and GPT-5.4 nano model configs

### DIFF
--- a/api/routes/tutorial.py
+++ b/api/routes/tutorial.py
@@ -346,11 +346,11 @@ PROVIDER_PRESETS: Dict[str, Dict[str, Optional[str]]] = {
     },
     "openai": {
         "default_model": "gpt-4o-2024-11-20",
-        "lightweight_model": "gpt-5-nano",
-        "agentic_model": "gpt-5-mini",
-        "memory_weave_model": "gpt-5-mini",
-        "image_summary_model": "gpt-5-nano",
-        "task_creation_model": "gpt-5-mini",
+        "lightweight_model": "gpt-5.4-nano",
+        "agentic_model": "gpt-5.4-mini",
+        "memory_weave_model": "gpt-5.4-mini",
+        "image_summary_model": "gpt-5.4-nano",
+        "task_creation_model": "gpt-5.4-mini",
     },
     "grok": {
         "default_model": "grok-4-1-fast-reasoning",

--- a/builtin_data/models/gpt-5.4-mini.json
+++ b/builtin_data/models/gpt-5.4-mini.json
@@ -1,0 +1,53 @@
+{
+  "model": "gpt-5.4-mini",
+  "system_prompt": "現在の使用モデルはGPT-5.4 miniです。\n\n[Model info]\n- Aug 31, 2025 knowledge cutoff",
+  "display_name": "GPT-5.4 mini",
+  "provider": "openai",
+  "context_length": 400000,
+  "default_max_history_messages": 60,
+  "metabolism_keep_messages": 20,
+  "supports_images": true,
+  "parameters": {
+    "reasoning_effort": {
+      "type": "enum",
+      "options": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "label": "Reasoning Effort",
+      "description": "Controls how much thinking time the model spends."
+    },
+    "verbosity": {
+      "type": "enum",
+      "options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "high",
+      "label": "Verbosity",
+      "description": "Controls how long or detailed responses should be.",
+      "client_support": [
+        "responses"
+      ]
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8192,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on how many tokens the reply can use."
+    }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 0.75,
+    "cached_input_per_1m_tokens": 0.075,
+    "output_per_1m_tokens": 4.5,
+    "currency": "USD"
+  }
+}

--- a/builtin_data/models/gpt-5.4-nano.json
+++ b/builtin_data/models/gpt-5.4-nano.json
@@ -1,0 +1,53 @@
+{
+  "model": "gpt-5.4-nano",
+  "system_prompt": "現在の使用モデルはGPT-5.4 nanoです。\n\n[Model info]\n- Aug 31, 2025 knowledge cutoff",
+  "display_name": "GPT-5.4 nano",
+  "provider": "openai",
+  "context_length": 400000,
+  "default_max_history_messages": 60,
+  "metabolism_keep_messages": 20,
+  "supports_images": true,
+  "parameters": {
+    "reasoning_effort": {
+      "type": "enum",
+      "options": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "label": "Reasoning Effort",
+      "description": "Controls how much thinking time the model spends."
+    },
+    "verbosity": {
+      "type": "enum",
+      "options": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "high",
+      "label": "Verbosity",
+      "description": "Controls how long or detailed responses should be.",
+      "client_support": [
+        "responses"
+      ]
+    },
+    "max_completion_tokens": {
+      "type": "int",
+      "min": 32,
+      "max": 8192,
+      "step": 1,
+      "default": 4096,
+      "label": "Max completion tokens",
+      "description": "Upper bound on how many tokens the reply can use."
+    }
+  },
+  "pricing": {
+    "input_per_1m_tokens": 0.2,
+    "cached_input_per_1m_tokens": 0.02,
+    "output_per_1m_tokens": 1.25,
+    "currency": "USD"
+  }
+}


### PR DESCRIPTION
## Summary
- GPT-5.4 mini と GPT-5.4 nano のモデル設定ファイルを追加
- 両モデルとも 400K コンテキスト、128K max output、2025年8月 knowledge cutoff
- 公式ドキュメントから料金情報を反映済み

## 参考
- https://developers.openai.com/api/docs/models/gpt-5.4-mini
- https://developers.openai.com/api/docs/models/gpt-5.4-nano

## Test plan
- [ ] アプリ起動後、モデル選択ドロップダウンに GPT-5.4 mini / nano が表示されること
- [ ] 各モデルでチャットが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)