### PR TITLE
Fix auto-git-init: set branch name and upstream

### DIFF
--- a/scripts/self_update.py
+++ b/scripts/self_update.py
@@ -474,7 +474,9 @@ def main():
                     (["git", "remote", "add", "origin",
                       "https://github.com/maha0525/SAIVerse.git"], "git remote add"),
                     (["git", "fetch", "origin"], "git fetch"),
+                    (["git", "branch", "-M", "main"], "git branch -M main"),
                     (["git", "reset", "origin/main"], "git reset"),
+                    (["git", "branch", "--set-upstream-to=origin/main"], "git branch --set-upstream-to"),
                 ]:
                     r = subprocess.run(cmd, cwd=project_dir, capture_output=True,
                                        text=True, timeout=120)

--- a/setup.bat
+++ b/setup.bat
@@ -214,7 +214,9 @@ if %errorlevel% equ 0 (
         git init
         git remote add origin https://github.com/maha0525/SAIVerse.git
         git fetch origin
+        git branch -M main
         git reset origin/main
+        git branch --set-upstream-to=origin/main
         echo [OK] Git repository initialized
     ) else (
         echo [OK] Git repository already exists

--- a/setup.sh
+++ b/setup.sh
@@ -96,7 +96,9 @@ if command -v git &>/dev/null; then
         git init
         git remote add origin https://github.com/maha0525/SAIVerse.git
         git fetch origin
+        git branch -M main
         git reset origin/main
+        git branch --set-upstream-to=origin/main
         echo "[OK] Git リポジトリを初期化しました"
     else
         echo "[OK] Git リポジトリは既に存在します"

--- a/update.bat
+++ b/update.bat
@@ -23,7 +23,9 @@ if %errorlevel% equ 0 (
         git init
         git remote add origin https://github.com/maha0525/SAIVerse.git
         git fetch origin
+        git branch -M main
         git reset origin/main
+        git branch --set-upstream-to=origin/main
         echo [OK] Git repository initialized
     )
     if exist ".git" (

--- a/update.sh
+++ b/update.sh
@@ -22,7 +22,9 @@ if command -v git &>/dev/null && [ ! -d ".git" ]; then
     git init
     git remote add origin https://github.com/maha0525/SAIVerse.git
     git fetch origin
+    git branch -M main
     git reset origin/main
+    git branch --set-upstream-to=origin/main
     echo "[OK] Git リポジトリを初期化しました"
 fi
 if command -v git &>/dev/null && [ -d ".git" ]; then


### PR DESCRIPTION
## Summary
- #210 の補足修正
- `git init` のデフォルトブランチ名が `master` になる環境で `git pull` が失敗する問題を修正
- `git branch -M main` でブランチ名を統一し、`git branch --set-upstream-to=origin/main` で追跡ブランチを設定

## Test plan
- [x] `init.defaultBranch` 未設定の環境で setup/update を実行し、`git branch -vv` で `main -> origin/main` が設定されていることを確認
- [x] その後 `git pull` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)