### PR TITLE
Fix broken import for Chronicle Lv.1 regeneration

### DIFF
--- a/sai_memory/arasuji/storage.py
+++ b/sai_memory/arasuji/storage.py
@@ -584,7 +584,7 @@ def regenerate_entry(
     messages.sort(key=lambda m: m.created_at)
     
     # 5. Call scripts layer for business logic
-    from scripts.build_arasuji import regenerate_entry_from_messages
+    from scripts.arasuji.build_arasuji_core import regenerate_entry_from_messages
     new_entry = regenerate_entry_from_messages(conn, messages, model_name, persona_id=persona_id)
     
     if not new_entry:


### PR DESCRIPTION
## Summary
- Chronicle Lv.1の再生成ボタンが `cannot import name 'regenerate_entry_from_messages' from 'scripts.build_arasuji'` で失敗する不具合を修正
- リファクタリングで `scripts/build_arasuji.py` が薄いCLIエントリポイントになった際、`sai_memory/arasuji/storage.py` のインポートパスが追従していなかった
- インポート先を `scripts.arasuji.build_arasuji_core` に修正

## Test plan
- [ ] Chronicle Lv.1の再生成ボタンを実行し、エラーなく再生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)