### PR TITLE
fix: context_profile使用時のパルスメッセージ重複を修正

### DIFF
--- a/builtin_data/tools/send_email_to_user.py
+++ b/builtin_data/tools/send_email_to_user.py
@@ -114,7 +114,7 @@ def send_email_to_user(user_id: int, subject: str, body: str) -> str:
     message.set_content(body)
 
     try:
-        with smtplib.SMTP(cfg["host"], cfg["port"], timeout=10) as server:
+        with smtplib.SMTP(cfg["host"], cfg["port"], timeout=30) as server:
             if cfg["use_tls"]:
                 context = ssl.create_default_context()
                 server.starttls(context=context)

--- a/persona/history_manager.py
+++ b/persona/history_manager.py
@@ -236,6 +236,7 @@ class HistoryManager:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         """Retrieves recent messages from persona history up to a character limit."""
         if self.memory_adapter is not None:
@@ -251,6 +252,7 @@ class HistoryManager:
                     max_chars,
                     required_tags=required_tags,
                     pulse_id=pulse_id,
+                    exclude_pulse_id=exclude_pulse_id,
                 )
                 LOGGER.debug(
                     "SAIMemory returned %d persona messages for %s",
@@ -278,6 +280,7 @@ class HistoryManager:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         """Retrieves recent messages from persona history up to a message count limit."""
         if self.memory_adapter is not None:
@@ -293,6 +296,7 @@ class HistoryManager:
                     max_messages,
                     required_tags=required_tags,
                     pulse_id=pulse_id,
+                    exclude_pulse_id=exclude_pulse_id,
                 )
                 LOGGER.debug(
                     "SAIMemory returned %d persona messages for %s",
@@ -315,6 +319,7 @@ class HistoryManager:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         """Retrieves messages from anchor onwards (for metabolism anchor-based retrieval)."""
         if self.memory_adapter is not None:
@@ -330,6 +335,7 @@ class HistoryManager:
                     anchor_message_id,
                     required_tags=required_tags,
                     pulse_id=pulse_id,
+                    exclude_pulse_id=exclude_pulse_id,
                 )
                 LOGGER.debug(
                     "SAIMemory returned %d messages from anchor for %s",
@@ -357,6 +363,7 @@ class HistoryManager:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         """Retrieves recent messages balanced across conversation partners.
 
@@ -365,6 +372,7 @@ class HistoryManager:
             participant_ids: List of partner IDs to balance (e.g., ["user", "persona_b"])
             required_tags: Only include messages with these tags
             pulse_id: Always include messages with this pulse ID
+            exclude_pulse_id: Exclude messages with this pulse ID
 
         Returns:
             List of messages balanced across participants
@@ -381,6 +389,7 @@ class HistoryManager:
                 participant_ids,
                 required_tags=required_tags,
                 pulse_id=pulse_id,
+                exclude_pulse_id=exclude_pulse_id,
             )
             LOGGER.debug(
                 "SAIMemory returned %d balanced messages for %s",
@@ -394,6 +403,7 @@ class HistoryManager:
             max_chars,
             required_tags=required_tags,
             pulse_id=pulse_id,
+            exclude_pulse_id=exclude_pulse_id,
         )
 
     def get_last_user_message(self) -> Optional[str]:

--- a/saiverse_memory/adapter.py
+++ b/saiverse_memory/adapter.py
@@ -291,6 +291,7 @@ class SAIMemoryAdapter:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[dict]:
         if not self._ready:
             return []
@@ -307,6 +308,7 @@ class SAIMemoryAdapter:
         consumed = 0
         required_tags = required_tags or []
         pulse_tag = f"pulse:{pulse_id}" if pulse_id else None
+        exclude_tag = f"pulse:{exclude_pulse_id}" if exclude_pulse_id else None
 
         for payload in reversed(payloads):
             tags = []
@@ -315,6 +317,10 @@ class SAIMemoryAdapter:
                 raw_tags = metadata.get("tags")
                 if isinstance(raw_tags, list):
                     tags = [str(tag) for tag in raw_tags if tag]
+
+            # Exclude messages belonging to the specified pulse
+            if exclude_tag and exclude_tag in tags:
+                continue
 
             include = True
             if required_tags:
@@ -339,6 +345,7 @@ class SAIMemoryAdapter:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[dict]:
         """Get recent persona messages limited by message count instead of characters."""
         if not self._ready:
@@ -355,6 +362,7 @@ class SAIMemoryAdapter:
         selected: List[dict] = []
         required_tags = required_tags or []
         pulse_tag = f"pulse:{pulse_id}" if pulse_id else None
+        exclude_tag = f"pulse:{exclude_pulse_id}" if exclude_pulse_id else None
 
         for payload in reversed(payloads):
             tags = []
@@ -363,6 +371,10 @@ class SAIMemoryAdapter:
                 raw_tags = metadata.get("tags")
                 if isinstance(raw_tags, list):
                     tags = [str(tag) for tag in raw_tags if tag]
+
+            # Exclude messages belonging to the specified pulse
+            if exclude_tag and exclude_tag in tags:
+                continue
 
             include = True
             if required_tags:
@@ -384,6 +396,7 @@ class SAIMemoryAdapter:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[dict]:
         """Get persona messages from anchor message onwards.
 
@@ -407,6 +420,7 @@ class SAIMemoryAdapter:
         selected: List[dict] = []
         required_tags = required_tags or []
         pulse_tag = f"pulse:{pulse_id}" if pulse_id else None
+        exclude_tag = f"pulse:{exclude_pulse_id}" if exclude_pulse_id else None
 
         for payload in payloads:  # already in chronological order
             tags = []
@@ -415,6 +429,10 @@ class SAIMemoryAdapter:
                 raw_tags = metadata.get("tags")
                 if isinstance(raw_tags, list):
                     tags = [str(tag) for tag in raw_tags if tag]
+
+            # Exclude messages belonging to the specified pulse
+            if exclude_tag and exclude_tag in tags:
+                continue
 
             include = True
             if required_tags:
@@ -436,6 +454,7 @@ class SAIMemoryAdapter:
         *,
         required_tags: Optional[List[str]] = None,
         pulse_id: Optional[str] = None,
+        exclude_pulse_id: Optional[str] = None,
     ) -> List[dict]:
         """Get recent messages balanced across conversation partners.
 
@@ -447,6 +466,7 @@ class SAIMemoryAdapter:
             participant_ids: List of partner IDs to balance (e.g., ["user", "persona_b"])
             required_tags: Only include messages with these tags
             pulse_id: Always include messages with this pulse ID
+            exclude_pulse_id: Exclude messages with this pulse ID (for mid-pulse context_profile reads)
 
         Returns:
             List of messages, sorted by timestamp, balanced across participants
@@ -465,6 +485,7 @@ class SAIMemoryAdapter:
 
         required_tags = required_tags or []
         pulse_tag = f"pulse:{pulse_id}" if pulse_id else None
+        exclude_tag = f"pulse:{exclude_pulse_id}" if exclude_pulse_id else None
 
         # Group messages by participant
         # Key: participant_id, Value: list of (index, payload) tuples
@@ -475,6 +496,10 @@ class SAIMemoryAdapter:
             metadata = payload.get("metadata") or {}
             tags = metadata.get("tags", [])
             with_list = metadata.get("with", [])
+
+            # Exclude messages belonging to the specified pulse
+            if exclude_tag and exclude_tag in tags:
+                continue
 
             # Check if message matches required tags
             include = True

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -1682,7 +1682,7 @@ class SEARuntime:
 
     # ---------------- context preparation -----------------
 
-    def _prepare_context(self, persona: Any, building_id: str, user_input: Optional[str], requirements: Optional[Any] = None, pulse_id: Optional[str] = None, warnings: Optional[List[Dict[str, Any]]] = None, preview_only: bool = False, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None, cancellation_token: Optional[Any] = None) -> List[Dict[str, Any]]:
+    def _prepare_context(self, persona: Any, building_id: str, user_input: Optional[str], requirements: Optional[Any] = None, pulse_id: Optional[str] = None, exclude_pulse_id: Optional[str] = None, warnings: Optional[List[Dict[str, Any]]] = None, preview_only: bool = False, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None, cancellation_token: Optional[Any] = None) -> List[Dict[str, Any]]:
         return prepare_context_impl(
             self,
             persona,
@@ -1690,6 +1690,7 @@ class SEARuntime:
             user_input,
             requirements=requirements,
             pulse_id=pulse_id,
+            exclude_pulse_id=exclude_pulse_id,
             warnings=warnings,
             preview_only=preview_only,
             event_callback=event_callback,

--- a/sea/runtime_context.py
+++ b/sea/runtime_context.py
@@ -14,7 +14,7 @@ from saiverse.model_configs import (
 
 LOGGER = logging.getLogger(__name__)
 
-def prepare_context(runtime, persona: Any, building_id: str, user_input: Optional[str], requirements: Optional[Any] = None, pulse_id: Optional[str] = None, warnings: Optional[List[Dict[str, Any]]] = None, preview_only: bool = False, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None, cancellation_token: Optional[Any] = None) -> List[Dict[str, Any]]:
+def prepare_context(runtime, persona: Any, building_id: str, user_input: Optional[str], requirements: Optional[Any] = None, pulse_id: Optional[str] = None, exclude_pulse_id: Optional[str] = None, warnings: Optional[List[Dict[str, Any]]] = None, preview_only: bool = False, event_callback: Optional[Callable[[Dict[str, Any]], None]] = None, cancellation_token: Optional[Any] = None) -> List[Dict[str, Any]]:
     from sea.playbook_models import ContextRequirements
 
     # Use provided requirements or default to full context
@@ -228,6 +228,7 @@ def prepare_context(runtime, persona: Any, building_id: str, user_input: Optiona
                             # Case 1 or 2: valid anchor found
                             recent_from_anchor = history_mgr.get_history_from_anchor(
                                 anchor_id, required_tags=required_tags, pulse_id=pulse_id,
+                                exclude_pulse_id=exclude_pulse_id,
                             )
                             if recent_from_anchor:
                                 recent = recent_from_anchor
@@ -282,6 +283,7 @@ def prepare_context(runtime, persona: Any, building_id: str, user_input: Optiona
                         if anchor_id:
                             recent_from_anchor = history_mgr.get_history_from_anchor(
                                 anchor_id, required_tags=required_tags, pulse_id=pulse_id,
+                                exclude_pulse_id=exclude_pulse_id,
                             )
                             if recent_from_anchor:
                                 recent = recent_from_anchor
@@ -331,6 +333,7 @@ def prepare_context(runtime, persona: Any, building_id: str, user_input: Optiona
                             limit_value,
                             required_tags=required_tags,
                             pulse_id=pulse_id,
+                            exclude_pulse_id=exclude_pulse_id,
                         )
                     elif reqs.history_balanced:
                         # Get conversation partners for balanced retrieval
@@ -346,6 +349,7 @@ def prepare_context(runtime, persona: Any, building_id: str, user_input: Optiona
                             participant_ids,
                             required_tags=required_tags,
                             pulse_id=pulse_id,
+                            exclude_pulse_id=exclude_pulse_id,
                         )
                     else:
                         # Filter by required tags or current pulse_id
@@ -353,6 +357,7 @@ def prepare_context(runtime, persona: Any, building_id: str, user_input: Optiona
                             limit_value,
                             required_tags=required_tags,
                             pulse_id=pulse_id,
+                            exclude_pulse_id=exclude_pulse_id,
                         )
 
                     # Set metabolism anchor on first count-based retrieval and persist (skip in preview)

--- a/sea/runtime_llm.py
+++ b/sea/runtime_llm.py
@@ -64,15 +64,18 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                 if _profile:
                     _cache_key = f"_ctx_profile_{_profile_name}"
                     if _cache_key not in state:
+                        # Exclude current pulse messages from SAIMemory — PulseContext
+                        # provides them instead, avoiding duplication of memorized messages.
                         state[_cache_key] = runtime._prepare_context(
                             persona, building_id,
                             state.get("input") or None,
                             _profile["requirements"],
                             pulse_id=state.get("_pulse_id"),
+                            exclude_pulse_id=state.get("_pulse_id"),
                             event_callback=event_callback,
                         )
-                        LOGGER.info("[sea] Prepared context for profile '%s' (node=%s, %d messages)",
-                                    _profile_name, node_id, len(state[_cache_key]))
+                        LOGGER.info("[sea] Prepared context for profile '%s' (node=%s, %d messages, exclude_pulse=%s)",
+                                    _profile_name, node_id, len(state[_cache_key]), state.get("_pulse_id"))
                     _profile_base = state[_cache_key]
                     _pulse_ctx = state.get("_pulse_context")
                     _intermediate = _pulse_ctx.get_protocol_messages() if _pulse_ctx else []


### PR DESCRIPTION
## Summary
- context_profile付きLLMノードがパルス途中でSAIMemoryから現在パルスのメッセージを再取得し、PulseContextと重複してLLMコンテキストに載る問題を修正
- `_prepare_context`に`exclude_pulse_id`パラメータを追加。context_profile使用時はSAIMemoryから現在パルスのメッセージを除外し、PulseContextに一元化
- SMTP送信のタイムアウトを10秒→30秒に延長（Gmail深夜帯の一時的な応答遅延対策）

## Background
ツールplaybook（例: send_email_to_user）の実行後にsub_speakが走る際、memorizeで保存済みのメッセージがSAIMemoryとPulseContextの両方から取得されて結合されていた。LLMはコンテキスト上のメッセージを見て「2回実行された」と誤認していた。

## Test plan
- [x] スケジュール実行でメール送信後、LLMが「1回だけ送信した」と正しく認識することを確認
- [x] llm_io.logでメッセージの重複がないことを確認
- [x] 通常のユーザー会話（context_profile="conversation"）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)