### PR TITLE
fix: .env ファイルのパーミッションを 600 に制限 (#228)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -109,6 +109,10 @@ def write_env_updates(updates: Dict[str, str]) -> None:
         if new_lines:
             f.write("\n")
 
+    # Ensure .env is only readable by owner (Linux/macOS)
+    if os.name != "nt":
+        os.chmod(ENV_FILE_PATH, 0o600)
+
     # Also update os.environ so changes take effect immediately
     for key, val in updates.items():
         os.environ[key] = val

--- a/setup.sh
+++ b/setup.sh
@@ -110,9 +110,12 @@ if [ ! -f ".env" ]; then
     echo ""
     echo "[SETUP] .env ファイルを作成中..."
     cp .env.example .env
-    echo "[OK] .env を作成しました"
+    chmod 600 .env
+    echo "[OK] .env を作成しました (権限: 600)"
     echo "  APIキーの設定は初回起動時のチュートリアルで行えます。"
 else
+    # 既存の .env も安全な権限に修正
+    chmod 600 .env
     echo "[OK] .env は既に存在します"
 fi
 


### PR DESCRIPTION
## Summary
- Linux環境で `.env` が `664` で作成され、APIキーが他ユーザーから読める問題を修正
- `setup.sh`: 新規作成時・既存ファイルに `chmod 600` を適用
- `api/routes/admin.py`: `write_env_updates()` での書き込み後にも `chmod 600` を適用（Linux/macOSのみ）

Closes #228

## Test plan
- [ ] Linux環境で `setup.sh` を実行し、`.env` のパーミッションが `600` になることを確認
- [ ] 既存の `.env` がある状態で `setup.sh` を再実行し、権限が `600` に修正されることを確認
- [ ] チュートリアルでAPIキーを設定後、`.env` のパーミッションが `600` のままであることを確認
- [ ] Windows環境で `chmod` がスキップされエラーにならないことを確認

https://claude.ai/code/session_0188EeT9fDQ612X7oVvKa3hi