### PR TITLE
fix: playbook間テンプレート引数の型保持

### DIFF
--- a/sea/runtime_engine.py
+++ b/sea/runtime_engine.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from saiverse.logging_config import log_sea_trace
 from sea.playbook_models import PlaybookSchema
-from sea.runtime_utils import _format
+from sea.runtime_utils import _format, _resolve_template_arg
 
 LOGGER = logging.getLogger(__name__)
 
@@ -211,7 +211,7 @@ class RuntimeEngine:
                 state_vars = {k: v for k, v in state.items() if not k.startswith("_")}
                 for key, tmpl in static_args.items():
                     if isinstance(tmpl, str):
-                        child_args[key] = _format(tmpl, state_vars)
+                        child_args[key] = _resolve_template_arg(tmpl, state_vars)
                     else:
                         child_args[key] = tmpl
             # 2. Merge dynamic args from args_source (takes precedence)

--- a/sea/runtime_nodes.py
+++ b/sea/runtime_nodes.py
@@ -138,7 +138,7 @@ def lg_subplay_node(runtime: Any, node_def: Any, persona: Any, building_id: str,
         if not sub_pb:
             state["last"] = f"Sub-playbook {sub_name} not found"
             return state
-        from .runtime_utils import _format as runtime_format
+        from .runtime_utils import _resolve_template_arg
 
         # Build child args from node_def.args, resolving template strings against current state
         node_args = getattr(node_def, "args", None)
@@ -147,7 +147,7 @@ def lg_subplay_node(runtime: Any, node_def: Any, persona: Any, building_id: str,
             child_args = {}
             for key, tmpl in node_args.items():
                 if isinstance(tmpl, str):
-                    child_args[key] = runtime_format(tmpl, state_vars)
+                    child_args[key] = _resolve_template_arg(tmpl, state_vars)
                 else:
                     child_args[key] = tmpl
             sub_input = child_args.get("input") or child_args.get("query") or ""

--- a/sea/runtime_utils.py
+++ b/sea/runtime_utils.py
@@ -27,3 +27,23 @@ def _format(template: str, variables: Dict[str, Any]) -> str:
         return match.group(0)
 
     return re.sub(r"\{([\w.]+)\}", replacer, template)
+
+
+def _resolve_template_arg(template: str, variables: Dict[str, Any]) -> Any:
+    """Resolve a template arg, preserving non-string types for pure variable references.
+
+    If the template is exactly ``{key}`` (a single variable reference with no
+    surrounding text) and the corresponding value is a dict or list, return
+    the original value instead of stringifying it.  This allows structured
+    data (e.g. metadata dicts) to flow through playbook args without being
+    converted to their ``str()`` representation.
+
+    For any other template pattern (e.g. ``"prefix {key} suffix"``), fall
+    back to the regular ``_format`` string interpolation.
+    """
+    m = re.fullmatch(r"\{([\w.]+)\}", template)
+    if m:
+        key = m.group(1)
+        if key in variables:
+            return variables[key]
+    return _format(template, variables)

--- a/tests/sea/test_resolve_template_arg.py
+++ b/tests/sea/test_resolve_template_arg.py
@@ -1,0 +1,72 @@
+"""Tests for _resolve_template_arg in sea/runtime_utils.py."""
+
+import unittest
+from sea.runtime_utils import _resolve_template_arg
+
+
+class TestResolveTemplateArg(unittest.TestCase):
+    """Verify that pure variable references preserve original types."""
+
+    def test_dict_value_preserved(self):
+        """A pure {key} reference to a dict should return the dict, not str(dict)."""
+        metadata = {"media": [{"type": "image", "uri": "saiverse://image/test.jpg"}]}
+        variables = {"metadata": metadata, "input": "hello"}
+        result = _resolve_template_arg("{metadata}", variables)
+        self.assertIs(result, metadata)
+        self.assertIsInstance(result, dict)
+
+    def test_list_value_preserved(self):
+        """A pure {key} reference to a list should return the list."""
+        items = [1, 2, 3]
+        variables = {"items": items}
+        result = _resolve_template_arg("{items}", variables)
+        self.assertIs(result, items)
+
+    def test_string_value_returned_as_is(self):
+        """A pure {key} reference to a string returns the string."""
+        variables = {"name": "hello"}
+        result = _resolve_template_arg("{name}", variables)
+        self.assertEqual(result, "hello")
+
+    def test_none_value_preserved(self):
+        """A pure {key} reference to None returns None."""
+        variables = {"empty": None}
+        result = _resolve_template_arg("{empty}", variables)
+        self.assertIsNone(result)
+
+    def test_mixed_template_uses_format(self):
+        """Templates with surrounding text should stringify values normally."""
+        metadata = {"key": "value"}
+        variables = {"metadata": metadata, "name": "test"}
+        result = _resolve_template_arg("prefix {name} suffix", variables)
+        self.assertEqual(result, "prefix test suffix")
+        self.assertIsInstance(result, str)
+
+    def test_missing_key_returns_original_template(self):
+        """A reference to a missing key should return the template unchanged."""
+        variables = {"other": "value"}
+        result = _resolve_template_arg("{missing}", variables)
+        self.assertEqual(result, "{missing}")
+
+    def test_empty_string_value(self):
+        """A pure {key} reference to an empty string returns empty string."""
+        variables = {"text": ""}
+        result = _resolve_template_arg("{text}", variables)
+        self.assertEqual(result, "")
+
+    def test_int_value_preserved(self):
+        """A pure {key} reference to an int returns the int."""
+        variables = {"count": 42}
+        result = _resolve_template_arg("{count}", variables)
+        self.assertEqual(result, 42)
+        self.assertIsInstance(result, int)
+
+    def test_dot_notation_key(self):
+        """Dot-notation keys like {result.summary} should also work."""
+        variables = {"result.summary": "some summary"}
+        result = _resolve_template_arg("{result.summary}", variables)
+        self.assertEqual(result, "some summary")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `_format()` が全ての値を `str()` で文字列化していたため、playbook間で構造化データ（metadata dict等）を `{key}` テンプレートで渡す際に文字列に変換されていた
- 画像生成playbook → sub_speak の metadata 受け渡しで、`{"media": [...]}` が `"{'media': [...]}"` という文字列になり、`isinstance(metadata, dict)` チェックが失敗 → building history に画像情報が含まれず、チャットUIに画像が表示されなかった
- `_resolve_template_arg()` を新設。テンプレートが純粋な変数参照 `{key}` のみの場合、元の型（dict, list等）を保持して返す。混合テンプレート（`"prefix {key} suffix"`）は従来通り文字列化

## Changed files
- `sea/runtime_utils.py` — `_resolve_template_arg()` 追加
- `sea/runtime_engine.py` — exec node の args 解決で使用
- `sea/runtime_nodes.py` — subplay node の args 解決で使用
- `tests/sea/test_resolve_template_arg.py` — ユニットテスト（9ケース）

## Test plan
- [x] `_resolve_template_arg` ユニットテスト 9件パス
- [x] 既存テスト 309件パス（無関係の1件除く）
- [x] 画像生成playbook実行後、チャットUIに画像がインライン表示されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)