### PR TITLE
feat: Gemma 4モデル設定を追加

### DIFF
--- a/builtin_data/models/gemma-4-26b-a4b-it.json
+++ b/builtin_data/models/gemma-4-26b-a4b-it.json
@@ -1,0 +1,67 @@
+{
+  "model": "gemma-4-26b-a4b-it",
+  "system_prompt": "",
+  "display_name": "Gemma 4 26B A4B(無料枠)",
+  "provider": "gemini",
+  "context_length": 262144,
+  "default_max_history_messages": 60,
+  "metabolism_keep_messages": 40,
+  "supports_structured_output": true,
+  "supports_images": true,
+  "prefer_paid": false,
+  "parameters": {
+    "temperature": {
+      "type": "slider",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1.0,
+      "label": "Temperature",
+      "description": "出力のランダム性。0で決定的、高いほど多様。"
+    },
+    "safety_harassment": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_NONE",
+      "label": "Safety: Harassment"
+    },
+    "safety_hate_speech": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_ONLY_HIGH",
+      "label": "Safety: Hate Speech"
+    },
+    "safety_sexually_explicit": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_NONE",
+      "label": "Safety: Sexually Explicit"
+    },
+    "safety_dangerous_content": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_ONLY_HIGH",
+      "label": "Safety: Dangerous Content"
+    }
+  }
+}

--- a/builtin_data/models/gemma-4-31b-it.json
+++ b/builtin_data/models/gemma-4-31b-it.json
@@ -1,0 +1,67 @@
+{
+  "model": "gemma-4-31b-it",
+  "system_prompt": "",
+  "display_name": "Gemma 4 31B(無料枠)",
+  "provider": "gemini",
+  "context_length": 262144,
+  "default_max_history_messages": 60,
+  "metabolism_keep_messages": 40,
+  "supports_structured_output": true,
+  "supports_images": true,
+  "prefer_paid": false,
+  "parameters": {
+    "temperature": {
+      "type": "slider",
+      "min": 0,
+      "max": 2,
+      "step": 0.1,
+      "default": 1.0,
+      "label": "Temperature",
+      "description": "出力のランダム性。0で決定的、高いほど多様。"
+    },
+    "safety_harassment": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_NONE",
+      "label": "Safety: Harassment"
+    },
+    "safety_hate_speech": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_ONLY_HIGH",
+      "label": "Safety: Hate Speech"
+    },
+    "safety_sexually_explicit": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_NONE",
+      "label": "Safety: Sexually Explicit"
+    },
+    "safety_dangerous_content": {
+      "type": "dropdown",
+      "options": [
+        "BLOCK_NONE",
+        "BLOCK_ONLY_HIGH",
+        "BLOCK_MEDIUM_AND_ABOVE",
+        "BLOCK_LOW_AND_ABOVE"
+      ],
+      "default": "BLOCK_ONLY_HIGH",
+      "label": "Safety: Dangerous Content"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Google Gemma 4のGemini API版モデル設定を追加
- Gemma 4 26B A4B (MoE) と Gemma 4 31B Dense の2バリアント
- 両モデルとも無料枠で利用可能、256Kコンテキスト、画像入力対応

## Test plan
- [x] Gemma 4 31Bでペルソナとの会話を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)