### PR TITLE
feat: Chronicle診断レポートのダウンロード機能を追加

### DIFF
--- a/api/routes/people/arasuji.py
+++ b/api/routes/people/arasuji.py
@@ -288,6 +288,108 @@ def get_arasuji_stats(persona_id: str, manager = Depends(get_manager)):
     finally:
         conn.close()
 
+@router.get("/{persona_id}/arasuji/diagnosis")
+def get_chronicle_diagnosis(persona_id: str, manager=Depends(get_manager)):
+    """Get diagnostic information about Chronicle structure (no message content)."""
+    from sai_memory.arasuji.storage import (
+        get_entries_by_level,
+        count_entries_by_level,
+        count_unconsolidated_by_level,
+        get_max_level,
+        get_progress,
+    )
+    from sai_memory.memory.storage import count_messages
+
+    conn = _get_arasuji_db(persona_id)
+    if not conn:
+        raise HTTPException(status_code=404, detail=f"Memory database not found for {persona_id}")
+
+    try:
+        total_messages = count_messages(conn)
+        counts_by_level = count_entries_by_level(conn)
+        unconsolidated_by_level = count_unconsolidated_by_level(conn)
+        max_level = get_max_level(conn)
+        progress = get_progress(conn)
+
+        # Build per-level entry details (no content)
+        level_details: Dict[int, list] = {}
+        lv1_entries = []
+        for level in range(1, max_level + 1):
+            entries = get_entries_by_level(conn, level, order_by_time=True)
+            if level == 1:
+                lv1_entries = entries
+            level_details[level] = [
+                {
+                    "id": e.id,
+                    "start_time": e.start_time,
+                    "end_time": e.end_time,
+                    "source_count": e.source_count,
+                    "message_count": e.message_count,
+                    "is_consolidated": e.is_consolidated,
+                    "parent_id": e.parent_id,
+                }
+                for e in entries
+            ]
+
+        # Gap analysis: messages between consecutive Lv1 Chronicles
+        gaps = []
+        for i in range(len(lv1_entries) - 1):
+            e1 = lv1_entries[i]
+            e2 = lv1_entries[i + 1]
+            if e1.end_time is not None and e2.start_time is not None and e1.end_time < e2.start_time:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE created_at > ? AND created_at < ?",
+                    (e1.end_time, e2.start_time),
+                )
+                gap_count = cur.fetchone()[0]
+                if gap_count > 0:
+                    gaps.append({
+                        "prev_chronicle_id": e1.id,
+                        "next_chronicle_id": e2.id,
+                        "gap_start_time": e1.end_time,
+                        "gap_end_time": e2.start_time,
+                        "isolated_message_count": gap_count,
+                    })
+
+        # Messages after last Chronicle
+        messages_after_last = 0
+        last_end_time = None
+        if lv1_entries:
+            last_entry = lv1_entries[-1]
+            last_end_time = last_entry.end_time
+            if last_end_time is not None:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE created_at > ?",
+                    (last_end_time,),
+                )
+                messages_after_last = cur.fetchone()[0]
+        else:
+            messages_after_last = total_messages
+
+        messages_covered = sum(e.message_count for e in lv1_entries)
+
+        return {
+            "persona_id": persona_id,
+            "generated_at": int(time.time()),
+            "total_messages": total_messages,
+            "messages_covered_by_lv1": messages_covered,
+            "messages_after_last_chronicle": messages_after_last,
+            "max_level": max_level,
+            "counts_by_level": counts_by_level,
+            "unconsolidated_by_level": unconsolidated_by_level,
+            "last_chronicle_end_time": last_end_time,
+            "last_processed_message_id": progress.last_processed_message_id if progress else None,
+            "last_processed_at": progress.last_processed_at if progress else None,
+            "level_details": level_details,
+            "gaps": gaps,
+        }
+    except Exception as e:
+        LOGGER.error("Failed to get chronicle diagnosis for %s: %s", persona_id, e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get chronicle diagnosis: {e}")
+    finally:
+        conn.close()
+
+
 @router.get("/{persona_id}/arasuji", response_model=ArasujiListResponse, tags=["Chronicle"])
 def list_arasuji_entries(
     persona_id: str,

--- a/frontend/src/components/memory/MemoryRecall.tsx
+++ b/frontend/src/components/memory/MemoryRecall.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Search, Loader2, AlertCircle, Brain, Bug, Trash2 } from 'lucide-react';
+import { Search, Loader2, AlertCircle, Brain, Bug, Trash2, FileDown, Activity } from 'lucide-react';
 import styles from './MemoryRecall.module.css';
 
 interface MemoryRecallProps {
@@ -43,6 +43,115 @@ export default function MemoryRecall({ personaId }: MemoryRecallProps) {
     const [confirmChronicle, setConfirmChronicle] = useState(false);
     const [confirmMemopedia, setConfirmMemopedia] = useState(false);
     const [deleteResult, setDeleteResult] = useState<string | null>(null);
+
+    // Chronicle diagnosis state
+    const [isDiagnosing, setIsDiagnosing] = useState(false);
+    const [diagnosisError, setDiagnosisError] = useState<string | null>(null);
+
+    const formatDiagnosisReport = (data: any): string => {
+        const lines: string[] = [];
+        const formatTime = (ts: number | null): string => {
+            if (ts == null) return '(不明)';
+            return new Date(ts * 1000).toISOString().replace('T', ' ').replace('.000Z', '') + ' UTC';
+        };
+
+        lines.push('Chronicle 診断レポート');
+        lines.push('='.repeat(60));
+        lines.push(`生成日時: ${formatTime(data.generated_at)}`);
+        lines.push(`ペルソナ: ${data.persona_id}`);
+        lines.push('');
+
+        lines.push('== 全体サマリー ==');
+        lines.push(`総メッセージ数: ${data.total_messages}`);
+        lines.push(`Lv1 Chronicle がカバーするメッセージ数: ${data.messages_covered_by_lv1}`);
+        lines.push(`最後の Chronicle 以降の未処理メッセージ数: ${data.messages_after_last_chronicle}`);
+        lines.push(`Chronicle の最大レベル: ${data.max_level}`);
+        if (data.last_chronicle_end_time != null) {
+            lines.push(`最後の Chronicle 終端時刻: ${formatTime(data.last_chronicle_end_time)}`);
+        }
+        if (data.last_processed_at != null) {
+            lines.push(`最後の Chronicle 生成日時: ${formatTime(data.last_processed_at)}`);
+        }
+        if (data.last_processed_message_id) {
+            lines.push(`最後に処理したメッセージID: ${data.last_processed_message_id}`);
+        }
+        lines.push('');
+
+        lines.push('== レベル別統計 ==');
+        for (let level = 1; level <= data.max_level; level++) {
+            const total = data.counts_by_level[level] ?? 0;
+            const unconsolidated = data.unconsolidated_by_level[level] ?? 0;
+            const consolidated = total - unconsolidated;
+            lines.push(`  Level ${level}: 計 ${total} 件  (統合済み: ${consolidated}  未統合: ${unconsolidated})`);
+        }
+        lines.push('');
+
+        // Per-level entry details
+        for (let level = 1; level <= data.max_level; level++) {
+            const entries: any[] = data.level_details[level] ?? [];
+            lines.push(`== Level ${level} Chronicle エントリ詳細 (${entries.length} 件) ==`);
+            entries.forEach((entry: any, idx: number) => {
+                lines.push(`  [${idx + 1}] ID: ${entry.id}`);
+                lines.push(`       期間: ${formatTime(entry.start_time)}  〜  ${formatTime(entry.end_time)}`);
+                lines.push(`       含むメッセージ数: ${entry.message_count}  ソース数: ${entry.source_count}`);
+                const consolidatedStr = entry.is_consolidated
+                    ? `はい → 親ID: ${entry.parent_id ?? '(なし)'}`
+                    : 'いいえ';
+                lines.push(`       統合済み: ${consolidatedStr}`);
+            });
+            lines.push('');
+        }
+
+        // Gap analysis
+        lines.push('== ギャップ分析 (Chronicle 間の孤立メッセージ) ==');
+        if (data.gaps.length > 0) {
+            data.gaps.forEach((gap: any, idx: number) => {
+                lines.push(`  ギャップ ${idx + 1}:`);
+                lines.push(`    孤立メッセージ数: ${gap.isolated_message_count}`);
+                lines.push(`    期間: ${formatTime(gap.gap_start_time)}  〜  ${formatTime(gap.gap_end_time)}`);
+                lines.push(`    直前の Chronicle ID: ${gap.prev_chronicle_id}`);
+                lines.push(`    直後の Chronicle ID: ${gap.next_chronicle_id}`);
+            });
+        } else {
+            lines.push('  ギャップなし (Level 1 Chronicle 間に孤立メッセージは検出されませんでした)');
+        }
+
+        return lines.join('\n');
+    };
+
+    const handleDownloadDiagnosis = async () => {
+        setIsDiagnosing(true);
+        setDiagnosisError(null);
+        try {
+            const backendUrl = 'http://127.0.0.1:8000';
+            const res = await fetch(`${backendUrl}/api/people/${personaId}/arasuji/diagnosis`);
+            if (!res.ok) {
+                const text = await res.text();
+                try {
+                    const data = JSON.parse(text);
+                    throw new Error(data.detail || 'Chronicle診断の取得に失敗しました');
+                } catch {
+                    throw new Error(`Server error: ${text.substring(0, 200)}`);
+                }
+            }
+            const data = await res.json();
+            const report = formatDiagnosisReport(data);
+            const blob = new Blob([report], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+            a.download = `chronicle_diagnosis_${personaId}_${ts}.txt`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        } catch (err: any) {
+            setDiagnosisError(err.message || 'エラーが発生しました');
+        } finally {
+            setIsDiagnosing(false);
+        }
+    };
 
     const handleRecall = async () => {
         const trimmedQuery = query.trim();
@@ -423,6 +532,38 @@ export default function MemoryRecall({ personaId }: MemoryRecallProps) {
                             </tbody>
                         </table>
                     </div>
+                </div>
+            )}
+
+            {/* Chronicle Diagnosis Download */}
+            <div className={styles.header} style={{ marginTop: '2rem' }}>
+                <Activity size={24} className={styles.icon} />
+                <div>
+                    <h3 className={styles.title}>Chronicle 診断</h3>
+                    <p className={styles.description}>
+                        Chronicle の構造情報（レベル別統計・各エントリの期間・ギャップ分析）をテキストファイルでダウンロードします。
+                        チャットログや Chronicle の本文は含まれません。
+                    </p>
+                </div>
+            </div>
+
+            <button
+                className={styles.executeButton}
+                onClick={handleDownloadDiagnosis}
+                disabled={isDiagnosing}
+                style={{ background: '#495057' }}
+            >
+                {isDiagnosing ? (
+                    <><Loader2 size={16} className={styles.loader} /> 取得中...</>
+                ) : (
+                    <><FileDown size={16} /> 診断レポートをダウンロード</>
+                )}
+            </button>
+
+            {diagnosisError && (
+                <div className={styles.error}>
+                    <AlertCircle size={16} />
+                    <span>{diagnosisError}</span>
                 </div>
             )}
 


### PR DESCRIPTION
## Summary

- **API追加**: `GET /api/people/{persona_id}/arasuji/diagnosis`
  - Chronicleの構造情報をJSON形式で返す（本文・チャットログは含まない）
  - レベル別エントリ数（総数・未統合数）、各エントリの期間・message_count
  - Level 1 Chronicle 間の孤立メッセージ数（ギャップ分析）
  - 最後のChronicle以降の未処理メッセージ数、最終処理日時
- **UI追加**: デバッグタブに「Chronicle 診断」セクションを追加
  - 「診断レポートをダウンロード」ボタンでテキストファイル（.txt）をローカルに保存
  - ファイル名: `chronicle_diagnosis_{persona_id}_{timestamp}.txt`

## Background

Chronicle が生成されないという不具合報告への対応として、相手方の状況を把握するための診断ツール。プライバシーに配慮してメッセージ内容は一切含まない。

## Test plan

- [x] サーバー起動後、メモリモーダル → デバッグタブ → 「Chronicle 診断」セクションを確認
- [x] 「診断レポートをダウンロード」ボタンを押してファイルがダウンロードされることを確認
- [ ] Chronicle が存在しない場合に正常に動作することを確認（全体サマリーが 0 件）
- [x] Chronicle が複数レベル存在する場合にレベル別統計が正しく出力されることを確認
- [ ] `GET /api/people/{persona_id}/arasuji/diagnosis` に memory.db がない場合 404 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)