### PR TITLE
fix: Chronicle診断ツールを実態値ベースに改善

### DIFF
--- a/api/routes/people/arasuji.py
+++ b/api/routes/people/arasuji.py
@@ -311,27 +311,101 @@ def get_chronicle_diagnosis(persona_id: str, manager=Depends(get_manager)):
         max_level = get_max_level(conn)
         progress = get_progress(conn)
 
-        # Build per-level entry details (no content)
+        # --- Level-1 source_ids 実態調査 ---
+        # DB保存値（source_count/message_count）ではなく source_ids_json の実際の内容を集計
+
+        # 各エントリの実際の source_ids 長（json_array_length）をまとめて取得
+        cur = conn.execute(
+            "SELECT id, json_array_length(source_ids_json) FROM arasuji_entries WHERE level = 1"
+        )
+        lv1_actual_lengths: Dict[str, int] = {row[0]: (row[1] or 0) for row in cur.fetchall()}
+
+        if lv1_actual_lengths:
+            lengths = list(lv1_actual_lengths.values())
+            lv1_actual_total = sum(lengths)
+            lv1_actual_avg = lv1_actual_total / len(lengths)
+            lv1_actual_max = max(lengths)
+            lv1_actual_min = min(lengths)
+        else:
+            lv1_actual_total = lv1_actual_avg = lv1_actual_max = lv1_actual_min = 0
+
+        # ユニーク source_ids 数（generate_unprocessed が「処理済み」とみなす件数と同じ）
+        cur = conn.execute(
+            "SELECT COUNT(DISTINCT value) "
+            "FROM arasuji_entries, json_each(source_ids_json) WHERE level = 1"
+        )
+        lv1_unique_source_ids = cur.fetchone()[0] or 0
+
+        # source_ids 重複数（合計 - ユニーク）
+        lv1_duplicate_source_ids = lv1_actual_total - lv1_unique_source_ids
+
+        # 存在しないメッセージを指す source_ids（孤児）
+        cur = conn.execute(
+            "SELECT COUNT(DISTINCT value) "
+            "FROM arasuji_entries, json_each(source_ids_json) "
+            "WHERE level = 1 AND value NOT IN (SELECT id FROM messages)"
+        )
+        lv1_orphan_source_ids = cur.fetchone()[0] or 0
+
+        # source_count フィールドと実際の長さが異なるエントリ
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM arasuji_entries "
+            "WHERE level = 1 AND source_count != json_array_length(source_ids_json)"
+        )
+        lv1_mismatched_entries = cur.fetchone()[0] or 0
+
+        # --- Stelis 除外後の統計 ---
+        stelis_excluded: Optional[int] = None
+        non_stelis_total: Optional[int] = None
+        non_stelis_after_last: Optional[int] = None
+        stelis_error: Optional[str] = None
+        try:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM messages "
+                "WHERE thread_id IN (SELECT thread_id FROM stelis_threads)"
+            )
+            stelis_excluded = cur.fetchone()[0] or 0
+            non_stelis_total = total_messages - stelis_excluded
+        except Exception as ex:
+            stelis_error = str(ex)
+
+        # --- per-level エントリ詳細（実際の source_ids 長を含む）---
         level_details: Dict[int, list] = {}
         lv1_entries = []
         for level in range(1, max_level + 1):
             entries = get_entries_by_level(conn, level, order_by_time=True)
             if level == 1:
                 lv1_entries = entries
-            level_details[level] = [
-                {
-                    "id": e.id,
-                    "start_time": e.start_time,
-                    "end_time": e.end_time,
-                    "source_count": e.source_count,
-                    "message_count": e.message_count,
-                    "is_consolidated": e.is_consolidated,
-                    "parent_id": e.parent_id,
-                }
-                for e in entries
-            ]
 
-        # Gap analysis: messages between consecutive Lv1 Chronicles
+            if level == 1:
+                level_details[level] = [
+                    {
+                        "id": e.id,
+                        "start_time": e.start_time,
+                        "end_time": e.end_time,
+                        "source_count_stored": e.source_count,
+                        "actual_source_ids_count": lv1_actual_lengths.get(e.id, 0),
+                        "message_count": e.message_count,
+                        "is_consolidated": e.is_consolidated,
+                        "parent_id": e.parent_id,
+                    }
+                    for e in entries
+                ]
+            else:
+                level_details[level] = [
+                    {
+                        "id": e.id,
+                        "start_time": e.start_time,
+                        "end_time": e.end_time,
+                        "source_count_stored": e.source_count,
+                        "message_count": e.message_count,
+                        "is_consolidated": e.is_consolidated,
+                        "parent_id": e.parent_id,
+                    }
+                    for e in entries
+                ]
+
+        # --- Gap analysis: Level-1 Chronicle 間の孤立メッセージ ---
         gaps = []
         for i in range(len(lv1_entries) - 1):
             e1 = lv1_entries[i]
@@ -351,28 +425,40 @@ def get_chronicle_diagnosis(persona_id: str, manager=Depends(get_manager)):
                         "isolated_message_count": gap_count,
                     })
 
-        # Messages after last Chronicle
+        # --- 最後の Chronicle 以降のメッセージ数 ---
         messages_after_last = 0
         last_end_time = None
         if lv1_entries:
-            last_entry = lv1_entries[-1]
-            last_end_time = last_entry.end_time
+            last_end_time = lv1_entries[-1].end_time
             if last_end_time is not None:
                 cur = conn.execute(
                     "SELECT COUNT(*) FROM messages WHERE created_at > ?",
                     (last_end_time,),
                 )
                 messages_after_last = cur.fetchone()[0]
+                if non_stelis_total is not None:
+                    try:
+                        cur = conn.execute(
+                            "SELECT COUNT(*) FROM messages WHERE created_at > ? "
+                            "AND thread_id NOT IN (SELECT thread_id FROM stelis_threads)",
+                            (last_end_time,),
+                        )
+                        non_stelis_after_last = cur.fetchone()[0] or 0
+                    except Exception:
+                        pass
         else:
             messages_after_last = total_messages
+            non_stelis_after_last = non_stelis_total
 
-        messages_covered = sum(e.message_count for e in lv1_entries)
+        # DB保存の message_count 合計（旧来の値）
+        messages_covered_stored = sum(e.message_count for e in lv1_entries)
 
         return {
             "persona_id": persona_id,
             "generated_at": int(time.time()),
+            # --- 全体サマリー ---
             "total_messages": total_messages,
-            "messages_covered_by_lv1": messages_covered,
+            "messages_covered_by_lv1_stored": messages_covered_stored,  # DB保存値の合計（不正確な可能性あり）
             "messages_after_last_chronicle": messages_after_last,
             "max_level": max_level,
             "counts_by_level": counts_by_level,
@@ -380,6 +466,21 @@ def get_chronicle_diagnosis(persona_id: str, manager=Depends(get_manager)):
             "last_chronicle_end_time": last_end_time,
             "last_processed_message_id": progress.last_processed_message_id if progress else None,
             "last_processed_at": progress.last_processed_at if progress else None,
+            # --- source_ids 実態調査 ---
+            "lv1_actual_source_ids_total": lv1_actual_total,
+            "lv1_unique_source_ids": lv1_unique_source_ids,        # generate_unprocessed の processed_ids 件数と同値
+            "lv1_duplicate_source_ids": lv1_duplicate_source_ids,  # 重複分（0でなければ異常）
+            "lv1_orphan_source_ids": lv1_orphan_source_ids,        # 存在しないメッセージ参照数
+            "lv1_mismatched_entries": lv1_mismatched_entries,      # source_count != 実際長 のエントリ数
+            "lv1_actual_source_ids_avg": round(lv1_actual_avg, 1),
+            "lv1_actual_source_ids_max": lv1_actual_max,
+            "lv1_actual_source_ids_min": lv1_actual_min,
+            # --- Stelis 除外後の統計 ---
+            "stelis_excluded_messages": stelis_excluded,
+            "non_stelis_total_messages": non_stelis_total,
+            "non_stelis_after_last_chronicle": non_stelis_after_last,
+            "stelis_stats_error": stelis_error,
+            # --- 詳細 ---
             "level_details": level_details,
             "gaps": gaps,
         }

--- a/frontend/src/components/memory/MemoryRecall.tsx
+++ b/frontend/src/components/memory/MemoryRecall.tsx
@@ -61,22 +61,46 @@ export default function MemoryRecall({ personaId }: MemoryRecallProps) {
         lines.push(`ペルソナ: ${data.persona_id}`);
         lines.push('');
 
+        // --- 全体サマリー ---
         lines.push('== 全体サマリー ==');
-        lines.push(`総メッセージ数: ${data.total_messages}`);
-        lines.push(`Lv1 Chronicle がカバーするメッセージ数: ${data.messages_covered_by_lv1}`);
-        lines.push(`最後の Chronicle 以降の未処理メッセージ数: ${data.messages_after_last_chronicle}`);
+        lines.push(`総メッセージ数 (Stelis含む): ${data.total_messages}`);
+        lines.push(`最後の Chronicle 以降のメッセージ数 (Stelis含む): ${data.messages_after_last_chronicle}`);
         lines.push(`Chronicle の最大レベル: ${data.max_level}`);
         if (data.last_chronicle_end_time != null) {
             lines.push(`最後の Chronicle 終端時刻: ${formatTime(data.last_chronicle_end_time)}`);
         }
         if (data.last_processed_at != null) {
-            lines.push(`最後の Chronicle 生成日時: ${formatTime(data.last_processed_at)}`);
+            lines.push(`最後の Chronicle 生成日時 (CLI経由): ${formatTime(data.last_processed_at)}`);
         }
         if (data.last_processed_message_id) {
-            lines.push(`最後に処理したメッセージID: ${data.last_processed_message_id}`);
+            lines.push(`最後に処理したメッセージID (CLI経由): ${data.last_processed_message_id}`);
         }
         lines.push('');
 
+        // --- Stelis 除外後の統計 ---
+        lines.push('== Stelis 除外後の統計 (generate_unprocessed の実行環境に相当) ==');
+        if (data.stelis_stats_error) {
+            lines.push(`  ※ stelis_threads テーブルが存在しません: ${data.stelis_stats_error}`);
+            lines.push('  ※ generate_unprocessed はこのエラーで全メッセージをスキップする可能性があります');
+        } else {
+            lines.push(`  Stelis 除外メッセージ数: ${data.stelis_excluded_messages ?? '(取得失敗)'}`);
+            lines.push(`  生成対象の総メッセージ数 (Stelis除外): ${data.non_stelis_total_messages ?? '(取得失敗)'}`);
+            lines.push(`  生成対象の未処理メッセージ数 (Stelis除外 & 最後のChronicle以降): ${data.non_stelis_after_last_chronicle ?? '(取得失敗)'}`);
+        }
+        lines.push('');
+
+        // --- source_ids 実態調査 ---
+        lines.push('== Level 1 source_ids 実態調査 ==');
+        lines.push(`  【実際の source_ids 合計数】: ${data.lv1_actual_source_ids_total}`);
+        lines.push(`  【DB保存の message_count 合計】: ${data.messages_covered_by_lv1_stored}  ← 上と乖離していれば異常`);
+        lines.push(`  generate_unprocessed が「処理済み」とみなす件数 (ユニーク source_ids): ${data.lv1_unique_source_ids}`);
+        lines.push(`  重複 source_ids 数: ${data.lv1_duplicate_source_ids}  ${data.lv1_duplicate_source_ids > 0 ? '⚠️ 異常' : '(正常)'}`);
+        lines.push(`  孤児 source_ids 数 (存在しないメッセージ参照): ${data.lv1_orphan_source_ids}  ${data.lv1_orphan_source_ids > 0 ? '⚠️ 異常' : '(正常)'}`);
+        lines.push(`  source_count と実際の長さが不一致なエントリ数: ${data.lv1_mismatched_entries}  ${data.lv1_mismatched_entries > 0 ? '⚠️ 異常' : '(正常)'}`);
+        lines.push(`  source_ids 長の統計 (実値): 平均 ${data.lv1_actual_source_ids_avg}  最大 ${data.lv1_actual_source_ids_max}  最小 ${data.lv1_actual_source_ids_min}`);
+        lines.push('');
+
+        // --- レベル別統計 ---
         lines.push('== レベル別統計 ==');
         for (let level = 1; level <= data.max_level; level++) {
             const total = data.counts_by_level[level] ?? 0;
@@ -86,14 +110,20 @@ export default function MemoryRecall({ personaId }: MemoryRecallProps) {
         }
         lines.push('');
 
-        // Per-level entry details
+        // --- Per-level エントリ詳細 ---
         for (let level = 1; level <= data.max_level; level++) {
             const entries: any[] = data.level_details[level] ?? [];
             lines.push(`== Level ${level} Chronicle エントリ詳細 (${entries.length} 件) ==`);
             entries.forEach((entry: any, idx: number) => {
                 lines.push(`  [${idx + 1}] ID: ${entry.id}`);
                 lines.push(`       期間: ${formatTime(entry.start_time)}  〜  ${formatTime(entry.end_time)}`);
-                lines.push(`       含むメッセージ数: ${entry.message_count}  ソース数: ${entry.source_count}`);
+                if (level === 1) {
+                    const mismatch = entry.actual_source_ids_count !== entry.source_count_stored
+                        ? `  ⚠️ DB保存値: ${entry.source_count_stored}` : '';
+                    lines.push(`       source_ids 実数: ${entry.actual_source_ids_count}${mismatch}  message_count: ${entry.message_count}`);
+                } else {
+                    lines.push(`       source_count: ${entry.source_count_stored}  message_count: ${entry.message_count}`);
+                }
                 const consolidatedStr = entry.is_consolidated
                     ? `はい → 親ID: ${entry.parent_id ?? '(なし)'}`
                     : 'いいえ';
@@ -102,7 +132,7 @@ export default function MemoryRecall({ personaId }: MemoryRecallProps) {
             lines.push('');
         }
 
-        // Gap analysis
+        // --- ギャップ分析 ---
         lines.push('== ギャップ分析 (Chronicle 間の孤立メッセージ) ==');
         if (data.gaps.length > 0) {
             data.gaps.forEach((gap: any, idx: number) => {


### PR DESCRIPTION
## Summary

- DB保存の `source_count`/`message_count` ではなく `source_ids_json` の実際の内容を直接SQLでクエリする形に修正
- 今回の不具合調査で「37920 processed なのに Level-1 が832件×20=16640件のはず」という乖離を診断ツールが見逃していた問題への対処

### 追加された診断情報

**source_ids 実態調査 (Level 1)**
- `lv1_actual_source_ids_total`: 実際の source_ids 合計数（`json_array_length` で計測）
- `lv1_unique_source_ids`: ユニーク source_ids 数（= `generate_unprocessed` が「処理済み」とみなす件数）
- `lv1_duplicate_source_ids`: 重複数（0でなければ異常）
- `lv1_orphan_source_ids`: 存在しないメッセージを指す source_ids 数
- `lv1_mismatched_entries`: `source_count` フィールドと実際の長さが異なるエントリ数
- source_ids 長の avg/max/min 統計

**Stelis 除外後の統計**
- Stelis 除外後の総メッセージ数・最後のChronicle以降のメッセージ数
- `stelis_threads` テーブルが存在しない場合のエラーを明示報告

**出力フォーマット改善**
- 異常値には ⚠️ マーク
- Stelis含む / Stelis除外 を明確に分離表記
- Level-1 エントリに実際の source_ids 数を表示（DB保存値との乖離を即確認可能）

## Test plan
- [ ] Chronicle診断ダウンロードで新フィールドが出力されることを確認
- [ ] `lv1_mismatched_entries > 0` の環境で ⚠️ が表示されることを確認
- [ ] `stelis_threads` テーブルが存在しない場合にエラーメッセージが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)