### PR TITLE
fix: アドオン基盤のバブル再生ボタン動作に必要な配線を補完

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -23,6 +23,9 @@ from api.routes.people.x_auth import callback_router as x_callback_router
 api_router.include_router(x_callback_router, prefix="/x", tags=["x"])
 
 from api.routes import addon, addon_events
-api_router.include_router(addon.router, prefix="/addon", tags=["addon"])
+# addon_events(/events など固定パス)を addon(/{addon_name} キャッチオール)より
+# 先に登録する。逆順だと GET /api/addon/events が GET /api/addon/{addon_name} に
+# 飲まれて 404 "Addon not found" になる。
 api_router.include_router(addon_events.router, prefix="/addon", tags=["addon-events"])
+api_router.include_router(addon.router, prefix="/addon", tags=["addon"])
 

--- a/api/routes/addon.py
+++ b/api/routes/addon.py
@@ -43,6 +43,7 @@ class AddonUiBubbleButton(BaseModel):
     id: str
     icon: str
     label: str
+    action: Optional[str] = None  # "play_audio" 等のクライアント側ビルトインアクション
     tool: Optional[str] = None
     metadata_key: Optional[str] = None
     show_when: Optional[str] = None  # "metadata_exists" | "always"

--- a/api/routes/people/__init__.py
+++ b/api/routes/people/__init__.py
@@ -1,10 +1,38 @@
+from typing import List
+
 from fastapi import APIRouter
+from pydantic import BaseModel
+
 from . import summon, memory, recall, config, autonomous
 from . import import_chatlog, reembed, memopedia, native_export_import
 from . import schedule, tasks, inventory, arasuji
 from . import x_auth, pulse_logs, memory_notes, working_memory, autonomy
 
 router = APIRouter()
+
+
+class PersonaListItem(BaseModel):
+    id: str
+    name: str
+
+
+@router.get("/", response_model=List[PersonaListItem], tags=["people"])
+def list_all_personas() -> List[PersonaListItem]:
+    """Return all registered personas (AI rows).
+
+    アドオン管理UIの「ペルソナ別設定」でペルソナを選択するために使用される。
+    AddonManagerModal が `/api/people/` を叩いているが、対応するハンドラが
+    無かったため 404 になっていた。シンプルな id/name のリストを返す。
+    """
+    from database.models import AI
+    from database.session import SessionLocal
+
+    db = SessionLocal()
+    try:
+        rows = db.query(AI.AIID, AI.AINAME).all()
+        return [PersonaListItem(id=r.AIID, name=r.AINAME or r.AIID) for r in rows]
+    finally:
+        db.close()
 
 # 各サブモジュールのルーターを include
 router.include_router(summon.router, tags=["people"])

--- a/frontend/src/app/api/addon/events/route.ts
+++ b/frontend/src/app/api/addon/events/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Next.js Route Handler that streams SSE from the FastAPI backend.
+ *
+ * next.config.ts の `rewrites` は通常の HTTP リクエストには機能するが、
+ * text/event-stream の長命チャンク転送はバッファされて流れてこないケースが
+ * ある(特に Turbopack)。ここでは明示的に fetch → ReadableStream をそのまま
+ * 返すことで、EventSource の初回接続後にサーバー側から届く chunk が確実に
+ * ブラウザに届くようにする。
+ *
+ * /api/addon/events の URL を維持することで、useAddonEvents フック側は無改修。
+ */
+import type { NextRequest } from "next/server";
+
+const BACKEND = process.env.SAIVERSE_BACKEND_URL ?? "http://127.0.0.1:8000";
+
+// このルートは常に動的。Next.js の静的最適化を避ける。
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+// 長命コネクションを許す(デフォルトのタイムアウトを伸ばす)
+export const maxDuration = 3600;
+
+export async function GET(req: NextRequest): Promise<Response> {
+    const upstream = new URL("/api/addon/events", BACKEND);
+
+    let upstreamResp: Response;
+    try {
+        upstreamResp = await fetch(upstream, {
+            method: "GET",
+            headers: {
+                accept: "text/event-stream",
+                "cache-control": "no-cache",
+                "x-forwarded-for": req.headers.get("x-forwarded-for") ?? "",
+            },
+            signal: req.signal,
+            // duplex は GET（body 無し）では不要。削除するとデフォルト ReadableStream
+            // 挙動が保たれ、Next.js ランタイムでの互換性が高い。
+        });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("[addon-events proxy] upstream fetch failed:", msg);
+        return new Response(`upstream fetch failed: ${msg}`, { status: 502 });
+    }
+
+    if (!upstreamResp.ok || !upstreamResp.body) {
+        const bodyText = await upstreamResp.text().catch(() => "");
+        console.error(
+            "[addon-events proxy] upstream returned non-ok:",
+            upstreamResp.status,
+            bodyText.slice(0, 200),
+        );
+        return new Response(
+            `upstream error: ${upstreamResp.status} ${bodyText.slice(0, 200)}`,
+            { status: 502 },
+        );
+    }
+
+    return new Response(upstreamResp.body, {
+        status: 200,
+        headers: {
+            "content-type": "text/event-stream; charset=utf-8",
+            "cache-control": "no-cache, no-transform",
+            connection: "keep-alive",
+            "x-accel-buffering": "no",
+        },
+    });
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -523,6 +523,38 @@ export default function Home() {
                     setMessages(newMessages);
                     setTimeout(() => setIsHistoryLoaded(true), 150);
                 }
+
+                // アシスタントメッセージに紐付くアドオンメタデータを先読みする。
+                // SSE の audio_ready イベントは発生時に1回だけ配信されるため、
+                // ページリロード後に過去メッセージのバブルボタンを復元するには
+                // ここで明示的にフェッチする必要がある。
+                const assistantIds = newMessages
+                    .filter(m => m.role === 'assistant' && m.id)
+                    .map(m => m.id as string);
+                if (assistantIds.length > 0) {
+                    void Promise.all(
+                        assistantIds.map(async (mid) => {
+                            try {
+                                const r = await fetch(
+                                    `/api/addon/messages/${encodeURIComponent(mid)}/metadata`,
+                                );
+                                if (!r.ok) return;
+                                const body = await r.json() as {
+                                    metadata?: Record<string, Record<string, unknown>>;
+                                };
+                                const meta = body.metadata;
+                                if (meta && Object.keys(meta).length > 0) {
+                                    setAddonMetadata(prev => ({
+                                        ...prev,
+                                        [mid]: { ...(prev[mid] ?? {}), ...meta },
+                                    }));
+                                }
+                            } catch {
+                                // 個別失敗は無視(他メッセージは継続)
+                            }
+                        }),
+                    );
+                }
             } else {
                 const errorPayload: HistoryResponse | null = await res.json().catch(() => null);
                 console.error("[DEBUG] Fetch failed", {

--- a/frontend/src/components/AddonBubbleButtons.tsx
+++ b/frontend/src/components/AddonBubbleButtons.tsx
@@ -41,7 +41,9 @@ function PlayAudioButton({
         if (!audioRef.current) {
             audioRef.current = new Audio(audioUrl);
             audioRef.current.onended = () => setPlaying(false);
-            audioRef.current.onerror = () => {
+            audioRef.current.onerror = (e) => {
+                const mediaErr = audioRef.current?.error;
+                console.error('[PlayAudioButton] audio error', mediaErr?.code, mediaErr?.message, e);
                 setPlaying(false);
                 setError(true);
             };
@@ -55,7 +57,8 @@ function PlayAudioButton({
             try {
                 await audioRef.current.play();
                 setPlaying(true);
-            } catch {
+            } catch (err) {
+                console.error('[PlayAudioButton] play() rejected', err);
                 setError(true);
             }
         }

--- a/frontend/src/hooks/useAddonEvents.ts
+++ b/frontend/src/hooks/useAddonEvents.ts
@@ -47,6 +47,7 @@ export function useAddonEvents(onEvent: AddonEventHandler): void {
         };
 
         es.onerror = () => {
+            console.warn('[addon-events] SSE connection error, reconnecting in 5s');
             // エラー時は一定時間後に再接続
             es.close();
             esRef.current = null;

--- a/persona/history_manager.py
+++ b/persona/history_manager.py
@@ -217,16 +217,19 @@ class HistoryManager:
         msg: Dict[str, str],
         *,
         heard_by: Optional[List[str]] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Adds a message only to a specific building's history.
 
         building_id must be the canonical building ID present in building_memory_paths.
+        Returns the saved building message dict (including confirmed message_id) so
+        callers can associate addon metadata (same contract as add_message).
         """
         prepared_msg = self._prepare_message(msg)
         hist = self.building_histories.setdefault(building_id, [])
         building_msg = self._decorate_building_message(building_id, prepared_msg, heard_by)
         hist.append(building_msg)
         self._ensure_size_limit(hist, self._get_building_memory_path(building_id))
+        return building_msg
 
     def add_to_persona_only(self, msg: Dict[str, str]) -> None:
         """Adds a message only to the persona's main history."""

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -1209,8 +1209,8 @@ class SEARuntime:
     def _emit_speak(self, persona: Any, building_id: str, text: str, pulse_id: Optional[str] = None, record_history: bool = True, extra_metadata: Optional[Dict[str, Any]] = None) -> None:
         self._emitters.emit_speak(persona, building_id, text, pulse_id=pulse_id, record_history=record_history, extra_metadata=extra_metadata)
 
-    def _emit_say(self, persona: Any, building_id: str, text: str, pulse_id: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> None:
-        self._emitters.emit_say(persona, building_id, text, pulse_id=pulse_id, metadata=metadata)
+    def _emit_say(self, persona: Any, building_id: str, text: str, pulse_id: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+        return self._emitters.emit_say(persona, building_id, text, pulse_id=pulse_id, metadata=metadata)
 
     def _emit_think(self, persona: Any, pulse_id: str, text: str, record_history: bool = True) -> None:
         self._emitters.emit_think(persona, pulse_id, text, record_history=record_history)

--- a/sea/runtime_emitters.py
+++ b/sea/runtime_emitters.py
@@ -71,7 +71,7 @@ class RuntimeEmitters:
         text: str,
         pulse_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    ) -> Optional[Dict[str, Any]]:
         msg = {"role": "assistant", "content": text, "persona_id": persona.persona_id}
         msg_metadata: Dict[str, Any] = {}
         if pulse_id:
@@ -97,12 +97,21 @@ class RuntimeEmitters:
 
         if msg_metadata:
             msg["metadata"] = msg_metadata
+        building_msg: Optional[Dict[str, Any]] = None
         try:
-            persona.history_manager.add_to_building_only(building_id, msg)
+            building_msg = persona.history_manager.add_to_building_only(building_id, msg)
+            # BuildingHistory 保存完了直後に message_id を ContextVar に確定させる。
+            # 後続のアドオンツール (TTS 等) が get_active_message_id() で正しい ID を
+            # 取得できるよう、emit_speak と同様の配線を行う。
+            msg_id = building_msg.get("message_id") if building_msg else None
+            if msg_id:
+                from tools.context import set_active_message_id
+                set_active_message_id(str(msg_id))
             self.runtime.manager.gateway_handle_ai_replies(building_id, persona, [text])
         except Exception:
             LOGGER.exception("Failed to emit say message")
         self.notify_unity_speak(persona, text)
+        return building_msg
 
     def emit_think(self, persona: Any, pulse_id: str, text: str, record_history: bool = True) -> None:
         if not record_history:

--- a/sea/runtime_engine.py
+++ b/sea/runtime_engine.py
@@ -76,8 +76,12 @@ class RuntimeEngine:
                     LOGGER.info("[sea][tool] Tool function found: %s", tool_func)
 
                 # Execute tool with persona context
+                # 直前の LLM speak ノードが保存した message_id を後続ツールにも
+                # 引き継ぐ。persona_context は毎回 _MESSAGE_ID を強制的に書き換える
+                # ため、state 経由で明示的に渡さないとアドオン連携が切れる。
+                _current_msg_id = state.get("_last_message_id")
                 if persona_id and persona_dir:
-                    with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name, auto_mode=auto_mode, event_callback=event_callback):
+                    with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name, auto_mode=auto_mode, event_callback=event_callback, message_id=_current_msg_id):
                         result = tool_func(**kwargs) if callable(tool_func) else None
                 else:
                     result = tool_func(**kwargs) if callable(tool_func) else None

--- a/sea/runtime_llm.py
+++ b/sea/runtime_llm.py
@@ -573,7 +573,11 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                             if _at_both:
                                 msg_metadata["activity_trace"] = list(_at_both)
                             eff_bid = runtime._effective_building_id(persona, building_id)
-                            runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                            _last_bmsg = runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                            if isinstance(_last_bmsg, dict):
+                                _last_mid = _last_bmsg.get("message_id")
+                                if _last_mid:
+                                    state["_last_message_id"] = str(_last_mid)
                             LOGGER.info("[sea] 'both' response: text kept in UI and Building history (len=%d), tool call continues", len(text))
                         elif text_chunks:
                             # "tool_call" only — discard streamed text
@@ -620,7 +624,13 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                         if accumulator:
                             msg_metadata["llm_usage_total"] = dict(accumulator)
                         eff_bid = runtime._effective_building_id(persona, building_id)
-                        runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                        _last_bmsg = runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                        # 後続ツールが新しい persona_context 配下でも
+                        # 最新の message_id を参照できるよう state に残す。
+                        if isinstance(_last_bmsg, dict):
+                            _last_mid = _last_bmsg.get("message_id")
+                            if _last_mid:
+                                state["_last_message_id"] = str(_last_mid)
 
                 else:
                     # ── Synchronous tool mode (original) ──
@@ -1235,7 +1245,13 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                         if accumulator:
                             msg_metadata["llm_usage_total"] = dict(accumulator)
                         eff_bid = runtime._effective_building_id(persona, building_id)
-                        runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                        _last_bmsg = runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                        # 後続ツールが新しい persona_context 配下でも
+                        # 最新の message_id を参照できるよう state に残す。
+                        if isinstance(_last_bmsg, dict):
+                            _last_mid = _last_bmsg.get("message_id")
+                            if _last_mid:
+                                state["_last_message_id"] = str(_last_mid)
 
                     # Store reasoning in state for downstream speak/say nodes
                     if reasoning_text:
@@ -1418,7 +1434,13 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                         if accumulator:
                             msg_metadata["llm_usage_total"] = dict(accumulator)
                         eff_bid = runtime._effective_building_id(persona, building_id)
-                        runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                        _last_bmsg = runtime._emit_say(persona, eff_bid, text, pulse_id=pulse_id, metadata=msg_metadata if msg_metadata else None)
+                        # 後続ツールが新しい persona_context 配下でも
+                        # 最新の message_id を参照できるよう state に残す。
+                        if isinstance(_last_bmsg, dict):
+                            _last_mid = _last_bmsg.get("message_id")
+                            if _last_mid:
+                                state["_last_message_id"] = str(_last_mid)
                         if event_callback is not None:
                             LOGGER.info("[DEBUG] Sending 'say' event with content: %s", text[:100] if text else "(empty)")
                             say_event: Dict[str, Any] = {

--- a/sea/runtime_nodes.py
+++ b/sea/runtime_nodes.py
@@ -56,8 +56,10 @@ def lg_tool_call_node(runtime: Any, node_def: Any, persona: Any, playbook: Any, 
             persona_dir = persona_dir.parent if persona_dir else Path.cwd()
             manager_ref = getattr(persona_obj, "manager_ref", None)
             LOGGER.info("[sea][tool_call] CALL %s (persona=%s) args=%s", tool_name, persona_id, tool_args)
+            # 直前の LLM speak ノードが保存した message_id を後続ツールに引き継ぐ。
+            _current_msg_id = state.get("_last_message_id")
             if persona_id and persona_dir:
-                with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name, auto_mode=auto_mode, event_callback=event_callback):
+                with persona_context(persona_id, persona_dir, manager_ref, playbook_name=playbook.name, auto_mode=auto_mode, event_callback=event_callback, message_id=_current_msg_id):
                     result = tool_func(**tool_args)
             else:
                 result = tool_func(**tool_args)


### PR DESCRIPTION
# TTSアドオン連携のバグ修正まとめ

`saiverse-voice-tts` 拡張パックを使ってペルソナ発話に再生ボタンを付与するフローを
end-to-end で動作確認した結果、以下の配線ギャップを補完しました。
動作確認済み(Chrome + Windows + RTX 4080)です。

## バグ分類と主要な修正箇所

### A. message_id が拡張パックに届かない
- `persona_context()` が毎回 `_MESSAGE_ID` を None に上書きしていた
- `emit_say` に `set_active_message_id` 配線が抜けていた
- 対応: `state['_last_message_id']` 経由で引き継ぎ

### B. `/api/addon/events` が `/api/addon/{addon_name}` に飲まれて 404
- `addon.router` → `addon_events.router` の順序を逆転

### C. `GET /api/people/` が 404
- ルート一覧ハンドラを追加(`AddonManagerModal` のペルソナ追加UIが機能)

### D. **`action` フィールドがレスポンスから脱落**(最大のハマり所)
- `AddonUiBubbleButton` Pydantic モデルに `action: Optional[str]` を追加
- これが抜けていたため `PlayAudioButton` が一度も描画されていなかった

### E. Next.js rewrite が SSE を通さない
- `app/api/addon/events/route.ts` を追加して明示的にチャンクプロキシ

### F. ページリロードで「準備中」に戻る
- 履歴読込後に `/api/addon/messages/{id}/metadata` を並列フェッチして state に反映

## テスト結果
- 🔊ボタン表示、有効化、クリック再生、リロード後復元、アドオン ON/OFF、ペルソナ別設定、全て動作
- 既存チャット機能・他Tool類への影響なし

コミット: 8b1af8a
