### PR TITLE
feat: アドオン params_schema の汎用 file/text/number 型サポート

### DIFF
--- a/api/routes/addon.py
+++ b/api/routes/addon.py
@@ -7,10 +7,14 @@ from __future__ import annotations
 
 import json
 import logging
+import mimetypes
+import re
+import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from api.deps import get_manager
@@ -27,16 +31,22 @@ router = APIRouter()
 class AddonParamSchema(BaseModel):
     key: str
     label: str
-    type: str  # "toggle" | "dropdown" | "slider" | "file"
+    description: Optional[str] = None
+    type: str  # "toggle" | "text" | "number" | "file" | "dropdown" | "slider"
     default: Any = None
     persona_configurable: bool = False
+    placeholder: Optional[str] = None  # text / number 用の placeholder
     # dropdown 用
     options: Optional[List[str]] = None
-    # slider 用
+    # number / slider 用
     min: Optional[float] = None
     max: Optional[float] = None
     step: Optional[float] = None
     value_type: Optional[str] = None  # "int" | "float"
+    # file 用
+    accept: Optional[str] = None  # MIME type CSV: "audio/wav,audio/mpeg,video/mp4"
+    max_size_mb: Optional[float] = None  # デフォルト 500MB。本体上限 1GB
+    preview: Optional[str] = None  # "audio" | "image" | None
 
 
 class AddonUiBubbleButton(BaseModel):
@@ -398,3 +408,301 @@ def get_message_addon_metadata(
         return {"message_id": message_id, "metadata": result}
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# File parameter endpoints (per-persona)
+# ---------------------------------------------------------------------------
+
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_SYSTEM_MAX_SIZE_BYTES = 1024 * 1024 * 1024  # 1 GB
+
+
+def _addon_files_base() -> Path:
+    from saiverse.data_paths import get_saiverse_home
+    return get_saiverse_home() / "user_data" / "addon_files"
+
+
+def _validate_names(*names: str) -> None:
+    for name in names:
+        if not name or not _SAFE_NAME_RE.match(name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid name (alphanumeric, -, _ only): {name!r}",
+            )
+
+
+def _get_file_param_schema(addon_name: str, param_key: str) -> AddonParamSchema:
+    from saiverse.data_paths import EXPANSION_DATA_DIR
+    manifest_path = EXPANSION_DATA_DIR / addon_name / "addon.json"
+    if not manifest_path.exists():
+        raise HTTPException(status_code=404, detail=f"Addon manifest not found: {addon_name}")
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to read addon manifest: {exc}")
+    for param in data.get("params_schema", []):
+        if param.get("key") == param_key and param.get("type") == "file":
+            return AddonParamSchema(**param)
+    raise HTTPException(
+        status_code=404,
+        detail=f"File parameter '{param_key}' not found in addon '{addon_name}'",
+    )
+
+
+def _resolve_file_dir(addon_name: str, persona_id: Optional[str], param_key: str) -> Path:
+    base = _addon_files_base() / addon_name
+    if persona_id:
+        return base / "personas" / persona_id
+    return base / "global"
+
+
+def _ext_from_content_type(content_type: str) -> str:
+    ext = mimetypes.guess_extension(content_type)
+    if ext:
+        return ext
+    mapping = {
+        "audio/wav": ".wav",
+        "audio/x-wav": ".wav",
+        "audio/mpeg": ".mp3",
+        "audio/mp3": ".mp3",
+        "audio/flac": ".flac",
+        "audio/ogg": ".ogg",
+        "video/mp4": ".mp4",
+        "video/webm": ".webm",
+        "image/png": ".png",
+        "image/jpeg": ".jpg",
+        "image/webp": ".webp",
+    }
+    return mapping.get(content_type, "")
+
+
+@router.post("/{addon_name}/config/persona/{persona_id}/file/{param_key}")
+async def upload_persona_file(
+    addon_name: str,
+    persona_id: str,
+    param_key: str,
+    file: UploadFile = File(...),
+    _manager=Depends(get_manager),
+):
+    """ペルソナ別のファイルパラメータをアップロードする。
+
+    addon.json の params_schema で type="file" かつ persona_configurable=true の
+    パラメータにのみ使用可能。ファイルは ~/.saiverse/user_data/addon_files/ 配下に
+    保存され、AddonPersonaConfig.params_json に保存先パスが書き込まれる。
+    """
+    _validate_names(addon_name, persona_id, param_key)
+    schema = _get_file_param_schema(addon_name, param_key)
+
+    if not schema.persona_configurable:
+        raise HTTPException(status_code=400, detail="This parameter is not persona-configurable")
+
+    # Content-type validation
+    ct = file.content_type or "application/octet-stream"
+    if schema.accept:
+        allowed = [t.strip() for t in schema.accept.split(",")]
+        if ct not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"File type '{ct}' not allowed. Accepted: {schema.accept}",
+            )
+
+    # Size limit
+    max_bytes = int((schema.max_size_mb or 500) * 1024 * 1024)
+    max_bytes = min(max_bytes, _SYSTEM_MAX_SIZE_BYTES)
+
+    # Read file with size check
+    content = await file.read()
+    if len(content) > max_bytes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File too large ({len(content)} bytes). Max: {max_bytes} bytes ({max_bytes / 1024 / 1024:.0f} MB)",
+        )
+
+    # Determine extension and save
+    ext = _ext_from_content_type(ct)
+    dest_dir = _resolve_file_dir(addon_name, persona_id, param_key)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_file = dest_dir / f"{param_key}{ext}"
+
+    # Atomic write: temp file then rename
+    tmp_file = dest_file.with_suffix(dest_file.suffix + ".tmp")
+    try:
+        tmp_file.write_bytes(content)
+        shutil.move(str(tmp_file), str(dest_file))
+    except Exception as exc:
+        tmp_file.unlink(missing_ok=True)
+        raise HTTPException(status_code=500, detail=f"Failed to save file: {exc}")
+
+    # Update AddonPersonaConfig.params_json
+    from database.models import AddonPersonaConfig
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+    db = _get_session()
+    try:
+        row = (
+            db.query(AddonPersonaConfig)
+            .filter(
+                AddonPersonaConfig.addon_name == addon_name,
+                AddonPersonaConfig.persona_id == persona_id,
+            )
+            .first()
+        )
+        params: Dict[str, Any] = {}
+        if row and row.params_json:
+            try:
+                params = json.loads(row.params_json)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        params[param_key] = str(dest_file)
+        params_str = json.dumps(params, ensure_ascii=False)
+
+        stmt = sqlite_insert(AddonPersonaConfig).values(
+            addon_name=addon_name,
+            persona_id=persona_id,
+            params_json=params_str,
+        ).on_conflict_do_update(
+            index_elements=["addon_name", "persona_id"],
+            set_={"params_json": params_str},
+        )
+        db.execute(stmt)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+    LOGGER.info(
+        "addon file uploaded: addon=%s persona=%s key=%s size=%d path=%s",
+        addon_name, persona_id, param_key, len(content), dest_file,
+    )
+    return {
+        "path": str(dest_file),
+        "size": len(content),
+        "content_type": ct,
+    }
+
+
+@router.get("/{addon_name}/config/persona/{persona_id}/file/{param_key}")
+async def get_persona_file(
+    addon_name: str,
+    persona_id: str,
+    param_key: str,
+    _manager=Depends(get_manager),
+):
+    """ペルソナ別のファイルパラメータを取得(プレビュー/ダウンロード)する。"""
+    _validate_names(addon_name, persona_id, param_key)
+    _get_file_param_schema(addon_name, param_key)
+
+    # Look up file path from AddonPersonaConfig
+    from database.models import AddonPersonaConfig
+    db = _get_session()
+    try:
+        row = (
+            db.query(AddonPersonaConfig)
+            .filter(
+                AddonPersonaConfig.addon_name == addon_name,
+                AddonPersonaConfig.persona_id == persona_id,
+            )
+            .first()
+        )
+        if not row or not row.params_json:
+            raise HTTPException(status_code=404, detail="No persona config found")
+        params = json.loads(row.params_json)
+        file_path = params.get(param_key)
+        if not file_path:
+            raise HTTPException(status_code=404, detail="File parameter not set")
+    finally:
+        db.close()
+
+    path = Path(file_path)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="File not found on disk")
+
+    ct = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+    return FileResponse(
+        path=str(path),
+        media_type=ct,
+        filename=path.name,
+        content_disposition_type="inline",
+    )
+
+
+@router.delete("/{addon_name}/config/persona/{persona_id}/file/{param_key}")
+async def delete_persona_file(
+    addon_name: str,
+    persona_id: str,
+    param_key: str,
+    _manager=Depends(get_manager),
+):
+    """ペルソナ別のファイルパラメータを削除する。"""
+    _validate_names(addon_name, persona_id, param_key)
+
+    # Remove from params_json
+    from database.models import AddonPersonaConfig
+    db = _get_session()
+    file_path: Optional[str] = None
+    try:
+        row = (
+            db.query(AddonPersonaConfig)
+            .filter(
+                AddonPersonaConfig.addon_name == addon_name,
+                AddonPersonaConfig.persona_id == persona_id,
+            )
+            .first()
+        )
+        if row and row.params_json:
+            params = json.loads(row.params_json)
+            file_path = params.pop(param_key, None)
+            row.params_json = json.dumps(params, ensure_ascii=False)
+            db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+    # Delete physical file
+    if file_path:
+        p = Path(file_path)
+        if p.exists():
+            p.unlink()
+            LOGGER.info("addon file deleted: %s", p)
+
+    return {"deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# File parameter endpoints (global) — scaffold
+# ---------------------------------------------------------------------------
+
+@router.post("/{addon_name}/config/file/{param_key}")
+async def upload_global_file(
+    addon_name: str,
+    param_key: str,
+    file: UploadFile = File(...),
+    _manager=Depends(get_manager),
+):
+    """グローバルのファイルパラメータをアップロードする（雛形）。"""
+    raise HTTPException(status_code=501, detail="Global file upload not yet implemented")
+
+
+@router.get("/{addon_name}/config/file/{param_key}")
+async def get_global_file(
+    addon_name: str,
+    param_key: str,
+    _manager=Depends(get_manager),
+):
+    """グローバルのファイルパラメータを取得する（雛形）。"""
+    raise HTTPException(status_code=501, detail="Global file retrieval not yet implemented")
+
+
+@router.delete("/{addon_name}/config/file/{param_key}")
+async def delete_global_file(
+    addon_name: str,
+    param_key: str,
+    _manager=Depends(get_manager),
+):
+    """グローバルのファイルパラメータを削除する（雛形）。"""
+    raise HTTPException(status_code=501, detail="Global file deletion not yet implemented")

--- a/frontend/src/components/AddonManagerModal.module.css
+++ b/frontend/src/components/AddonManagerModal.module.css
@@ -338,9 +338,99 @@
     height: 100%;
 }
 
+/* --- Text / Number --- */
+
+.textInput,
+.numberInput {
+    padding: 0.3rem 0.5rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.375rem;
+    font-size: 0.85rem;
+    background: transparent;
+    color: inherit;
+    min-width: 120px;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.textInput:focus,
+.numberInput:focus {
+    border-color: #6366f1;
+}
+
+.numberInput {
+    min-width: 80px;
+    max-width: 120px;
+}
+
 .unsupported {
     font-size: 0.8rem;
     color: #94a3b8;
+}
+
+/* --- FileControl --- */
+
+.fileControl {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 200px;
+}
+
+.filePreviewRow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.audioPreview {
+    max-width: 220px;
+    height: 32px;
+}
+
+.imagePreview {
+    max-width: 120px;
+    max-height: 80px;
+    border-radius: 0.375rem;
+    object-fit: contain;
+}
+
+.fileNameDisplay {
+    font-size: 0.8rem;
+    color: #64748b;
+    word-break: break-all;
+}
+
+.fileDeleteBtn {
+    background: none;
+    border: none;
+    color: #94a3b8;
+    cursor: pointer;
+    padding: 0.2rem;
+    border-radius: 0.25rem;
+    display: flex;
+    align-items: center;
+}
+
+.fileDeleteBtn:hover {
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.1);
+}
+
+.fileUploading {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.fileError {
+    font-size: 0.75rem;
+    color: #ef4444;
+}
+
+.fileHint {
+    font-size: 0.72rem;
+    color: #94a3b8;
+    display: block;
 }
 
 /* --- Persona config --- */

--- a/frontend/src/components/AddonManagerModal.tsx
+++ b/frontend/src/components/AddonManagerModal.tsx
@@ -12,14 +12,19 @@ import styles from './AddonManagerModal.module.css';
 interface AddonParamSchema {
     key: string;
     label: string;
-    type: 'toggle' | 'dropdown' | 'slider' | 'file';
+    description?: string;
+    type: 'toggle' | 'text' | 'number' | 'dropdown' | 'slider' | 'file';
     default: unknown;
     persona_configurable: boolean;
+    placeholder?: string;
     options?: string[];
     min?: number;
     max?: number;
     step?: number;
     value_type?: 'int' | 'float';
+    accept?: string;
+    max_size_mb?: number;
+    preview?: 'audio' | 'image';
 }
 
 interface AddonInfo {
@@ -55,10 +60,14 @@ function ParamControl({
     schema,
     value,
     onChange,
+    addonName,
+    personaId,
 }: {
     schema: AddonParamSchema;
     value: unknown;
     onChange: (key: string, val: unknown) => void;
+    addonName?: string;
+    personaId?: string;
 }) {
     const current = value !== undefined ? value : schema.default;
 
@@ -75,6 +84,38 @@ function ParamControl({
                     <span className={styles.toggleSlider} />
                 </label>
             );
+
+        case 'text':
+            return (
+                <input
+                    type="text"
+                    className={styles.textInput}
+                    value={String(current ?? '')}
+                    placeholder={schema.placeholder ?? ''}
+                    onChange={(e) => onChange(schema.key, e.target.value)}
+                />
+            );
+
+        case 'number': {
+            const num = typeof current === 'number' ? current : Number(current ?? schema.min ?? 0);
+            return (
+                <input
+                    type="number"
+                    className={styles.numberInput}
+                    value={num}
+                    min={schema.min}
+                    max={schema.max}
+                    step={schema.step ?? 1}
+                    placeholder={schema.placeholder ?? ''}
+                    onChange={(e) => {
+                        const v = schema.value_type === 'int'
+                            ? parseInt(e.target.value, 10)
+                            : parseFloat(e.target.value);
+                        onChange(schema.key, isNaN(v) ? schema.default : v);
+                    }}
+                />
+            );
+        }
 
         case 'dropdown':
             return (
@@ -93,7 +134,7 @@ function ParamControl({
             const min = schema.min ?? 0;
             const max = schema.max ?? 100;
             const step = schema.step ?? 1;
-            const num = typeof current === 'number' ? current : Number(current ?? min);
+            const snum = typeof current === 'number' ? current : Number(current ?? min);
             return (
                 <div className={styles.sliderRow}>
                     <input
@@ -102,7 +143,7 @@ function ParamControl({
                         min={min}
                         max={max}
                         step={step}
-                        value={num}
+                        value={snum}
                         onChange={(e) => {
                             const v = schema.value_type === 'int'
                                 ? parseInt(e.target.value, 10)
@@ -110,39 +151,180 @@ function ParamControl({
                             onChange(schema.key, v);
                         }}
                     />
-                    <span className={styles.sliderValue}>{num}</span>
+                    <span className={styles.sliderValue}>{snum}</span>
                 </div>
             );
         }
 
         case 'file':
             return (
-                <div
-                    className={styles.fileDropArea}
-                    onDragOver={(e) => e.preventDefault()}
-                    onDrop={(e) => {
-                        e.preventDefault();
-                        const file = e.dataTransfer.files[0];
-                        if (file) onChange(schema.key, file.name);
-                    }}
-                >
-                    <span className={styles.fileDropText}>
-                        {current ? String(current) : 'ファイルをドロップ or クリック'}
-                    </span>
-                    <input
-                        type="file"
-                        className={styles.fileInput}
-                        onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (file) onChange(schema.key, file.name);
-                        }}
-                    />
-                </div>
+                <FileParamControl
+                    schema={schema}
+                    value={current}
+                    onChange={onChange}
+                    addonName={addonName}
+                    personaId={personaId}
+                />
             );
 
         default:
             return <span className={styles.unsupported}>（未対応の型: {schema.type}）</span>;
     }
+}
+
+// ---------------------------------------------------------------------------
+// FileParamControl — file upload / preview / delete
+// ---------------------------------------------------------------------------
+
+function FileParamControl({
+    schema,
+    value,
+    onChange,
+    addonName,
+    personaId,
+}: {
+    schema: AddonParamSchema;
+    value: unknown;
+    onChange: (key: string, val: unknown) => void;
+    addonName?: string;
+    personaId?: string;
+}) {
+    const [uploading, setUploading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const [previewUrl, setPreviewUrl] = React.useState<string | null>(null);
+    const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+    const hasFile = !!value;
+    const canUpload = !!addonName && !!personaId;
+
+    // Build API URLs
+    const fileApiBase = canUpload
+        ? `/api/addon/${addonName}/config/persona/${encodeURIComponent(personaId!)}/file/${schema.key}`
+        : null;
+
+    // Set preview URL when file exists
+    React.useEffect(() => {
+        if (hasFile && fileApiBase) {
+            setPreviewUrl(fileApiBase);
+        } else {
+            setPreviewUrl(null);
+        }
+    }, [hasFile, fileApiBase]);
+
+    const handleUpload = async (file: File) => {
+        if (!fileApiBase) return;
+        setUploading(true);
+        setError(null);
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            const res = await fetch(fileApiBase, {
+                method: 'POST',
+                body: formData,
+            });
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({ detail: res.statusText }));
+                throw new Error(body.detail || `Upload failed: ${res.status}`);
+            }
+            const data = await res.json();
+            onChange(schema.key, data.path);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Upload failed');
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!fileApiBase) return;
+        setError(null);
+        try {
+            await fetch(fileApiBase, { method: 'DELETE' });
+            onChange(schema.key, undefined);
+            setPreviewUrl(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Delete failed');
+        }
+    };
+
+    const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const f = e.target.files?.[0];
+        if (f) handleUpload(f);
+        if (e.target) e.target.value = '';
+    };
+
+    const handleDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        const f = e.dataTransfer.files[0];
+        if (f) handleUpload(f);
+    };
+
+    return (
+        <div className={styles.fileControl}>
+            {/* Current file info + preview */}
+            {hasFile && previewUrl && (
+                <div className={styles.filePreviewRow}>
+                    {schema.preview === 'audio' && (
+                        <audio controls src={previewUrl} className={styles.audioPreview}>
+                            <track kind="captions" />
+                        </audio>
+                    )}
+                    {schema.preview === 'image' && (
+                        <img src={previewUrl} alt={schema.label} className={styles.imagePreview} />
+                    )}
+                    {!schema.preview && (
+                        <span className={styles.fileNameDisplay}>
+                            {String(value).split(/[\\/]/).pop()}
+                        </span>
+                    )}
+                    <button
+                        className={styles.fileDeleteBtn}
+                        onClick={handleDelete}
+                        title="削除（デフォルトに戻す）"
+                    >
+                        <Trash2 size={13} />
+                    </button>
+                </div>
+            )}
+
+            {/* Upload area */}
+            <div
+                className={`${styles.fileDropArea} ${uploading ? styles.fileUploading : ''}`}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+            >
+                <span className={styles.fileDropText}>
+                    {uploading
+                        ? 'アップロード中...'
+                        : hasFile
+                            ? 'ファイルを差し替え'
+                            : 'ファイルをドロップ or クリック'}
+                </span>
+                {schema.description && !hasFile && (
+                    <span className={styles.fileHint}>{schema.description}</span>
+                )}
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    className={styles.fileInput}
+                    accept={schema.accept}
+                    onChange={handleFileSelect}
+                />
+            </div>
+
+            {/* Error display */}
+            {error && <span className={styles.fileError}>{error}</span>}
+
+            {/* Size limit hint */}
+            {!hasFile && schema.max_size_mb && (
+                <span className={styles.fileHint}>
+                    最大 {schema.max_size_mb >= 1024 ? `${(schema.max_size_mb / 1024).toFixed(1)} GB` : `${schema.max_size_mb} MB`}
+                    {schema.accept && ` / ${schema.accept.split(',').map(t => t.split('/')[1]).join(', ')}`}
+                </span>
+            )}
+        </div>
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -258,6 +440,7 @@ function ParamsSection({
                             schema={schema}
                             value={globalParams[schema.key]}
                             onChange={handleGlobalChange}
+                            addonName={addon.addon_name}
                         />
                     </div>
                 ))}
@@ -313,6 +496,8 @@ function ParamsSection({
                                         schema={schema}
                                         value={pc.params[schema.key]}
                                         onChange={(key, val) => handlePersonaChange(pc.persona_id, key, val)}
+                                        addonName={addon.addon_name}
+                                        personaId={pc.persona_id}
                                     />
                                 </div>
                             ))}


### PR DESCRIPTION
## Summary
拡張パックが `addon.json` の `params_schema` で宣言するだけで、ペルソナごとのファイルアップロード・テキスト入力・数値入力をアドオン管理UIに自動描画できる汎用基盤です。

初期ユースケースはTTS拡張の参照音声設定ですが、今後の拡張パックでも同じ仕組みで UI を自動生成できます。

## 新規 params_schema type

| type | ウィジェット | 用途例 |
|---|---|---|
| `text` | 1行テキスト入力 | 書き起こしテキスト |
| `number` | 数値入力 (min/max/step) | 話速、ピッチ等 |
| `file` | ファイルアップローダ + プレビュー | 参照音声、アバター画像 |

既存の `toggle` / `dropdown` / `slider` は無改修で動作維持。

## ファイルパラメータ API (汎用)

ペルソナ別:
- `POST /api/addon/{addon}/config/persona/{pid}/file/{key}` — multipart アップロード
- `GET` — Content-Disposition: inline でプレビュー/ダウンロード
- `DELETE` — 物理ファイル削除 + params_json から除去

グローバル版は 501 雛形のみ（将来拡張用）。

### バリデーション
- `accept`: addon.json で MIME type を制限 (例: `audio/wav,audio/mpeg`)
- `max_size_mb`: addon.json で指定 (デフォルト 500MB、システム上限 1GB)
- パストラバーサル防止: addon_name / persona_id / param_key を `^[a-zA-Z0-9_-]+$` に制限
- アトミック書込: tmp → rename

### ファイル保存先
`~/.saiverse/user_data/addon_files/<addon>/personas/<persona_id>/<key>.<ext>`

## フロントエンド

### ParamControl リファクタ
`switch(schema.type)` で各型のウィジェットを描画。`addonName` / `personaId` props を追加してファイル API の URL を構築。

### FileControl コンポーネント
- ファイル選択 / ドラッグ&ドロップ → POST upload
- `preview: "audio"` → `<audio controls>` でインライン試聴
- `preview: "image"` → `<img>` でインラインプレビュー
- 削除ボタン → DELETE API → デフォルトに戻す
- エラー表示 / サイズ上限ヒント

## addon.json 側の宣言例 (TTS拡張パック)

```json
{
    "key": "ref_audio",
    "label": "参照音声",
    "type": "file",
    "accept": "audio/wav,audio/mpeg,audio/flac",
    "max_size_mb": 50,
    "preview": "audio",
    "persona_configurable": true
}
```

## テスト結果
- 構文チェック: バックエンド (Python) + フロント (TypeScript) 全 OK
- 既存の toggle 型パラメータの動作に影響なし
- ファイルアップロード → params_json 自動更新 → プレビュー表示: 動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
