### PR TITLE
fix: 共通設定欄にペルソナ別パラメータが重複表示される問題を修正

### DIFF
--- a/frontend/src/components/AddonManagerModal.tsx
+++ b/frontend/src/components/AddonManagerModal.tsx
@@ -343,7 +343,7 @@ function ParamsSection({
     const [saving, setSaving] = useState(false);
     const [addingPersona, setAddingPersona] = useState(false);
 
-    const configurableSchemas = addon.params_schema;
+    const configurableSchemas = addon.params_schema.filter((s) => !s.persona_configurable);
     const personaConfigurableSchemas = addon.params_schema.filter((s) => s.persona_configurable);
 
     // 保存（グローバル）


### PR DESCRIPTION
### 追加修正: 共通/ペルソナ別の表示分離
`persona_configurable=false` のパラメータのみ共通設定欄に表示し、ペルソナ別パラメータとの重複を解消。
