### PR TITLE
feat: アドオン管理UIのペルソナ別設定プルダウン化と音声再生修正

### DIFF
--- a/api/routes/addon.py
+++ b/api/routes/addon.py
@@ -38,6 +38,10 @@ class AddonParamSchema(BaseModel):
     placeholder: Optional[str] = None  # text / number 用の placeholder
     # dropdown 用
     options: Optional[List[str]] = None
+    # dropdown 用（動的）: 指定された場合、アドオン側エンドポイントから選択肢を取得する。
+    # パスは "/audio-devices" のようなアドオンローカルパスでも、
+    # "/api/addon/<name>/..." のような絶対パスでも可。
+    options_endpoint: Optional[str] = None
     # number / slider 用
     min: Optional[float] = None
     max: Optional[float] = None

--- a/frontend/src/app/api/addon/[...path]/route.ts
+++ b/frontend/src/app/api/addon/[...path]/route.ts
@@ -91,14 +91,46 @@ async function proxy(
     }
 
     const respHeaders = filterHeaders(upstreamResp.headers, STRIP_RESPONSE_HEADERS);
-    return new Response(
-        method === "HEAD" ? null : upstreamResp.body,
-        {
+
+    // Connection: close を明示的に消して keep-alive が維持されるようにする。
+    // <audio> 要素が 206 レスポンス + Connection: close の組み合わせで、
+    // Content-Length 到達前に早期停止するケースがあるため。
+    respHeaders.delete("connection");
+    respHeaders.delete("keep-alive");
+
+    // 音声/動画など大きなメディアは「ストリーム素通し」だと Node fetch → Next
+    // ランタイム間のバックプレッシャーで upstream 側の socket が早期 close
+    // される事象が観測された (curl は問題なし、<audio> のみで再現)。
+    // メディア系 Content-Type のみバッファ展開してから返すことで、
+    // ブラウザ側への転送を Next ランタイム内完結にする。
+    const contentType = upstreamResp.headers.get("content-type") ?? "";
+    const isMedia =
+        contentType.startsWith("audio/") ||
+        contentType.startsWith("video/") ||
+        contentType.startsWith("image/");
+
+    if (method === "HEAD") {
+        return new Response(null, {
             status: upstreamResp.status,
             statusText: upstreamResp.statusText,
             headers: respHeaders,
-        },
-    );
+        });
+    }
+
+    if (isMedia) {
+        const buffer = await upstreamResp.arrayBuffer();
+        return new Response(buffer, {
+            status: upstreamResp.status,
+            statusText: upstreamResp.statusText,
+            headers: respHeaders,
+        });
+    }
+
+    return new Response(upstreamResp.body, {
+        status: upstreamResp.status,
+        statusText: upstreamResp.statusText,
+        headers: respHeaders,
+    });
 }
 
 export const GET = proxy;

--- a/frontend/src/app/api/addon/[...path]/route.ts
+++ b/frontend/src/app/api/addon/[...path]/route.ts
@@ -1,0 +1,110 @@
+/**
+ * Next.js Route Handler: generic pass-through proxy for /api/addon/*.
+ *
+ * Why this exists — a more specific replacement for the global `/api/:path*`
+ * rewrite in `next.config.ts`:
+ *
+ *   - `<audio>` 要素は長めの音声ファイルを HTTP Range リクエスト
+ *     (`Range: bytes=X-`) で分割ロードする。
+ *   - しかし Next.js の `rewrites` 経由だと Range ヘッダや 206 Partial Content
+ *     レスポンスが正しく中継されず、バッファが尽きた時点で再生が途中で停止する
+ *     (特に Turbopack 下、2〜3 分程度の音声でも再現)。
+ *   - ここで fetch → ReadableStream の素通しプロキシに置き換えることで、
+ *     Range / 206 / Content-Range / Accept-Ranges をすべて維持する。
+ *
+ * 既存の `/api/addon/events/route.ts` (SSE 専用) は、より特定のパスなので
+ * このキャッチオール Route Handler より優先される。
+ */
+import type { NextRequest } from "next/server";
+
+const BACKEND = process.env.SAIVERSE_BACKEND_URL ?? "http://127.0.0.1:8000";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 3600;
+
+// リクエスト転送時に落とすヘッダ（hop-by-hop or fetch が自動付与するもの）。
+const STRIP_REQUEST_HEADERS = new Set([
+    "host",
+    "connection",
+    "content-length",
+    "transfer-encoding",
+    "accept-encoding", // 自動再エンコードで Range 計算が狂うのを防ぐ
+]);
+
+// レスポンス側で取り除くヘッダ。content-length / content-encoding は Node の
+// 自動再エンコードでズレるため明示排除。
+const STRIP_RESPONSE_HEADERS = new Set([
+    "content-encoding",
+    "transfer-encoding",
+    "connection",
+]);
+
+function filterHeaders(src: Headers, strip: Set<string>): Headers {
+    const out = new Headers();
+    src.forEach((value, key) => {
+        if (!strip.has(key.toLowerCase())) {
+            out.set(key, value);
+        }
+    });
+    return out;
+}
+
+async function proxy(
+    req: NextRequest,
+    context: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+    const { path } = await context.params;
+    const upstream = new URL(
+        `/api/addon/${path.map(encodeURIComponent).join("/")}`,
+        BACKEND,
+    );
+    // クエリ文字列もそのまま引き継ぐ
+    const reqUrl = new URL(req.url);
+    upstream.search = reqUrl.search;
+
+    const method = req.method.toUpperCase();
+    const headers = filterHeaders(req.headers, STRIP_REQUEST_HEADERS);
+
+    const hasBody = method !== "GET" && method !== "HEAD";
+
+    let upstreamResp: Response;
+    try {
+        const init: RequestInit & { duplex?: "half" } = {
+            method,
+            headers,
+            signal: req.signal,
+            // Next.js/Node の fetch は redirect を自動で追うので明示的に manual
+            // (FastAPI が 307 を返すケースでクライアントに見せたい)。
+            redirect: "manual",
+        };
+        if (hasBody) {
+            init.body = req.body as BodyInit | null;
+            // Node 18+ の fetch で ReadableStream を送るには duplex 必須。
+            init.duplex = "half";
+        }
+        upstreamResp = await fetch(upstream, init);
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("[addon-proxy] upstream fetch failed:", method, upstream.pathname, msg);
+        return new Response(`upstream fetch failed: ${msg}`, { status: 502 });
+    }
+
+    const respHeaders = filterHeaders(upstreamResp.headers, STRIP_RESPONSE_HEADERS);
+    return new Response(
+        method === "HEAD" ? null : upstreamResp.body,
+        {
+            status: upstreamResp.status,
+            statusText: upstreamResp.statusText,
+            headers: respHeaders,
+        },
+    );
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const DELETE = proxy;
+export const PATCH = proxy;
+export const HEAD = proxy;
+export const OPTIONS = proxy;

--- a/frontend/src/app/api/addon/[...path]/route.ts
+++ b/frontend/src/app/api/addon/[...path]/route.ts
@@ -66,6 +66,21 @@ async function proxy(
     const method = req.method.toUpperCase();
     const headers = filterHeaders(req.headers, STRIP_REQUEST_HEADERS);
 
+    // audio/video 系 GET は Range ヘッダを剥がして常に 200 OK で全量取得する。
+    // Chrome の <audio> は progressive streaming (Range + 206) モードだと
+    // 途中でソケットを読み止めるケースがあり (Chrome 内部バッファ制御の副作用)、
+    // 結果として長時間音声が途中で停止する事象になっていた。シーク機能は
+    // 犠牲になるが、<audio> 要素は duration 判明後なら currentTime 書き込みで
+    // 擬似シーク可能なので実用上の影響は小さい。
+    const isMediaGet =
+        method === "GET" &&
+        (/\/audio\//.test(upstream.pathname) ||
+            /\/video\//.test(upstream.pathname) ||
+            /\.(wav|mp3|ogg|flac|mp4|webm|mov|m4a|aac)$/i.test(upstream.pathname));
+    if (isMediaGet) {
+        headers.delete("range");
+    }
+
     const hasBody = method !== "GET" && method !== "HEAD";
 
     let upstreamResp: Response;

--- a/frontend/src/components/AddonManagerModal.module.css
+++ b/frontend/src/components/AddonManagerModal.module.css
@@ -467,40 +467,59 @@
     gap: 0.5rem;
 }
 
-.addPersonaBtn {
-    background: none;
-    border: 1px solid #e2e8f0;
-    border-radius: 0.4rem;
-    cursor: pointer;
-    padding: 0.2rem 0.3rem;
+.personaSelectorRow {
     display: flex;
     align-items: center;
-    color: #64748b;
-    transition: all 0.15s;
+    gap: 0.5rem;
 }
 
-.addPersonaBtn:hover {
-    border-color: #6366f1;
-    color: #6366f1;
-}
-
-.personaPickerList {
-    border: 1px solid #e2e8f0;
-    border-radius: 0.5rem;
-    overflow-y: auto;
-    max-height: 200px;
-}
-
-.personaPickerItem {
-    padding: 0.5rem 0.75rem;
+.personaSelector {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
     font-size: 0.88rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.4rem;
+    background: #ffffff;
     color: #374151;
     cursor: pointer;
-    transition: background 0.1s;
+    transition: border-color 0.15s;
 }
 
-.personaPickerItem:hover {
-    background: #f1f5f9;
+.personaSelector:hover {
+    border-color: #6366f1;
+}
+
+.personaSelector:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.personaUnconfiguredHint {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px dashed #cbd5e1;
+    border-radius: 0.5rem;
+    font-size: 0.85rem;
+    color: #64748b;
+}
+
+.createPersonaConfigBtn {
+    background: #6366f1;
+    color: #ffffff;
+    border: none;
+    border-radius: 0.4rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.createPersonaConfigBtn:hover {
+    background: #4f46e5;
 }
 
 .personaConfigBlock {
@@ -512,41 +531,21 @@
     gap: 0.4rem;
 }
 
-.personaConfigHeader {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 0.25rem;
-    user-select: none;
-}
-
-.personaConfigHeaderLeft {
-    display: flex;
-    align-items: center;
-    gap: 0.3rem;
-    color: #94a3b8;
-}
-
-.personaName {
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: #475569;
-}
-
 .deletePersonaBtn {
     background: none;
-    border: none;
+    border: 1px solid #e2e8f0;
     cursor: pointer;
     color: #cbd5e1;
-    padding: 0.15rem;
+    padding: 0.35rem 0.4rem;
     display: flex;
     align-items: center;
-    border-radius: 0.25rem;
-    transition: color 0.15s;
+    border-radius: 0.4rem;
+    transition: all 0.15s;
 }
 
 .deletePersonaBtn:hover {
     color: #ef4444;
+    border-color: #ef4444;
 }
 
 /* toggle used standalone (inside ParamsSection) */
@@ -658,38 +657,27 @@
     color: #94a3b8;
 }
 
-:global([data-theme="dark"]) .personaPickerList {
-    border-color: #334155;
-}
-
-:global([data-theme="dark"]) .personaPickerItem {
-    color: #cbd5e1;
-}
-
-:global([data-theme="dark"]) .personaPickerItem:hover {
+:global([data-theme="dark"]) .personaSelector {
     background: #0f172a;
+    border-color: #334155;
+    color: #e2e8f0;
+}
+
+:global([data-theme="dark"]) .personaSelector:hover {
+    border-color: #6366f1;
+}
+
+:global([data-theme="dark"]) .personaUnconfiguredHint {
+    border-color: #334155;
+    color: #94a3b8;
 }
 
 :global([data-theme="dark"]) .personaConfigBlock {
     border-color: #334155;
 }
 
-:global([data-theme="dark"]) .personaName {
-    color: #94a3b8;
-}
-
-:global([data-theme="dark"]) .personaConfigHeaderLeft {
-    color: #64748b;
-}
-
-:global([data-theme="dark"]) .addPersonaBtn {
+:global([data-theme="dark"]) .deletePersonaBtn {
     border-color: #334155;
-    color: #94a3b8;
-}
-
-:global([data-theme="dark"]) .addPersonaBtn:hover {
-    border-color: #6366f1;
-    color: #6366f1;
 }
 
 :global([data-theme="dark"]) .toggleSlider {

--- a/frontend/src/components/AddonManagerModal.module.css
+++ b/frontend/src/components/AddonManagerModal.module.css
@@ -467,12 +467,6 @@
     gap: 0.5rem;
 }
 
-.personaSelectorRow {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
 .personaSelector {
     flex: 1;
     padding: 0.4rem 0.6rem;
@@ -529,23 +523,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
-}
-
-.deletePersonaBtn {
-    background: none;
-    border: 1px solid #e2e8f0;
-    cursor: pointer;
-    color: #cbd5e1;
-    padding: 0.35rem 0.4rem;
-    display: flex;
-    align-items: center;
-    border-radius: 0.4rem;
-    transition: all 0.15s;
-}
-
-.deletePersonaBtn:hover {
-    color: #ef4444;
-    border-color: #ef4444;
 }
 
 /* toggle used standalone (inside ParamsSection) */
@@ -673,10 +650,6 @@
 }
 
 :global([data-theme="dark"]) .personaConfigBlock {
-    border-color: #334155;
-}
-
-:global([data-theme="dark"]) .deletePersonaBtn {
     border-color: #334155;
 }
 

--- a/frontend/src/components/AddonManagerModal.tsx
+++ b/frontend/src/components/AddonManagerModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { X, Package, ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+import { X, Package, ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
 import ModalOverlay from './common/ModalOverlay';
 import styles from './AddonManagerModal.module.css';
 
@@ -18,6 +18,7 @@ interface AddonParamSchema {
     persona_configurable: boolean;
     placeholder?: string;
     options?: string[];
+    options_endpoint?: string;
     min?: number;
     max?: number;
     step?: number;
@@ -119,15 +120,12 @@ function ParamControl({
 
         case 'dropdown':
             return (
-                <select
-                    className={styles.select}
-                    value={String(current ?? '')}
-                    onChange={(e) => onChange(schema.key, e.target.value)}
-                >
-                    {(schema.options ?? []).map((opt) => (
-                        <option key={opt} value={opt}>{opt}</option>
-                    ))}
-                </select>
+                <DropdownParamControl
+                    schema={schema}
+                    value={current}
+                    onChange={onChange}
+                    addonName={addonName}
+                />
             );
 
         case 'slider': {
@@ -170,6 +168,61 @@ function ParamControl({
         default:
             return <span className={styles.unsupported}>（未対応の型: {schema.type}）</span>;
     }
+}
+
+// ---------------------------------------------------------------------------
+// DropdownParamControl — static options or dynamically fetched from addon API
+// ---------------------------------------------------------------------------
+
+function DropdownParamControl({
+    schema,
+    value,
+    onChange,
+    addonName,
+}: {
+    schema: AddonParamSchema;
+    value: unknown;
+    onChange: (key: string, val: unknown) => void;
+    addonName?: string;
+}) {
+    const [dynamicOptions, setDynamicOptions] = useState<string[] | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!schema.options_endpoint || !addonName) return;
+        const ep = schema.options_endpoint;
+        const url = ep.startsWith('/') ? ep : `/api/addon/${addonName}/${ep}`;
+        setLoading(true);
+        fetch(url)
+            .then((r) => r.json())
+            .then((data) => {
+                // 想定レスポンス: {"options": [...]} または [...]（プレーン配列）
+                const opts: unknown = Array.isArray(data) ? data : data?.options;
+                if (Array.isArray(opts)) {
+                    setDynamicOptions(opts.map((o) => String(o)));
+                }
+            })
+            .catch(() => setDynamicOptions([]))
+            .finally(() => setLoading(false));
+    }, [schema.options_endpoint, addonName]);
+
+    const options = dynamicOptions ?? schema.options ?? [];
+    const current = value !== undefined ? value : schema.default;
+
+    return (
+        <select
+            className={styles.select}
+            value={String(current ?? '')}
+            onChange={(e) => onChange(schema.key, e.target.value)}
+            disabled={loading}
+        >
+            {loading && <option value="">読み込み中...</option>}
+            {!loading && options.length === 0 && <option value="">（選択肢なし）</option>}
+            {!loading && options.map((opt) => (
+                <option key={opt} value={opt}>{opt}</option>
+            ))}
+        </select>
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -341,17 +394,7 @@ function ParamsSection({
     const [globalParams, setGlobalParams] = useState<Record<string, unknown>>(addon.params ?? {});
     const [personaConfigs, setPersonaConfigs] = useState<PersonaPersonaConfig[]>([]);
     const [saving, setSaving] = useState(false);
-    const [addingPersona, setAddingPersona] = useState(false);
-    const [collapsedPersonas, setCollapsedPersonas] = useState<Set<string>>(new Set());
-
-    const togglePersonaCollapse = (personaId: string) => {
-        setCollapsedPersonas((prev) => {
-            const next = new Set(prev);
-            if (next.has(personaId)) next.delete(personaId);
-            else next.add(personaId);
-            return next;
-        });
-    };
+    const [selectedPersonaId, setSelectedPersonaId] = useState<string>('');
 
     const configurableSchemas = addon.params_schema.filter((s) => !s.persona_configurable);
     const personaConfigurableSchemas = addon.params_schema.filter((s) => s.persona_configurable);
@@ -427,16 +470,14 @@ function ParamsSection({
         const newConfig: PersonaPersonaConfig = { persona_id: personaId, persona_name: personaName, params: defaultParams };
         setPersonaConfigs((prev) => [...prev, newConfig]);
         savePersona(personaId, defaultParams);
-        setAddingPersona(false);
     };
 
-    if (configurableSchemas.length === 0) {
+    if (configurableSchemas.length === 0 && personaConfigurableSchemas.length === 0) {
         return <p className={styles.noParams}>設定項目はありません</p>;
     }
 
-    const unconfiguredPersonas = personas.filter(
-        (p) => !personaConfigs.find((c) => c.persona_id === p.id)
-    );
+    const selectedConfig = personaConfigs.find((c) => c.persona_id === selectedPersonaId);
+    const selectedPersona = personas.find((p) => p.id === selectedPersonaId);
 
     return (
         <div className={styles.paramsSection}>
@@ -462,70 +503,65 @@ function ParamsSection({
                 <div className={styles.personaSection}>
                     <div className={styles.personaSectionHeader}>
                         <span className={styles.paramsGroupLabel}>ペルソナ別設定</span>
-                        {unconfiguredPersonas.length > 0 && (
+                    </div>
+
+                    <div className={styles.personaSelectorRow}>
+                        <select
+                            className={styles.personaSelector}
+                            value={selectedPersonaId}
+                            onChange={(e) => setSelectedPersonaId(e.target.value)}
+                        >
+                            <option value="">-- ペルソナを選択 --</option>
+                            {personas.map((p) => {
+                                const isConfigured = personaConfigs.some((c) => c.persona_id === p.id);
+                                return (
+                                    <option key={p.id} value={p.id}>
+                                        {p.name}{isConfigured ? '' : '（未設定）'}
+                                    </option>
+                                );
+                            })}
+                        </select>
+                        {selectedConfig && (
                             <button
-                                className={styles.addPersonaBtn}
-                                onClick={() => setAddingPersona((v) => !v)}
-                                title="ペルソナを追加"
+                                className={styles.deletePersonaBtn}
+                                onClick={() => {
+                                    deletePersonaConfig(selectedPersonaId);
+                                }}
+                                title="削除（デフォルトに戻す）"
                             >
-                                <Plus size={14} />
+                                <Trash2 size={13} />
                             </button>
                         )}
                     </div>
 
-                    {addingPersona && (
-                        <div className={styles.personaPickerList}>
-                            {unconfiguredPersonas.map((p) => (
-                                <div
-                                    key={p.id}
-                                    className={styles.personaPickerItem}
-                                    onClick={() => addPersonaConfig(p.id, p.name)}
-                                >
-                                    {p.name}
+                    {selectedPersonaId && !selectedConfig && selectedPersona && (
+                        <div className={styles.personaUnconfiguredHint}>
+                            <span>このペルソナには個別設定がありません。</span>
+                            <button
+                                className={styles.createPersonaConfigBtn}
+                                onClick={() => addPersonaConfig(selectedPersona.id, selectedPersona.name)}
+                            >
+                                個別設定を作成
+                            </button>
+                        </div>
+                    )}
+
+                    {selectedConfig && (
+                        <div className={styles.personaConfigBlock}>
+                            {personaConfigurableSchemas.map((schema) => (
+                                <div key={schema.key} className={styles.paramRow}>
+                                    <span className={styles.paramLabel}>{schema.label}</span>
+                                    <ParamControl
+                                        schema={schema}
+                                        value={selectedConfig.params[schema.key]}
+                                        onChange={(key, val) => handlePersonaChange(selectedConfig.persona_id, key, val)}
+                                        addonName={addon.addon_name}
+                                        personaId={selectedConfig.persona_id}
+                                    />
                                 </div>
                             ))}
                         </div>
                     )}
-
-                    {personaConfigs.map((pc) => {
-                        const isCollapsed = collapsedPersonas.has(pc.persona_id);
-                        return (
-                            <div key={pc.persona_id} className={styles.personaConfigBlock}>
-                                <div
-                                    className={styles.personaConfigHeader}
-                                    onClick={() => togglePersonaCollapse(pc.persona_id)}
-                                    style={{ cursor: 'pointer' }}
-                                >
-                                    <div className={styles.personaConfigHeaderLeft}>
-                                        {isCollapsed
-                                            ? <ChevronRight size={13} />
-                                            : <ChevronDown size={13} />
-                                        }
-                                        <span className={styles.personaName}>{pc.persona_name}</span>
-                                    </div>
-                                    <button
-                                        className={styles.deletePersonaBtn}
-                                        onClick={(e) => { e.stopPropagation(); deletePersonaConfig(pc.persona_id); }}
-                                        title="削除（デフォルトに戻す）"
-                                    >
-                                        <Trash2 size={13} />
-                                    </button>
-                                </div>
-                                {!isCollapsed && personaConfigurableSchemas.map((schema) => (
-                                    <div key={schema.key} className={styles.paramRow}>
-                                        <span className={styles.paramLabel}>{schema.label}</span>
-                                        <ParamControl
-                                            schema={schema}
-                                            value={pc.params[schema.key]}
-                                            onChange={(key, val) => handlePersonaChange(pc.persona_id, key, val)}
-                                            addonName={addon.addon_name}
-                                            personaId={pc.persona_id}
-                                        />
-                                    </div>
-                                ))}
-                            </div>
-                        );
-                    })}
                 </div>
             )}
         </div>

--- a/frontend/src/components/AddonManagerModal.tsx
+++ b/frontend/src/components/AddonManagerModal.tsx
@@ -443,13 +443,6 @@ function ParamsSection({
         });
     };
 
-    const deletePersonaConfig = async (personaId: string) => {
-        await fetch(`/api/addon/${addon.addon_name}/config/persona/${personaId}`, {
-            method: 'DELETE',
-        });
-        setPersonaConfigs((prev) => prev.filter((c) => c.persona_id !== personaId));
-    };
-
     const handlePersonaChange = (personaId: string, key: string, val: unknown) => {
         setPersonaConfigs((prev) => {
             const next = prev.map((c) =>
@@ -505,34 +498,21 @@ function ParamsSection({
                         <span className={styles.paramsGroupLabel}>ペルソナ別設定</span>
                     </div>
 
-                    <div className={styles.personaSelectorRow}>
-                        <select
-                            className={styles.personaSelector}
-                            value={selectedPersonaId}
-                            onChange={(e) => setSelectedPersonaId(e.target.value)}
-                        >
-                            <option value="">-- ペルソナを選択 --</option>
-                            {personas.map((p) => {
-                                const isConfigured = personaConfigs.some((c) => c.persona_id === p.id);
-                                return (
-                                    <option key={p.id} value={p.id}>
-                                        {p.name}{isConfigured ? '' : '（未設定）'}
-                                    </option>
-                                );
-                            })}
-                        </select>
-                        {selectedConfig && (
-                            <button
-                                className={styles.deletePersonaBtn}
-                                onClick={() => {
-                                    deletePersonaConfig(selectedPersonaId);
-                                }}
-                                title="削除（デフォルトに戻す）"
-                            >
-                                <Trash2 size={13} />
-                            </button>
-                        )}
-                    </div>
+                    <select
+                        className={styles.personaSelector}
+                        value={selectedPersonaId}
+                        onChange={(e) => setSelectedPersonaId(e.target.value)}
+                    >
+                        <option value="">-- ペルソナを選択 --</option>
+                        {personas.map((p) => {
+                            const isConfigured = personaConfigs.some((c) => c.persona_id === p.id);
+                            return (
+                                <option key={p.id} value={p.id}>
+                                    {p.name}{isConfigured ? '' : '（未設定）'}
+                                </option>
+                            );
+                        })}
+                    </select>
 
                     {selectedPersonaId && !selectedConfig && selectedPersona && (
                         <div className={styles.personaUnconfiguredHint}>


### PR DESCRIPTION
## Summary
- アドオン管理UIのペルソナ別設定をアコーディオン方式からプルダウン選択方式に変更
- dropdown 型 params_schema に動的 options 対応 (`options_endpoint`) を追加
- 長時間音声 (2分以上) が `<audio>` 要素で途中停止する問題を修正

## 変更内容

### 1. ペルソナ別設定UIの改修 (`f27e460`, `af3cc56`)
アコーディオンが自動展開されて画面を埋める問題を解消するため、プルダウンで1ペルソナだけ選択して設定する方式に変更。未設定ペルソナは「（未設定）」サフィックス付きで選択可、選択後に「個別設定を作成」ボタンで初期化。利用頻度の低いプルダウン横の「削除（デフォルトに戻す）」ボタンは撤去。

### 2. dropdown 型の動的 options 対応 (`f27e460`)
`AddonParamSchema.options_endpoint` を新設。指定されたアドオンローカル or 絶対パスのエンドポイントから選択肢を fetch するようにし、拡張パックが動的な選択肢（接続デバイス一覧等）を提供できるようにした。

### 3. 長時間音声の途中停止修正 (`0bab614`, `b3fe7a1`, `6351098`)
原因: Next.js `rewrites` と Node fetch → Next ランタイムの組み合わせで、`<audio>` 要素の Range リクエスト＋206 Partial Content 中継が破綻し、バッファ枯渇時のソケット close に `<audio>` が反応して途中停止する。同じ音声でも停止位置が 2:05〜2:17 でバラつくのはこの副作用。

対処を3段階で積み上げ:
- `/api/addon/[...path]/route.ts` 汎用 Route Handler を新設し `rewrites` から移行
- メディア系 Content-Type は `arrayBuffer()` でランタイム側にフル展開してから返す
- audio/video 系 GET は Range ヘッダを剥がして 200 OK で全量取得 (progressive streaming 由来の詰まり経路を無効化)

結果として `curl` ✓ / file:// ✓ だけでなく Chrome `<audio>` ✓ で 4分以上の音声が最後まで再生できるようになった。

## Test plan
- [x] ペルソナ別設定のプルダウンで1ペルソナだけ選択・編集できる
- [x] 未設定ペルソナを選ぶと「個別設定を作成」ボタンが表示される
- [x] 4:11 の長時間音声がブラウザで最後まで再生できる
- [x] 動的 options の dropdown (拡張パック `saiverse-voice-tts` の出力デバイス選択) が正しく表示される
- [x] SSE (`/api/addon/events`) の挙動は従来通り (より特定の Route Handler が優先される)
- [ ] 他アドオン (もしあれば) のエンドポイントが従来通り動く

## 関連
拡張パック `saiverse-voice-tts` 側で本 PR の `options_endpoint` を利用する機能あり:
https://github.com/Nature109/saiverse-voice-tts/pull/new/experiment/output-device
