### PR TITLE
feat(addon): external/ ライブラリの名前空間隔離機構を追加(再発防止)

### DIFF
--- a/saiverse/addon_external_loader.py
+++ b/saiverse/addon_external_loader.py
@@ -1,0 +1,372 @@
+"""アドオン external/ 配下ライブラリの名前空間隔離ローダ。
+
+## 解決したい問題
+
+アドオン (拡張パック) は ``expansion_data/<addon>/external/`` 配下に、
+上流リポジトリ (例: GPT-SoVITS, Whisper 等) を直接 clone して取り込む。
+これらの上流コードはトップレベルに ``tools/`` ``utils/`` などの汎用名で
+パッケージを持つことが多く、SAIVerse 本体側の ``tools/`` などと **同名衝突**
+する。
+
+従来の対策(各パックが ``sys.modules['tools']`` を一時的に剥がす context
+manager)はシリアル実行では動くが、**並列スレッドで本体側 import が走ると
+パック側の external/ tools を掴んでしまう**(2026-04 時点で
+``addon_spell_help`` で実際に発生)。
+
+## このモジュールの方針
+
+ホスト側で1個だけ実装し、各パックの ``external/`` を**呼び出し元コードの
+ファイルパスベース**で振り分ける。
+
+1. パック登録時に ``external/<lib>/`` 配下から「ホスト top-level と同名」の
+   パッケージを検出し、``addons.<sanitized_addon>.<name>`` として
+   ``sys.modules`` に事前ロードする。
+2. ``builtins.__import__`` をパッチして、絶対 import が呼ばれた際に:
+   - 名前のトップ要素が「いずれかの登録パックでの衝突候補」なら
+   - 呼び出し元の ``__file__`` を見て、それが登録 external/ 配下なら
+   - その登録の ``addons.<sanitized_addon>.<name>`` 名前空間にリダイレクト
+3. ホスト側コードからの import は呼び出し元が external/ 配下ではないため
+   常にホスト本来の名前空間に解決される。
+
+呼び出し元判定はファイルパス(``__file__``)ベースなので、複数スレッドが
+並列実行しても**どのスレッドが import しているかではなく、どのコードが
+import しているか**で名前解決が決まる。スレッド間の汚染が原理的に発生しない。
+
+## パック作者向けの利点
+
+パック側で ``sys.modules['tools']`` を剥がす hack は不要。``external/`` を
+普通に sys.path に追加して上流コードを import するだけで、衝突は本機構が
+透過的に解決する。
+"""
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import logging
+import sys
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Set
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Host top-level package detection
+# ---------------------------------------------------------------------------
+
+
+def _saiverse_root() -> Path:
+    """SAIVerse リポジトリの root を返す (saiverse/ の親)。"""
+    return Path(__file__).resolve().parent.parent
+
+
+_HOST_TOP_LEVEL_CACHE: Optional[Set[str]] = None
+
+
+def _detect_host_top_level() -> Set[str]:
+    """SAIVerse 直下の top-level Python パッケージ/モジュール名を列挙する。
+
+    addon の external 内コードがこれらの名前を絶対 import すると、
+    ホスト側パッケージとの衝突候補となる。
+    """
+    global _HOST_TOP_LEVEL_CACHE
+    if _HOST_TOP_LEVEL_CACHE is not None:
+        return _HOST_TOP_LEVEL_CACHE
+
+    root = _saiverse_root()
+    names: Set[str] = set()
+    if not root.exists():
+        _HOST_TOP_LEVEL_CACHE = names
+        return names
+
+    skip_dirs = {".git", ".venv", "node_modules", "__pycache__",
+                 "expansion_data", "external", "frontend", "sbert",
+                 "user_data", "test_data"}
+    for entry in root.iterdir():
+        if entry.name.startswith(".") or entry.name in skip_dirs:
+            continue
+        if entry.is_dir() and (entry / "__init__.py").exists():
+            names.add(entry.name)
+        elif entry.is_file() and entry.suffix == ".py" and entry.stem != "__init__":
+            names.add(entry.stem)
+    _HOST_TOP_LEVEL_CACHE = names
+    LOGGER.debug("addon_external_loader: host top-level=%s", sorted(names))
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Registration data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Registration:
+    """1個のアドオンに対する登録情報。"""
+
+    addon_name: str  # オリジナル名 (ハイフンを含むことがある)
+    sanitized_name: str  # Python 識別子に正規化した名前
+    external_root: Path  # external/ ディレクトリ (絶対パス、解決済み)
+    namespace_prefix: str  # ``addons.<sanitized>``
+    # external/<lib>/<name> として実在し、かつホスト top-level と衝突する名前
+    conflicting_names: Set[str] = field(default_factory=set)
+    # name -> 物理パス (__init__.py または .py)
+    name_to_path: Dict[str, Path] = field(default_factory=dict)
+
+
+_lock = threading.Lock()
+_registrations: Dict[str, _Registration] = {}  # sanitized_name -> registration
+_import_patched = False
+_original_import = builtins.__import__
+
+
+# ---------------------------------------------------------------------------
+# __import__ patching
+# ---------------------------------------------------------------------------
+
+
+def _is_under(file_path: Path, root: Path) -> bool:
+    """``file_path`` が ``root`` 以下にあるか。例外なしで判定する。"""
+    try:
+        file_path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_caller_file(caller_globals: Optional[Dict[str, Any]]) -> Optional[Path]:
+    if not caller_globals:
+        return None
+    fname = caller_globals.get("__file__")
+    if not fname:
+        return None
+    try:
+        return Path(fname).resolve()
+    except (OSError, ValueError):
+        return None
+
+
+def _find_redirect(name: str, caller_globals: Optional[Dict[str, Any]]) -> Optional[str]:
+    """absolute import (level=0) の name が、登録パックの external/ 配下から
+    呼ばれた衝突名なら、リダイレクト先名を返す。該当しなければ None。
+    """
+    if not _registrations or not name:
+        return None
+    top = name.split(".", 1)[0]
+
+    # まず top が「いずれかの登録に属する衝突名」かどうかをホット判定
+    candidates = [
+        reg for reg in _registrations.values() if top in reg.conflicting_names
+    ]
+    if not candidates:
+        return None
+
+    caller_file = _resolve_caller_file(caller_globals)
+    if not caller_file:
+        return None
+
+    for reg in candidates:
+        if _is_under(caller_file, reg.external_root):
+            return f"{reg.namespace_prefix}.{name}"
+    return None
+
+
+def _patched_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if level == 0 and name:
+        redirect = _find_redirect(name, globals)
+        if redirect is not None:
+            LOGGER.debug(
+                "addon_external_loader: redirect %r -> %r (caller=%s)",
+                name, redirect,
+                globals.get("__file__") if globals else None,
+            )
+            return _original_import(redirect, globals, locals, fromlist, level)
+    return _original_import(name, globals, locals, fromlist, level)
+
+
+def _ensure_import_patched() -> None:
+    global _import_patched
+    if _import_patched:
+        return
+    builtins.__import__ = _patched_import
+    _import_patched = True
+    LOGGER.info("addon_external_loader: __import__ patched for namespace isolation")
+
+
+def _ensure_addons_namespace() -> None:
+    """``addons`` および ``addons.<sanitized>`` 仮想パッケージを sys.modules に登録。"""
+    if "addons" not in sys.modules:
+        addons_module = type(sys)("addons")
+        # 名前空間パッケージとして空のパスリストを持たせる
+        addons_module.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["addons"] = addons_module
+
+
+def _ensure_addon_namespace(reg: _Registration) -> None:
+    if reg.namespace_prefix in sys.modules:
+        return
+    addon_module = type(sys)(reg.namespace_prefix)
+    addon_module.__path__ = [str(reg.external_root)]  # type: ignore[attr-defined]
+    sys.modules[reg.namespace_prefix] = addon_module
+
+
+# ---------------------------------------------------------------------------
+# Pre-loading conflicting packages under namespaced names
+# ---------------------------------------------------------------------------
+
+
+def _preload_conflicting(reg: _Registration) -> None:
+    """external/<lib>/<conflict_name> を addons.<sanitized>.<conflict_name> として
+    sys.modules に事前ロードする。
+
+    これにより、リダイレクト先 ``addons.<sanitized>.tools.audio_sr`` のような
+    深い名前を ``__import__`` が解決できる(リダイレクト後のパスでパッケージを
+    探す際、トップ要素 ``addons.<sanitized>.tools`` が既に登録済みであれば
+    その submodule_search_locations 経由でサブモジュールを発見できる)。
+    """
+    for conflict_name, source_path in reg.name_to_path.items():
+        full_name = f"{reg.namespace_prefix}.{conflict_name}"
+        if full_name in sys.modules:
+            continue
+        try:
+            if source_path.is_dir():
+                init_file = source_path / "__init__.py"
+                if not init_file.exists():
+                    continue
+                spec = importlib.util.spec_from_file_location(
+                    full_name,
+                    str(init_file),
+                    submodule_search_locations=[str(source_path)],
+                )
+            else:
+                spec = importlib.util.spec_from_file_location(
+                    full_name, str(source_path)
+                )
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[full_name] = module
+            spec.loader.exec_module(module)
+            LOGGER.debug(
+                "addon_external_loader: pre-loaded %s from %s",
+                full_name, source_path,
+            )
+        except Exception:
+            # ロード失敗時は cache を引き上げて、後続の import 時に再試行できる
+            # ようにする(本機構の責任範囲を超えるので警告のみ)。
+            sys.modules.pop(full_name, None)
+            LOGGER.warning(
+                "addon_external_loader: failed to pre-load %s from %s",
+                full_name, source_path, exc_info=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def register_addon_external(addon_name: str, external_root: Path) -> None:
+    """指定アドオンの external/ ディレクトリを名前空間隔離下に登録する。
+
+    Args:
+        addon_name: アドオン名 (パックの addon.json の name)。ハイフンを含んでも可。
+        external_root: ``expansion_data/<addon>/external/`` のような Path。
+
+    呼ばれた後の挙動:
+        - ``external_root/<lib>/<name>`` のうちホスト top-level と衝突する名前を検出
+        - 検出した各パッケージを ``addons.<sanitized>.<name>`` として sys.modules に事前ロード
+        - ``builtins.__import__`` をパッチ(初回のみ)
+        - 以降、external/ 配下のコードが ``import <name>`` した際、自動的に
+          名前空間版にリダイレクトされる
+
+    呼び出し元コードからの ``import <name>`` は引き続きホスト本来の名前空間に解決される。
+    """
+    if not external_root.exists():
+        LOGGER.debug(
+            "addon_external_loader: %s/external does not exist, skipping (%s)",
+            addon_name, external_root,
+        )
+        return
+
+    sanitized = addon_name.replace("-", "_").replace(".", "_")
+    if not sanitized.isidentifier():
+        LOGGER.warning(
+            "addon_external_loader: addon name %r cannot be sanitized to identifier",
+            addon_name,
+        )
+        return
+
+    namespace_prefix = f"addons.{sanitized}"
+
+    with _lock:
+        if sanitized in _registrations:
+            LOGGER.debug(
+                "addon_external_loader: %s already registered, skipping",
+                addon_name,
+            )
+            return
+
+        host_top = _detect_host_top_level()
+        external_root_resolved = external_root.resolve()
+
+        # external_root/<lib>/<name> を走査し、ホスト top-level と衝突する name を
+        # その物理パスとともに収集
+        name_to_path: Dict[str, Path] = {}
+        for lib_dir in external_root_resolved.iterdir():
+            if not lib_dir.is_dir() or lib_dir.name.startswith("."):
+                continue
+            for entry in lib_dir.iterdir():
+                if entry.is_dir() and (entry / "__init__.py").exists():
+                    if entry.name in host_top and entry.name not in name_to_path:
+                        name_to_path[entry.name] = entry
+                elif entry.is_file() and entry.suffix == ".py":
+                    stem = entry.stem
+                    if stem in host_top and stem not in name_to_path and stem != "__init__":
+                        name_to_path[stem] = entry
+
+        if not name_to_path:
+            LOGGER.debug(
+                "addon_external_loader: %s has no host name conflicts under %s",
+                addon_name, external_root_resolved,
+            )
+            # 衝突がなければパッチ自体不要
+            return
+
+        reg = _Registration(
+            addon_name=addon_name,
+            sanitized_name=sanitized,
+            external_root=external_root_resolved,
+            namespace_prefix=namespace_prefix,
+            conflicting_names=set(name_to_path.keys()),
+            name_to_path=name_to_path,
+        )
+
+        _ensure_addons_namespace()
+        _ensure_addon_namespace(reg)
+        _preload_conflicting(reg)
+        _registrations[sanitized] = reg
+        _ensure_import_patched()
+
+        LOGGER.info(
+            "addon_external_loader: registered %s -> %s "
+            "(conflicting_names=%s)",
+            namespace_prefix, external_root_resolved,
+            sorted(reg.conflicting_names),
+        )
+
+
+def get_registered_addons() -> Iterable[str]:
+    """登録済みアドオン名 (sanitized) のイテレータ。診断/テスト用。"""
+    return tuple(_registrations.keys())
+
+
+def get_namespace_prefix(addon_name: str) -> Optional[str]:
+    """``register_addon_external`` で登録されたアドオンの名前空間プレフィックスを返す。
+
+    パック側で `importlib.import_module(prefix + '.GPT_SoVITS....')` などをする際に使う。
+    """
+    sanitized = addon_name.replace("-", "_").replace(".", "_")
+    reg = _registrations.get(sanitized)
+    return reg.namespace_prefix if reg else None

--- a/saiverse/addon_loader.py
+++ b/saiverse/addon_loader.py
@@ -16,11 +16,40 @@ from pathlib import Path
 LOGGER = logging.getLogger(__name__)
 
 
+def _register_addon_externals() -> None:
+    """expansion_data/ 下の全アドオンの external/ を名前空間隔離下に登録する。
+
+    各アドオンの api_routes.py を読み込む**前**に呼ぶ必要がある(隔離機構の
+    __import__ パッチが整ってから上流ライブラリを import するため)。
+    """
+    from saiverse.addon_external_loader import register_addon_external
+    from saiverse.data_paths import EXPANSION_DATA_DIR
+
+    if not EXPANSION_DATA_DIR.exists():
+        return
+    for addon_dir in sorted(EXPANSION_DATA_DIR.iterdir()):
+        if not addon_dir.is_dir():
+            continue
+        external_dir = addon_dir / "external"
+        if not external_dir.exists():
+            continue
+        try:
+            register_addon_external(addon_dir.name, external_dir)
+        except Exception:
+            LOGGER.exception(
+                "addon_loader: failed to register external/ for addon %r",
+                addon_dir.name,
+            )
+
+
 def load_addon_routers(app) -> None:
     """expansion_data/ 下の全アドオンの api_routes.py を自動ロードする。
 
     api_routes.py に `router` 属性（FastAPI APIRouter）が定義されていれば
     /api/addon/<addon_name>/ プレフィックスでマウントする。
+
+    本関数は同時に、各アドオンの ``external/`` ディレクトリを名前空間隔離
+    機構に登録する(本体側 ``tools`` 等とのトップレベル名前衝突を防ぐ)。
 
     Args:
         app: FastAPI アプリインスタンス
@@ -30,6 +59,9 @@ def load_addon_routers(app) -> None:
     if not EXPANSION_DATA_DIR.exists():
         LOGGER.debug("addon_loader: expansion_data/ not found, skipping")
         return
+
+    # external/ の名前空間隔離は **api_routes.py 読み込みより先**に行う。
+    _register_addon_externals()
 
     loaded_count = 0
     for addon_dir in sorted(EXPANSION_DATA_DIR.iterdir()):

--- a/tests/test_addon_external_loader.py
+++ b/tests/test_addon_external_loader.py
@@ -1,0 +1,260 @@
+"""addon_external_loader の動作検証 (再発防止テスト)。
+
+検証ポイント:
+1. 隔離機構なしで GPT-SoVITS の `from tools.audio_sr` を再現するとホスト側
+   tools と衝突して ImportError になる(ベースライン)
+2. register_addon_external を呼んだ後は同じ import が `addons.<addon>.tools.X`
+   へリダイレクトされて成功する
+3. **同じプロセス内**でホスト側コードからの `import tools` は引き続きホスト
+   tools を返す(リダイレクトは external/ 配下からの呼び出しのみ)
+4. **複数スレッドでの並列 import** で本体 tools とパック側 tools が混ざらない
+   (今回の不具合の再発検証)
+
+テストでは、ホスト側 ``tools`` パッケージを実物ではなくスタブで再現する
+(実物は重い依存をロードするため、テスト環境では不安定 + 副作用大)。
+スタブの責務は "host top-level パッケージとして検出される + import 経路上
+存在する" だけで十分。
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from pathlib import Path
+from textwrap import dedent
+
+# プロジェクトルートを sys.path へ
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def _make_fake_addon(tmp: Path, addon_name: str = "fake-pack") -> Path:
+    """テスト用に minimal な expansion_data 構造を作る。
+
+    layout:
+        tmp/
+          expansion_data/
+            fake-pack/
+              external/
+                FakeUpstream/
+                  tools/
+                    __init__.py        ← from tools.audio_sr import X が成立するか検証
+                    audio_sr.py        ← 'PACK_TOOLS_AUDIO_SR' を export
+                  consumer.py          ← 上流コードの代理(absolute import を行う)
+    """
+    addon_dir = tmp / "expansion_data" / addon_name
+    external_dir = addon_dir / "external" / "FakeUpstream"
+    tools_dir = external_dir / "tools"
+    tools_dir.mkdir(parents=True)
+
+    (tools_dir / "__init__.py").write_text(
+        "PACK_TOOLS_INIT = 'pack-tools'\n", encoding="utf-8"
+    )
+    (tools_dir / "audio_sr.py").write_text(
+        "PACK_TOOLS_AUDIO_SR = 'pack-audio-sr'\n", encoding="utf-8"
+    )
+
+    consumer_py = external_dir / "consumer.py"
+    consumer_py.write_text(
+        dedent(
+            """
+            # 上流ライブラリの代理。本体 tools/ ではなく自分の tools/ を見たい。
+            from tools.audio_sr import PACK_TOOLS_AUDIO_SR
+            from tools import PACK_TOOLS_INIT
+
+            def get_value():
+                return (PACK_TOOLS_INIT, PACK_TOOLS_AUDIO_SR)
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return external_dir
+
+
+def _install_host_tools_stub() -> types.ModuleType:
+    """ホスト側 ``tools`` パッケージのスタブを sys.modules に注入する。
+
+    本物の ``tools/`` は重い依存を伴うため、テストでは衝突再現の最小条件
+    (sys.modules に存在し、HOST_TOOLS_INIT 属性を持つ)だけ満たすスタブを使う。
+    """
+    if "tools" in sys.modules:
+        existing = sys.modules["tools"]
+        if hasattr(existing, "HOST_TOOLS_INIT"):
+            return existing
+    stub = types.ModuleType("tools")
+    stub.HOST_TOOLS_INIT = "host-tools"  # type: ignore[attr-defined]
+    stub.__path__ = []  # type: ignore[attr-defined]  # 名前空間パッケージ扱い
+    sys.modules["tools"] = stub
+    return stub
+
+
+class _SaveImportEnv:
+    """テスト前後で sys.modules / sys.path / __import__ を保存・復元する。"""
+
+    def __enter__(self):
+        import builtins
+        self._modules_backup = dict(sys.modules)
+        self._path_backup = list(sys.path)
+        self._import_backup = builtins.__import__
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import builtins
+        builtins.__import__ = self._import_backup
+        # 新規追加分を削除
+        for name in list(sys.modules):
+            if name not in self._modules_backup:
+                del sys.modules[name]
+        # 元の状態に戻す
+        for name, mod in self._modules_backup.items():
+            sys.modules[name] = mod
+        sys.path[:] = self._path_backup
+        # addon_external_loader の内部状態をリセット
+        ael = sys.modules.get("saiverse.addon_external_loader")
+        if ael is not None:
+            ael._registrations.clear()
+            ael._import_patched = False
+            ael._HOST_TOP_LEVEL_CACHE = None
+
+
+class AddonExternalLoaderTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp_handle = tempfile.TemporaryDirectory()
+        self.tmp = Path(self.tmp_handle.name)
+        self.external_dir = _make_fake_addon(self.tmp)
+        self.expansion_addon_root = self.tmp / "expansion_data" / "fake-pack" / "external"
+
+    def tearDown(self):
+        self.tmp_handle.cleanup()
+
+    def _patch_host_top_level(self, ael) -> None:
+        """テスト用に host top-level に 'tools' を含めさせる。
+
+        本物の SAIVerse/ には tools/ があるが、テストでは saiverse 自体を
+        sys.path 経由でロードしている可能性があり、自動検出が安定しない。
+        """
+        ael._HOST_TOP_LEVEL_CACHE = {"tools"}
+
+    def _import_consumer(self) -> types.ModuleType:
+        """external/FakeUpstream/consumer.py を毎回ユニーク名で import。"""
+        import uuid
+        unique_name = f"fakepack_consumer_{uuid.uuid4().hex}"
+        sys.path.insert(0, str(self.external_dir))
+        try:
+            spec = importlib.util.spec_from_file_location(
+                unique_name, str(self.external_dir / "consumer.py")
+            )
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[unique_name] = module
+            spec.loader.exec_module(module)
+            return module
+        finally:
+            sys.path.remove(str(self.external_dir))
+
+    # ------------------------------------------------------------------
+    # baseline: without isolation, host's `tools` shadows pack's tools
+    # ------------------------------------------------------------------
+    def test_baseline_collision_without_isolation(self):
+        """隔離機構なしでは、ホスト側 tools (スタブ、audio_sr 無し) が
+        sys.modules に存在する状態で consumer.py の `from tools.audio_sr` が
+        ImportError になることを再現する。"""
+        with _SaveImportEnv():
+            _install_host_tools_stub()
+
+            with self.assertRaises((ImportError, ModuleNotFoundError)):
+                self._import_consumer()
+
+    # ------------------------------------------------------------------
+    # with isolation: redirect resolves
+    # ------------------------------------------------------------------
+    def test_isolation_redirects_to_addon_namespace(self):
+        with _SaveImportEnv():
+            _install_host_tools_stub()
+            ael = importlib.import_module("saiverse.addon_external_loader")
+            self._patch_host_top_level(ael)
+
+            ael.register_addon_external("fake-pack", self.expansion_addon_root)
+
+            consumer = self._import_consumer()
+            self.assertEqual(
+                consumer.get_value(), ("pack-tools", "pack-audio-sr")
+            )
+            self.assertIn("addons.fake_pack.tools", sys.modules)
+
+    # ------------------------------------------------------------------
+    # host-side `import tools` still resolves to host's tools after registration
+    # ------------------------------------------------------------------
+    def test_host_imports_unaffected(self):
+        with _SaveImportEnv():
+            host_tools_before = _install_host_tools_stub()
+            ael = importlib.import_module("saiverse.addon_external_loader")
+            self._patch_host_top_level(ael)
+
+            ael.register_addon_external("fake-pack", self.expansion_addon_root)
+
+            # ホスト側コード(本テストファイル自身)からの import は本体 tools を返す
+            import tools as host_tools_after
+            self.assertIs(host_tools_after, host_tools_before)
+            self.assertEqual(host_tools_after.HOST_TOOLS_INIT, "host-tools")
+            self.assertFalse(hasattr(host_tools_after, "PACK_TOOLS_INIT"))
+
+    # ------------------------------------------------------------------
+    # parallel: thread A loads pack repeatedly, thread B imports host tools
+    # — neither sees contamination
+    # ------------------------------------------------------------------
+    def test_parallel_safety(self):
+        """今回再発した不具合の検証: 並列で external/ ロードと host import が
+        走っても、互いに名前空間を混染しない。"""
+        with _SaveImportEnv():
+            _install_host_tools_stub()
+            ael = importlib.import_module("saiverse.addon_external_loader")
+            self._patch_host_top_level(ael)
+
+            ael.register_addon_external("fake-pack", self.expansion_addon_root)
+
+            errors: list = []
+            barrier = threading.Barrier(2)
+
+            def thread_a_loads_pack():
+                """external/ から import — addon-namespaced tools を期待"""
+                try:
+                    barrier.wait()
+                    for _ in range(50):
+                        consumer = self._import_consumer()
+                        if consumer.get_value() != ("pack-tools", "pack-audio-sr"):
+                            errors.append(("thread_a", consumer.get_value()))
+                except Exception as e:
+                    errors.append(("thread_a_exc", repr(e)))
+
+            def thread_b_imports_host_tools():
+                """host 側コードから import — host tools を期待"""
+                try:
+                    barrier.wait()
+                    for _ in range(50):
+                        host_tools = importlib.import_module("tools")
+                        if hasattr(host_tools, "PACK_TOOLS_INIT"):
+                            errors.append(("thread_b_contamination",))
+                        if not hasattr(host_tools, "HOST_TOOLS_INIT"):
+                            errors.append(("thread_b_lost_host_attr",))
+                except Exception as e:
+                    errors.append(("thread_b_exc", repr(e)))
+
+            t1 = threading.Thread(target=thread_a_loads_pack)
+            t2 = threading.Thread(target=thread_b_imports_host_tools)
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+            self.assertEqual(errors, [], f"unexpected errors: {errors}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 背景

拡張パックは `expansion_data/<addon>/external/` に上流ライブラリを直接 clone して取り込みます。これらの上流コードがトップレベル `tools/` のような**ホスト側と同名のパッケージ**を持つ場合、Python の絶対 import が衝突します。

従来は各パックが `sys.modules['tools']` を一時的に剥がす context manager で対処していましたが、**並列スレッドが本体側 import を走らせると名前空間汚染が発生**します(2026-04-26 に `addon_spell_help` で実例発生、Slack で共有済み):

```
Spell error (addon_spell_help): ImportError: cannot import name 'SPELL_TOOL_SCHEMAS'
from 'tools' (.../expansion_data/saiverse-voice-tts/external/GPT-SoVITS/tools/__init__.py)
```

複数の拡張パック(ASR 等)が今後追加されると、同じ問題がパックごとに独立して発生します。

## 解決方針(案 Y を最終対応として採用)

ホスト側に1個だけ機構を持ち、各パックの `external/` を**呼び出し元ファイルパスベース**で振り分けます。subprocess 隔離(案 A)はパック作者にプロセス境界の通信実装(stdio/socket、ストリーミング再構築等)を強いるため、開発者負担が大きく不採用としました。

## 実装

### `saiverse/addon_external_loader.py` (新規)

`builtins.__import__` をパッチし、**呼び出し元のファイルパス**で名前解決を振り分けます:

- 各アドオンの `external/<lib>/<conflict>` のうち、ホスト top-level と同名の物だけを `addons.<sanitized>.<conflict>` として `sys.modules` に事前ロード
- 絶対 import 時、name のトップ要素が衝突候補 ∧ 呼び出し元 `__file__` が登録 external/ 配下なら、`addons.<sanitized>.<name>` にリダイレクト
- 上記以外(ホスト側コードからの import)は素通し

ファイルパスベース判定なので**スレッド非依存**(従来 hack の根本欠陥を解消)。

### `saiverse/addon_loader.py` (改修)

`load_addon_routers` の冒頭で `_register_addon_externals()` を呼び出し、api_routes.py 読み込み**前**に各アドオンの external/ を隔離下に登録します。

### `tests/test_addon_external_loader.py` (新規)

合計 4 テスト、全通過:

| テスト | 検証内容 |
|---|---|
| `test_baseline_collision_without_isolation` | 隔離なしで `ImportError` が出ることを再現(バグ存在の確認) |
| `test_isolation_redirects_to_addon_namespace` | 隔離後は `addons.<addon>.tools.audio_sr` へリダイレクトされる |
| `test_host_imports_unaffected` | ホスト側コードの `import tools` は引き続きホスト tools を返す |
| `test_parallel_safety` | Thread A: external/ 50回ロード、Thread B: host import 50回 を並列で回しても双方汚染なし(**今回の不具合の原理的再発防止確認**) |

```
Ran 4 tests in 0.119s
OK
```

## 拡張パック側への影響

- 既存パックの `_shadowed_tools_namespace` hack は**冗長になるが共存可能**(本機構と並行動作)
- saiverse-voice-tts では本 PR とは別途 [chore/remove-tools-shadow-hack](https://github.com/Nature109/saiverse-voice-tts/pull/new/chore/remove-tools-shadow-hack) で hack を削除済(本 PR マージ後に取り込み予定)
- 新規パックは hack 不要、`external/` に上流を置けば自動隔離

## 既知の限界

- 上流コードが**相対 import** (`from . import ...`) を使う場合は何もしない(Python 標準の解決で正しく動く)
- 上流コードが `__file__` を持たない動的生成モジュールから import をかけた場合はリダイレクト不可(極めて稀)
- 衝突検出は `external/<lib>/` 直下の1階層のみ走査(深く埋もれたパッケージ衝突は検出されない、現実装で十分なケースをカバー)

## レビュー観点

| 観点 | 評価 | 補足 |
|---|---|---|
| `__import__` パッチのパフォーマンス影響 | 微小 | `_registrations` 空時は即 return、それ以外も set lookup 1 回 + globals dict アクセスのみ |
| 他のモンキーパッチとの競合 | 低 | `_original_import` を保存して呼び出し |
| ホスト側 top-level 自動検出の誤検出 | 中 | 主要 skip_dirs (`expansion_data` `external` `frontend` 等) は除外済。新規 dir 増設時は要確認 |
| Python の import 機構変更 | 低 | `__import__` の signature は安定 |

## 関連

- 不具合報告: 2026-04-26 Slack(addon_spell_help ImportError)
- パック側対応: [Nature109/saiverse-voice-tts#chore/remove-tools-shadow-hack](https://github.com/Nature109/saiverse-voice-tts/tree/chore/remove-tools-shadow-hack)
