### PR TITLE
Strip user_only tags from message content in chat UI

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -29,6 +29,15 @@ import { ActiveClientIndicator } from '@/components/ActiveClientIndicator';
 import AddonBubbleButtons, { BubbleButtonDef } from '@/components/AddonBubbleButtons';
 import SystemAlertBanner from '@/components/SystemAlertBanner';
 
+// Strip <user_only alt="..."> wrapper tags from message content for UI display.
+// These tags are added by the backend (wrap_spell_blocks) so other personas can't read
+// the inner content, but in the user's own chat UI we want the inner content visible
+// without the wrapping tags leaking as raw text.
+const stripUserOnlyTags = (text: string): string => {
+    if (!text) return text;
+    return text.replace(/<user_only(?:\s[^>]*)?>/g, '').replace(/<\/user_only>/g, '');
+};
+
 // Allow className on HTML elements used by thinking blocks (<details>, <div>, <summary>)
 const sanitizeSchema = {
     ...defaultSchema,
@@ -2041,7 +2050,7 @@ export default function Home() {
                                                 components={{
                                                     a: ({ href, children }) => <SaiverseLink href={href} children={children} onOpenItem={handleOpenItemFromLink} />,
                                                 }}
-                                            >{msg.content}</ReactMarkdown>
+                                            >{stripUserOnlyTags(msg.content)}</ReactMarkdown>
                                         </>
                                     )}
                                 </div>


### PR DESCRIPTION
## Summary
This PR removes `<user_only>` wrapper tags from message content when displaying messages in the chat UI, while preserving the inner content that should be visible to the user.

## Changes
- Added `stripUserOnlyTags()` utility function that removes `<user_only>` opening and closing tags from message text using regex patterns
- Applied the function to message content rendering in the ReactMarkdown component to ensure clean UI display

## Implementation Details
The backend wraps certain message content with `<user_only alt="...">` tags to prevent other personas from reading the inner content. However, in the user's own chat interface, we want to display the inner content without the wrapper tags appearing as raw text. The `stripUserOnlyTags()` function handles this by:
- Removing opening tags: `<user_only>` or `<user_only ...attributes>`
- Removing closing tags: `</user_only>`
- Preserving all inner content between the tags

https://claude.ai/code/session_01PDZqzrN9isosTykTRx87mm