### PR TITLE
Add pulse_id tracking to group related say and activity events

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -108,6 +108,8 @@ interface Message {
     _streaming?: boolean;
     _streamingThinking?: string;
     _activities?: ActivityEntry[];
+    // Pulse identifier — groups say + activity events from the same pulse together
+    _pulse_id?: string;
 }
 
 interface ActivityEntry {
@@ -1267,32 +1269,52 @@ export default function Home() {
                         } else if (event.type === 'activity') {
                             // Activity trace: accumulate tool/memorize steps
                             const entry: ActivityEntry = { action: event.action, name: event.name, ...(event.playbook && { playbook: event.playbook }), status: event.status };
-                            setMessages(prev => {
-                                const last = prev[prev.length - 1];
-                                if (last && last.role === 'assistant' && last._streaming) {
-                                    const activities = [...(last._activities || [])];
-                                    if (event.status === 'completed' || event.status === 'error') {
-                                        const idx = activities.findIndex(
-                                            a => a.action === entry.action && a.name === entry.name && a.status === 'started'
-                                        );
-                                        if (idx >= 0) {
-                                            activities[idx] = { ...activities[idx], status: event.status };
-                                        } else {
-                                            activities.push(entry);
-                                        }
+                            const evtPulseId: string | undefined = event.pulse_id || undefined;
+                            const mergeActivity = (existing: ActivityEntry[] | undefined): ActivityEntry[] => {
+                                const activities = [...(existing || [])];
+                                if (event.status === 'completed' || event.status === 'error') {
+                                    const idx = activities.findIndex(
+                                        a => a.action === entry.action && a.name === entry.name && a.status === 'started'
+                                    );
+                                    if (idx >= 0) {
+                                        activities[idx] = { ...activities[idx], status: event.status };
                                     } else {
                                         activities.push(entry);
                                     }
-                                    return [...prev.slice(0, -1), { ...last, _activities: activities }];
                                 } else {
-                                    const actAvatarUrl = event.persona_avatar || (event.persona_id ? `/api/chat/persona/${event.persona_id}/avatar` : undefined);
-                                    return [...prev, {
-                                        role: 'assistant' as const, content: '', _streaming: true,
-                                        sender: event.persona_name || undefined,
-                                        avatar: actAvatarUrl,
-                                        _activities: [entry], timestamp: new Date().toISOString()
+                                    activities.push(entry);
+                                }
+                                return activities;
+                            };
+                            setMessages(prev => {
+                                const last = prev[prev.length - 1];
+                                if (last && last.role === 'assistant' && last._streaming) {
+                                    return [...prev.slice(0, -1), {
+                                        ...last,
+                                        _activities: mergeActivity(last._activities),
+                                        ...(evtPulseId && !last._pulse_id && { _pulse_id: evtPulseId }),
                                     }];
                                 }
+                                // Finalized message with the same pulse_id: append to its activity_trace
+                                if (evtPulseId) {
+                                    for (let i = prev.length - 1; i >= 0; i--) {
+                                        const m = prev[i];
+                                        if (m.role !== 'assistant') continue;
+                                        if (m._pulse_id !== evtPulseId) continue;
+                                        const merged = mergeActivity(m.activity_trace || m._activities);
+                                        const updated = [...prev];
+                                        updated[i] = { ...m, activity_trace: merged, _activities: undefined };
+                                        return updated;
+                                    }
+                                }
+                                const actAvatarUrl = event.persona_avatar || (event.persona_id ? `/api/chat/persona/${event.persona_id}/avatar` : undefined);
+                                return [...prev, {
+                                    role: 'assistant' as const, content: '', _streaming: true,
+                                    sender: event.persona_name || undefined,
+                                    avatar: actAvatarUrl,
+                                    _activities: [entry], timestamp: new Date().toISOString(),
+                                    ...(evtPulseId && { _pulse_id: evtPulseId }),
+                                }];
                             });
                             setLoadingStatus(event.status === 'started' ? `Running ${event.name}...` : event.name);
                         } else if (event.type === 'streaming_thinking') {
@@ -1436,6 +1458,7 @@ export default function Home() {
 
                             const sayReasoning = event.reasoning || undefined;
                             const sayActivityTrace = event.activity_trace || undefined;
+                            const sayPulseId: string | undefined = event.pulse_id || undefined;
                             setMessages(prev => {
                                 // Check if last message already has this content (from streaming completion)
                                 const last = prev[prev.length - 1];
@@ -1450,6 +1473,7 @@ export default function Home() {
                                         ...(sayUsageTotal && { llm_usage_total: sayUsageTotal }),
                                         ...(sayReasoning && { reasoning: sayReasoning }),
                                         ...(sayActivityTrace && { activity_trace: sayActivityTrace }),
+                                        ...(sayPulseId && { _pulse_id: sayPulseId }),
                                     }];
                                 }
                                 return [...prev, {
@@ -1463,6 +1487,7 @@ export default function Home() {
                                     ...(sayUsageTotal && { llm_usage_total: sayUsageTotal }),
                                     ...(sayReasoning && { reasoning: sayReasoning }),
                                     ...(sayActivityTrace && { activity_trace: sayActivityTrace }),
+                                    ...(sayPulseId && { _pulse_id: sayPulseId }),
                                 }];
                             });
                             setLoadingStatus('Thinking...');

--- a/sea/runtime.py
+++ b/sea/runtime.py
@@ -847,6 +847,8 @@ class SEARuntime:
                 outputs.append(text)
             if event_callback:
                 say_event: Dict[str, Any] = {"type": "say", "content": text, "persona_id": getattr(persona, "persona_id", None), "metadata": msg_metadata if msg_metadata else None}
+                if pulse_id:
+                    say_event["pulse_id"] = pulse_id
                 if building_msg and building_msg.get("message_id"):
                     say_event["message_id"] = str(building_msg["message_id"])
                 if reasoning_text:

--- a/sea/runtime_engine.py
+++ b/sea/runtime_engine.py
@@ -104,6 +104,7 @@ class RuntimeEngine:
                             "playbook": pb_display, "status": "completed",
                             "persona_id": getattr(persona, "persona_id", None),
                             "persona_name": getattr(persona, "persona_name", None),
+                            "pulse_id": state.get("_pulse_id"),
                         })
 
                 # Handle tuple results with output_keys (for multi-value returns)
@@ -447,6 +448,7 @@ class RuntimeEngine:
                         "playbook": pb_display, "status": "completed",
                         "persona_id": getattr(persona, "persona_id", None),
                         "persona_name": getattr(persona, "persona_name", None),
+                        "pulse_id": state.get("_pulse_id"),
                     })
 
             # Debug: log speak_content at end of memorize node
@@ -482,6 +484,8 @@ class RuntimeEngine:
             outputs.append(text)
         if event_callback:
             say_event: Dict[str, Any] = {"type": "say", "content": text, "persona_id": getattr(persona, "persona_id", None)}
+            if pulse_id:
+                say_event["pulse_id"] = pulse_id
             if building_msg and building_msg.get("message_id"):
                 say_event["message_id"] = str(building_msg["message_id"])
             if reasoning_text:

--- a/sea/runtime_llm.py
+++ b/sea/runtime_llm.py
@@ -987,6 +987,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                     "type": "say",
                                     "content": _first_text_before,
                                     "persona_id": getattr(persona, "persona_id", None),
+                                    "pulse_id": pulse_id,
                                 })
                             runtime._emit_say(persona, eff_bid, _first_text_before, pulse_id=pulse_id)
 
@@ -1010,6 +1011,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                 "type": "say",
                                 "content": _spell_bubble2,
                                 "persona_id": getattr(persona, "persona_id", None),
+                                "pulse_id": pulse_id,
                             }
                             if _spell_at:
                                 _say_event["activity_trace"] = list(_spell_at)
@@ -1321,6 +1323,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                         "type": "say",
                                         "content": _first_text_before_ns,
                                         "persona_id": getattr(persona, "persona_id", None),
+                                        "pulse_id": pulse_id,
                                     })
                                 runtime._emit_say(persona, eff_bid, _first_text_before_ns, pulse_id=pulse_id)
 
@@ -1349,6 +1352,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                     "type": "say",
                                     "content": _spell_bubble2_ns,
                                     "persona_id": getattr(persona, "persona_id", None),
+                                    "pulse_id": pulse_id,
                                 }
                                 if _spell_at_ns:
                                     _say_event_ns["activity_trace"] = list(_spell_at_ns)
@@ -1578,6 +1582,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                     "type": "say",
                                     "content": _first_text_before_sync,
                                     "persona_id": getattr(persona, "persona_id", None),
+                                    "pulse_id": pulse_id,
                                 })
 
                         # Bubble 2: all details blocks + continuation
@@ -1629,6 +1634,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                 "type": "say",
                                 "content": text,
                                 "persona_id": getattr(persona, "persona_id", None),
+                                "pulse_id": pulse_id,
                             }
                             if reasoning_text:
                                 say_event["reasoning"] = reasoning_text
@@ -1839,6 +1845,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                         "playbook": pb_display, "status": "completed",
                         "persona_id": getattr(persona, "persona_id", None),
                         "persona_name": getattr(persona, "persona_name", None),
+                        "pulse_id": state.get("_pulse_id"),
                     })
 
         # Important flag: dual-write to messages (long-term memory) if not already memorized

--- a/sea/runtime_nodes.py
+++ b/sea/runtime_nodes.py
@@ -74,7 +74,7 @@ def lg_tool_call_node(runtime: Any, node_def: Any, persona: Any, playbook: Any, 
                 if isinstance(_at, list):
                     _at.append({"action": "tool_call", "name": tool_name, "playbook": pb_display})
                 if event_callback:
-                    event_callback({"type": "activity", "action": "tool_call", "name": tool_name, "playbook": pb_display, "status": "completed", "persona_id": getattr(persona, "persona_id", None), "persona_name": getattr(persona, "persona_name", None)})
+                    event_callback({"type": "activity", "action": "tool_call", "name": tool_name, "playbook": pb_display, "status": "completed", "persona_id": getattr(persona, "persona_id", None), "persona_name": getattr(persona, "persona_name", None), "pulse_id": state.get("_pulse_id")})
             state["last"] = result_str
             if output_key:
                 state[output_key] = result


### PR DESCRIPTION
## Summary
This PR introduces pulse ID tracking to group related `say` and `activity` events that originate from the same execution pulse. This enables better correlation and organization of events in the UI, allowing activities and messages from a single pulse to be properly associated together.

## Key Changes

- **Message Interface Enhancement**: Added `_pulse_id` field to the `Message` interface to track which pulse a message belongs to
- **Activity Event Grouping**: Modified activity event handling to:
  - Extract `pulse_id` from activity events
  - Append activities to finalized messages with matching `pulse_id` (converting `_activities` to `activity_trace`)
  - Preserve `_pulse_id` when creating new streaming messages
- **Say Event Tracking**: Updated all `say` event emissions to include `pulse_id` from the execution state
- **Backend Event Emission**: Modified event callbacks across multiple runtime modules (`runtime.py`, `runtime_engine.py`, `runtime_llm.py`, `runtime_nodes.py`) to include `pulse_id` in both `say` and `activity` event payloads

## Implementation Details

- The `pulse_id` is extracted from the event payload and stored in the message state
- When processing activity events, the code now searches backwards through messages to find one with a matching `pulse_id` and appends the activity to its `activity_trace`
- A new `mergeActivity` helper function consolidates activity merging logic for both streaming and finalized messages
- The `pulse_id` is conditionally included in event objects only when present, maintaining backward compatibility

https://claude.ai/code/session_019m6iP7FXc6kBkPe1m9WftE