### PR TITLE
fix(ui): streaming イベントにも pulse_id を伝播してステップバブル分離を解消

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1320,12 +1320,14 @@ export default function Home() {
                         } else if (event.type === 'streaming_thinking') {
                             // Streaming thinking: accumulate into _streamingThinking
                             const avatarUrl = event.persona_avatar || (event.persona_id ? `/api/chat/persona/${event.persona_id}/avatar` : undefined);
+                            const evtPulseId: string | undefined = event.pulse_id || undefined;
                             setMessages(prev => {
                                 const last = prev[prev.length - 1];
                                 if (last && last.role === 'assistant' && last._streaming) {
                                     return [...prev.slice(0, -1), {
                                         ...last,
-                                        _streamingThinking: (last._streamingThinking || '') + event.content
+                                        _streamingThinking: (last._streamingThinking || '') + event.content,
+                                        ...(evtPulseId && !last._pulse_id && { _pulse_id: evtPulseId }),
                                     }];
                                 } else {
                                     return [...prev, {
@@ -1335,7 +1337,8 @@ export default function Home() {
                                         avatar: avatarUrl,
                                         timestamp: new Date().toISOString(),
                                         _streaming: true,
-                                        _streamingThinking: event.content
+                                        _streamingThinking: event.content,
+                                        ...(evtPulseId && { _pulse_id: evtPulseId }),
                                     }];
                                 }
                             });
@@ -1343,12 +1346,14 @@ export default function Home() {
                         } else if (event.type === 'streaming_chunk') {
                             // Streaming: append chunk to last message or create new one
                             const avatarUrl = event.persona_avatar || (event.persona_id ? `/api/chat/persona/${event.persona_id}/avatar` : undefined);
+                            const evtPulseId: string | undefined = event.pulse_id || undefined;
                             setMessages(prev => {
                                 const last = prev[prev.length - 1];
                                 if (last && last.role === 'assistant' && last._streaming) {
                                     return [...prev.slice(0, -1), {
                                         ...last,
-                                        content: last.content + event.content
+                                        content: last.content + event.content,
+                                        ...(evtPulseId && !last._pulse_id && { _pulse_id: evtPulseId }),
                                     }];
                                 } else {
                                     return [...prev, {
@@ -1357,7 +1362,8 @@ export default function Home() {
                                         sender: event.persona_name || 'Assistant',
                                         avatar: avatarUrl,
                                         timestamp: new Date().toISOString(),
-                                        _streaming: true
+                                        _streaming: true,
+                                        ...(evtPulseId && { _pulse_id: evtPulseId })
                                     }];
                                 }
                             });

--- a/sea/runtime_llm.py
+++ b/sea/runtime_llm.py
@@ -710,6 +710,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                         "content": chunk["content"],
                                         "persona_id": getattr(persona, "persona_id", None),
                                         "node_id": getattr(node_def, "id", "llm"),
+                                        "pulse_id": state.get("_pulse_id"),
                                     })
                                     continue
                                 text_chunks.append(chunk)
@@ -718,6 +719,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                     "content": chunk,
                                     "persona_id": getattr(persona, "persona_id", None),
                                     "node_id": getattr(node_def, "id", "llm"),
+                                    "pulse_id": state.get("_pulse_id"),
                                 })
                         finally:
                             if hasattr(stream_iter, 'close'):
@@ -808,6 +810,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                 "type": "streaming_complete",
                                 "persona_id": getattr(persona, "persona_id", None),
                                 "node_id": getattr(node_def, "id", "llm"),
+                                "pulse_id": state.get("_pulse_id"),
                             }
                             if _tool_reasoning_text:
                                 completion_event["reasoning"] = _tool_reasoning_text
@@ -842,6 +845,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                 "type": "streaming_discard",
                                 "persona_id": getattr(persona, "persona_id", None),
                                 "node_id": getattr(node_def, "id", "llm"),
+                                "pulse_id": state.get("_pulse_id"),
                             })
                             LOGGER.info("[sea] Streaming text discarded — tool_call only (no speak content)")
                     else:
@@ -856,6 +860,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                             "type": "streaming_complete",
                             "persona_id": getattr(persona, "persona_id", None),
                             "node_id": getattr(node_def, "id", "llm"),
+                            "pulse_id": state.get("_pulse_id"),
                         }
                         if _tool_reasoning_text:
                             completion_event["reasoning"] = _tool_reasoning_text
@@ -1179,6 +1184,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                         "content": chunk["content"],
                                         "persona_id": getattr(persona, "persona_id", None),
                                         "node_id": getattr(node_def, "id", "llm"),
+                                        "pulse_id": state.get("_pulse_id"),
                                     })
                                     continue
                                 text_chunks.append(chunk)
@@ -1188,6 +1194,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                     "content": chunk,
                                     "persona_id": getattr(persona, "persona_id", None),
                                     "node_id": getattr(node_def, "id", "llm"),
+                                    "pulse_id": state.get("_pulse_id"),
                                 })
                         finally:
                             # Explicitly close to disconnect HTTP streaming from LLM API
@@ -1316,6 +1323,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                     "type": "streaming_discard",
                                     "persona_id": getattr(persona, "persona_id", None),
                                     "node_id": getattr(node_def, "id", "llm"),
+                                    "pulse_id": pulse_id,
                                 })
                             if _first_text_before_ns.strip():
                                 if event_callback:
@@ -1376,6 +1384,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                             "type": "streaming_complete",
                             "persona_id": getattr(persona, "persona_id", None),
                             "node_id": getattr(node_def, "id", "llm"),
+                            "pulse_id": state.get("_pulse_id"),
                         }
                         if reasoning_text:
                             completion_event["reasoning"] = reasoning_text
@@ -1469,6 +1478,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                             "content": _cont_chunk,
                                             "persona_id": getattr(persona, "persona_id", None),
                                             "node_id": getattr(node_def, "id", "llm"),
+                                            "pulse_id": state.get("_pulse_id"),
                                         })
                             finally:
                                 if hasattr(_cont_iter, "close"):
@@ -1483,6 +1493,7 @@ def lg_llm_node(runtime, node_def: Any, persona: Any, building_id: str, playbook
                                         "type": "streaming_complete",
                                         "persona_id": getattr(persona, "persona_id", None),
                                         "node_id": getattr(node_def, "id", "llm"),
+                                        "pulse_id": state.get("_pulse_id"),
                                     })
                                 # Store continuation to building history
                                 runtime._emit_say(persona, eff_bid, _cont_text, pulse_id=pulse_id)


### PR DESCRIPTION
## 背景

PR #251 で `say` / `activity` イベントに `pulse_id` を載せ、フロント側で同 pulse のメッセージへ activity を合流させる仕組みを入れた。しかし実際の通信ログを確認したところ、ストリーミング配信経路では `say` イベントが一切発火されず、`streaming_chunk` → `streaming_complete` で発言が完結していた。

その結果、フロント側のメッセージに `_pulse_id` が一度もセットされず、後続の `activity (control_body)` が pulse_id 一致を見つけられないままフォールバックの新規バブルを生成してしまい、「2 steps」だけが表示される空バブルが残っていた。

## 修正内容

### バックエンド (`sea/runtime_llm.py`)

`streaming_chunk` / `streaming_complete` / `streaming_thinking` / `streaming_discard` の全 11 箇所に `pulse_id`（`state.get("_pulse_id")`）を追加。

### フロントエンド (`frontend/src/app/page.tsx`)

- `streaming_chunk` ハンドラ: streaming bubble 生成時 / 既存 bubble 更新時に `_pulse_id` を保持
- `streaming_thinking` ハンドラ: 同上
- `streaming_complete` は spread (`...rest`) で `_pulse_id` が引き継がれるため変更不要

## 動作確認

- `ruff check sea/runtime_llm.py` 通過
- `npx tsc --noEmit` で新規エラーなし

## 想定される効果

ペルソナ発言後に `process_body`（`control_body`）など speak 直後の tool ノードが実行されても、同 pulse の発言バブルに activity がマージされ、独立した空ステップバブルが出なくなる。

## 関連 PR

- #251 (前段の修正、既にマージ済み)

https://claude.ai/code/session_019m6iP7FXc6kBkPe1m9WftE

---
_Generated by [Claude Code](https://claude.ai/code/session_019m6iP7FXc6kBkPe1m9WftE)_