### PR TITLE
fix(addon): /api/addon/ で params_schema のデフォルト値を merge する

### DIFF
--- a/api/routes/addon.py
+++ b/api/routes/addon.py
@@ -222,12 +222,43 @@ def _get_session():
 # Endpoints
 # ---------------------------------------------------------------------------
 
+def _resolve_effective_params(
+    manifest: "AddonManifest",
+    params_json: Optional[str],
+) -> Dict[str, Any]:
+    """params_schema のデフォルト値とユーザー保存値を merge して返す。
+
+    フロントエンド側 (`useClientActions` の ``requires_enabled_param`` 等) は
+    ``addon.params[key]`` を truthy 判定で参照するため、ユーザーが UI で
+    一度もトグルを操作していないキーが ``undefined`` 扱いになって
+    ``client_actions`` がサイレント skip される事故が起きる。
+
+    バックエンド側の ``saiverse.addon_config.get_params`` は同様の merge を
+    既に行っているため、HTTP レスポンス側との整合を取るためここでも
+    同じ振る舞いをさせる。
+    """
+    params: Dict[str, Any] = {}
+    for schema_item in manifest.params_schema:
+        if schema_item.default is not None:
+            params[schema_item.key] = schema_item.default
+    if params_json:
+        try:
+            user_overrides = json.loads(params_json)
+            if isinstance(user_overrides, dict):
+                params.update(user_overrides)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return params
+
+
 @router.get("/", response_model=List[AddonInfo])
 @router.get("", response_model=List[AddonInfo], include_in_schema=False)
 def list_addons(_manager=Depends(get_manager)):
     """expansion_data/ 下のアドオン一覧を返す。
 
     addon.json が存在するディレクトリのみをアドオンとして認識する。
+    各エントリの ``params`` には params_schema のデフォルト値とユーザー
+    保存値をマージした値が含まれる。
     """
     exp_dir = _get_expansion_data_dir()
     if not exp_dir.exists():
@@ -247,12 +278,7 @@ def list_addons(_manager=Depends(get_manager)):
             config = _get_or_create_config(db, addon_name)
             db.commit()
 
-            params: Dict[str, Any] = {}
-            if config.params_json:
-                try:
-                    params = json.loads(config.params_json)
-                except (json.JSONDecodeError, TypeError):
-                    pass
+            params = _resolve_effective_params(manifest, config.params_json)
 
             results.append(AddonInfo(
                 addon_name=addon_name,
@@ -286,12 +312,7 @@ def get_addon(addon_name: str, _manager=Depends(get_manager)):
         config = _get_or_create_config(db, addon_name)
         db.commit()
 
-        params: Dict[str, Any] = {}
-        if config.params_json:
-            try:
-                params = json.loads(config.params_json)
-            except (json.JSONDecodeError, TypeError):
-                pass
+        params = _resolve_effective_params(manifest, config.params_json)
 
         return AddonInfo(
             addon_name=addon_name,

--- a/tests/test_addon_routes_params_merge.py
+++ b/tests/test_addon_routes_params_merge.py
@@ -1,0 +1,122 @@
+"""Tests for /api/addon/ params merge behavior.
+
+The list_addons and get_addon endpoints must merge ``params_schema`` defaults
+with user-saved overrides so that the frontend's
+``useClientActions.requires_enabled_param`` check works for users who have
+not explicitly toggled the relevant option.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Ensure project root is in sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+class ResolveEffectiveParamsTests(unittest.TestCase):
+    """``_resolve_effective_params(manifest, params_json)`` の挙動検証。"""
+
+    def setUp(self):
+        from api.routes.addon import (  # noqa: PLC0415
+            AddonManifest,
+            AddonParamSchema,
+            _resolve_effective_params,
+        )
+        self._resolve = _resolve_effective_params
+        self._manifest = AddonManifest(
+            name="test-addon",
+            params_schema=[
+                AddonParamSchema(
+                    key="bool_default_true",
+                    label="A",
+                    type="toggle",
+                    default=True,
+                    persona_configurable=False,
+                ),
+                AddonParamSchema(
+                    key="bool_default_false",
+                    label="B",
+                    type="toggle",
+                    default=False,
+                    persona_configurable=False,
+                ),
+                AddonParamSchema(
+                    key="text_no_default",
+                    label="C",
+                    type="text",
+                    default=None,
+                    persona_configurable=False,
+                ),
+                AddonParamSchema(
+                    key="dropdown_default_str",
+                    label="D",
+                    type="dropdown",
+                    default="<default>",
+                    persona_configurable=False,
+                ),
+            ],
+        )
+
+    def test_no_user_overrides_returns_all_defaults(self):
+        """params_json が None なら schema のデフォルト値だけが返る。"""
+        result = self._resolve(self._manifest, None)
+        self.assertEqual(result["bool_default_true"], True)
+        self.assertEqual(result["bool_default_false"], False)
+        self.assertEqual(result["dropdown_default_str"], "<default>")
+        # default=None のキーは含めない
+        self.assertNotIn("text_no_default", result)
+
+    def test_empty_params_json_returns_defaults(self):
+        result = self._resolve(self._manifest, "{}")
+        self.assertEqual(result["bool_default_true"], True)
+        self.assertEqual(result["bool_default_false"], False)
+
+    def test_user_override_takes_precedence_over_default(self):
+        """ユーザーが明示的に保存した値はデフォルトを上書きする。"""
+        result = self._resolve(self._manifest, '{"bool_default_true": false}')
+        self.assertEqual(result["bool_default_true"], False)
+        # 触っていないキーはデフォルトのまま
+        self.assertEqual(result["bool_default_false"], False)
+
+    def test_user_can_add_keys_without_default(self):
+        """schema に default が無いキーをユーザーが設定した場合は通す。"""
+        result = self._resolve(self._manifest, '{"text_no_default": "hello"}')
+        self.assertEqual(result["text_no_default"], "hello")
+
+    def test_invalid_json_falls_back_to_defaults_only(self):
+        """params_json が壊れている場合は黙ってデフォルトだけを返す。"""
+        result = self._resolve(self._manifest, "{not valid json")
+        self.assertEqual(result["bool_default_true"], True)
+        self.assertEqual(result["bool_default_false"], False)
+
+    def test_non_dict_json_is_ignored(self):
+        """params_json がオブジェクトでない場合は無視してデフォルトだけ返す。"""
+        result = self._resolve(self._manifest, "[1, 2, 3]")
+        self.assertEqual(result["bool_default_true"], True)
+        self.assertEqual(result["bool_default_false"], False)
+
+    def test_consistency_with_addon_config_get_params(self):
+        """``saiverse.addon_config.get_params`` の merge ロジックと同等の結果を返すこと。
+
+        両者の merge 順 (defaults < user) が一致することは、HTTP API と
+        Python API の整合性を保つ上で重要。
+        """
+        # defaults < user の順序
+        result = self._resolve(
+            self._manifest,
+            '{"bool_default_true": false, "text_no_default": "x"}',
+        )
+        # ユーザーが false に上書き
+        self.assertEqual(result["bool_default_true"], False)
+        # ユーザーが追加
+        self.assertEqual(result["text_no_default"], "x")
+        # 触っていないキーはデフォルトのまま
+        self.assertEqual(result["bool_default_false"], False)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 背景

`/api/addon/` および `/api/addon/{name}` の HTTP レスポンスで返す `params` フィールドが、ユーザーが UI で**明示的にトグル操作した値だけ**を含み、`params_schema` の `default` 値はマージされていませんでした。

これによりフロントエンド ([useClientActions.ts:118-121](frontend/src/hooks/useClientActions.ts#L118-L121)):

```javascript
if (action.requires_enabled_param) {
    const enabled = addon.params[action.requires_enabled_param];
    if (!enabled) continue;     // サイレント skip
}
```

の判定で、**ユーザーが該当トグルを一度も操作していない**と `addon.params[key]` が `undefined` になり、`client_actions` がコンソールに何も残さず skip されていました。

UI 上は `params_schema.default` が描画されてトグル ON 表示なのに、内部値は未設定で skip される、という見た目と挙動の食い違いです。

## 直接的な事象 (saiverse-voice-tts)

- `client_side_playback` を DB に未保存のユーザー環境では、`audio_ready` イベント受信後の `play_audio` action が静かに skip されてブラウザ側ストリーミング再生が機能しない
- バックエンドは正常(TTS 合成完了 → wav 保存 → `subscribers=1` で SSE 配信成功)、バブルの 🔊 ボタン手動再生は機能する → 切り分けが困難だった

## 整合性の問題

バックエンド側の `saiverse.addon_config.get_params()` は `_load_manifest_defaults` で manifest の `default` を merge してからユーザー保存値で上書きするため、**Python 側で `get_effective_params` を読むパック (TTS engine 等) は正しい値を取得できていた**。

つまり**同じ "params" 概念に対して HTTP API と Python API で異なる結果**が返る整合性バグでした。今回の修正で両 API の挙動が完全に一致します。

## 修正内容

`api/routes/addon.py` に `_resolve_effective_params(manifest, params_json)` ヘルパを新設し、`list_addons` と `get_addon` 両方で利用:

1. `manifest.params_schema` を走査して `default` 値を初期辞書に投入
2. `config.params_json` (ユーザー保存値) を `update` で上書き

merge 順は `saiverse.addon_config.get_params` と同じ (defaults < user)。

## テスト

`tests/test_addon_routes_params_merge.py` を新規追加し、ヘルパー関数の挙動を 7 ケースで検証:

- `test_no_user_overrides_returns_all_defaults` — params_json が None なら schema のデフォルトだけが返る
- `test_empty_params_json_returns_defaults` — 空 JSON でも defaults が返る
- `test_user_override_takes_precedence_over_default` — user override が defaults を上書き
- `test_user_can_add_keys_without_default` — schema に default が無いキーを user が設定可能
- `test_invalid_json_falls_back_to_defaults_only` — 壊れた JSON でも defaults だけは返る
- `test_non_dict_json_is_ignored` — オブジェクト以外の JSON は無視
- `test_consistency_with_addon_config_get_params` — Python API との merge 順整合性を確認

```
Ran 7 tests in 0.734s
OK
```

回帰検証として既存の addon 系テスト 18 件も全通過確認:

```
Ran 18 tests in 0.299s
OK
```

## 影響範囲と挙動変化

### フロントエンド側

`addon.params` を参照する全箇所が恩恵を受ける:
- `useClientActions.requires_enabled_param` の skip 判定が正しく動く ← 直接の修正対象
- `AddonManagerModal.globalParams` 初期値が defaults で埋まる
- 既に user override されている環境への影響なし(override が勝つため)

### DB 保存内容の挙動変化(注意点)

修正後、フロントの `globalParams` は defaults で初期化されるため、**ユーザーが何かトグルを操作するとその時点の defaults が DB に explicit に保存**される(従来は「触ったキーのみ」保存)。

これに伴う副次効果として、**将来 schema の `default` 値が変更されても、既に DB に保存された値が勝つため自動伝播されません**。これは Voice TTS のような default が安定したアドオンでは問題になりませんが、フレームワークレベルでは「explicit save される値が増える」という挙動シフトとして認識ください。

## 後方互換

- 既存ユーザーで既に override 設定されている環境 → 影響なし(override が defaults より優先)
- 純粋に「未定義キーがデフォルトで埋まる」だけの変更
- DB スキーマ変更なし

## Voice TTS 側への影響

不要。本 PR がマージされれば、`client_side_playback` を一度もトグルしていないユーザー環境でもブラウザ側ストリーミング再生が動くようになります(まはーさん環境で再現していた症状の根本治療)。
