### PR TITLE
feat(addon): params_schema に dict 型 + collapsible (アコーディオン) サポートを追加

### DIFF
--- a/api/routes/addon.py
+++ b/api/routes/addon.py
@@ -51,6 +51,10 @@ class AddonParamSchema(BaseModel):
     accept: Optional[str] = None  # MIME type CSV: "audio/wav,audio/mpeg,video/mp4"
     max_size_mb: Optional[float] = None  # デフォルト 500MB。本体上限 1GB
     preview: Optional[str] = None  # "audio" | "image" | None
+    # アコーディオン (折り畳み可能な行) として描画するか。dict など大きな
+    # 入力 UI を普段は折り畳んでおきたい場合に使う。
+    collapsible: Optional[bool] = None
+    default_collapsed: Optional[bool] = None  # collapsible=true 時の初期状態 (既定 true)
 
 
 class AddonUiBubbleButton(BaseModel):

--- a/api/routes/addon.py
+++ b/api/routes/addon.py
@@ -32,7 +32,7 @@ class AddonParamSchema(BaseModel):
     key: str
     label: str
     description: Optional[str] = None
-    type: str  # "toggle" | "text" | "password" | "number" | "file" | "dropdown" | "slider"
+    type: str  # "toggle" | "text" | "password" | "number" | "file" | "dropdown" | "slider" | "dict"
     default: Any = None
     persona_configurable: bool = False
     placeholder: Optional[str] = None  # text / number 用の placeholder

--- a/frontend/src/components/AddonManagerModal.module.css
+++ b/frontend/src/components/AddonManagerModal.module.css
@@ -415,6 +415,110 @@
     color: #94a3b8;
 }
 
+/* --- Dict (key/value table) --- */
+
+/* dict 型は通常の行レイアウトでは横幅が足りないため、ラベルを上、コントロールを下の縦積みに切替える */
+.paramRowStacked {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.4rem;
+}
+
+.dictControl {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    width: 100%;
+}
+
+.dictHeader {
+    display: flex;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0 0.1rem;
+}
+
+.dictHeaderCell {
+    flex: 1;
+    min-width: 0;
+}
+
+.dictHeaderSpacer {
+    width: 1.6rem;
+    flex-shrink: 0;
+}
+
+.dictRow {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.dictKeyInput,
+.dictValueInput {
+    flex: 1;
+    min-width: 0;
+    padding: 0.3rem 0.5rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.375rem;
+    font-size: 0.85rem;
+    background: transparent;
+    color: inherit;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.dictKeyInput:focus,
+.dictValueInput:focus {
+    border-color: #6366f1;
+}
+
+.dictDeleteBtn {
+    background: none;
+    border: none;
+    color: #94a3b8;
+    cursor: pointer;
+    padding: 0.2rem;
+    border-radius: 0.25rem;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.dictDeleteBtn:hover {
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.1);
+}
+
+.dictAddBtn {
+    align-self: flex-start;
+    background: none;
+    border: 1px dashed #cbd5e1;
+    border-radius: 0.375rem;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.78rem;
+    color: #64748b;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.dictAddBtn:hover {
+    border-color: #6366f1;
+    color: #6366f1;
+}
+
+.dictEmpty {
+    font-size: 0.78rem;
+    color: #94a3b8;
+    padding: 0.2rem 0;
+}
+
 /* --- FileControl --- */
 
 .fileControl {
@@ -654,6 +758,27 @@
 
 :global([data-theme="dark"]) .emptyState {
     color: #64748b;
+}
+
+:global([data-theme="dark"]) .dictKeyInput,
+:global([data-theme="dark"]) .dictValueInput {
+    border-color: #334155;
+    color: #e2e8f0;
+}
+
+:global([data-theme="dark"]) .dictKeyInput:focus,
+:global([data-theme="dark"]) .dictValueInput:focus {
+    border-color: #6366f1;
+}
+
+:global([data-theme="dark"]) .dictAddBtn {
+    border-color: #334155;
+    color: #94a3b8;
+}
+
+:global([data-theme="dark"]) .dictAddBtn:hover {
+    border-color: #6366f1;
+    color: #6366f1;
 }
 
 /* --- Mobile (narrow viewport) --- */

--- a/frontend/src/components/AddonManagerModal.module.css
+++ b/frontend/src/components/AddonManagerModal.module.css
@@ -415,6 +415,47 @@
     color: #94a3b8;
 }
 
+/* --- Accordion paramRow (schema.collapsible) --- */
+
+.paramRowAccordion {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 0.5rem;
+    padding: 0.4rem 0.5rem;
+}
+
+.paramRowAccordionHeader {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: none;
+    border: none;
+    padding: 0.15rem 0.1rem;
+    cursor: pointer;
+    color: #475569;
+    width: 100%;
+    text-align: left;
+}
+
+.paramRowAccordionHeader:hover {
+    color: #1e293b;
+}
+
+.paramRowAccordionHeader .paramLabel {
+    flex: 1;
+    font-size: 0.88rem;
+    color: inherit;
+}
+
+.paramRowAccordionBody {
+    padding: 0.1rem 0.1rem 0.2rem 1.4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
 /* --- Dict (key/value table) --- */
 
 /* dict 型は通常の行レイアウトでは横幅が足りないため、ラベルを上、コントロールを下の縦積みに切替える */
@@ -779,6 +820,18 @@
 :global([data-theme="dark"]) .dictAddBtn:hover {
     border-color: #6366f1;
     color: #6366f1;
+}
+
+:global([data-theme="dark"]) .paramRowAccordion {
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+:global([data-theme="dark"]) .paramRowAccordionHeader {
+    color: #94a3b8;
+}
+
+:global([data-theme="dark"]) .paramRowAccordionHeader:hover {
+    color: #e2e8f0;
 }
 
 /* --- Mobile (narrow viewport) --- */

--- a/frontend/src/components/AddonManagerModal.tsx
+++ b/frontend/src/components/AddonManagerModal.tsx
@@ -28,6 +28,10 @@ interface AddonParamSchema {
     accept?: string;
     max_size_mb?: number;
     preview?: 'audio' | 'image';
+    // 任意: true でこの行をアコーディオン (折り畳み可能) として描画する。
+    // 大きな入力 UI (dict など) や上級者向け項目を普段は折り畳んでおきたい用途で使う。
+    collapsible?: boolean;
+    default_collapsed?: boolean;  // 初期状態 (collapsible=true 時のみ意味がある)。既定 true。
 }
 
 interface AddonInfo {
@@ -517,6 +521,52 @@ function FileParamControl({
 }
 
 // ---------------------------------------------------------------------------
+// ParamRow — paramLabel + control の 1 行。schema.collapsible が true のとき
+// アコーディオン (折り畳み可能なヘッダ + ボディ) として描画する。
+// ---------------------------------------------------------------------------
+
+function ParamRow({
+    schema,
+    children,
+}: {
+    schema: AddonParamSchema;
+    children: React.ReactNode;
+}) {
+    const isCollapsible = !!schema.collapsible;
+    const [collapsed, setCollapsed] = useState<boolean>(
+        isCollapsible ? (schema.default_collapsed ?? true) : false
+    );
+
+    if (isCollapsible) {
+        return (
+            <div className={styles.paramRowAccordion}>
+                <button
+                    type="button"
+                    className={styles.paramRowAccordionHeader}
+                    onClick={() => setCollapsed((v) => !v)}
+                    aria-expanded={!collapsed}
+                >
+                    {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                    <span className={styles.paramLabel}>{schema.label}</span>
+                </button>
+                {!collapsed && (
+                    <div className={styles.paramRowAccordionBody}>
+                        {children}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className={`${styles.paramRow} ${schema.type === 'dict' ? styles.paramRowStacked : ''}`}>
+            <span className={styles.paramLabel}>{schema.label}</span>
+            {children}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
 // ParamsSection — list of parameters with global + per-persona sections
 // ---------------------------------------------------------------------------
 
@@ -616,18 +666,14 @@ function ParamsSection({
                 <div className={styles.paramsGroup}>
                     <div className={styles.paramsGroupLabel}>デフォルト（全ペルソナ共通）</div>
                     {configurableSchemas.map((schema) => (
-                        <div
-                            key={schema.key}
-                            className={`${styles.paramRow} ${schema.type === 'dict' ? styles.paramRowStacked : ''}`}
-                        >
-                            <span className={styles.paramLabel}>{schema.label}</span>
+                        <ParamRow key={schema.key} schema={schema}>
                             <ParamControl
                                 schema={schema}
                                 value={globalParams[schema.key]}
                                 onChange={handleGlobalChange}
                                 addonName={addon.addon_name}
                             />
-                        </div>
+                        </ParamRow>
                     ))}
                     {saving && <span className={styles.savingHint}>保存中...</span>}
                 </div>
@@ -657,11 +703,7 @@ function ParamsSection({
                             {personaConfigurableSchemas.length > 0 && (
                                 <div className={styles.personaConfigBlock}>
                                     {personaConfigurableSchemas.map((schema) => (
-                                        <div
-                                            key={schema.key}
-                                            className={`${styles.paramRow} ${schema.type === 'dict' ? styles.paramRowStacked : ''}`}
-                                        >
-                                            <span className={styles.paramLabel}>{schema.label}</span>
+                                        <ParamRow key={schema.key} schema={schema}>
                                             <ParamControl
                                                 schema={schema}
                                                 value={selectedPersonaParams[schema.key]}
@@ -669,7 +711,7 @@ function ParamsSection({
                                                 addonName={addon.addon_name}
                                                 personaId={selectedPersonaId}
                                             />
-                                        </div>
+                                        </ParamRow>
                                     ))}
                                 </div>
                             )}

--- a/frontend/src/components/AddonManagerModal.tsx
+++ b/frontend/src/components/AddonManagerModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { X, Package, ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
+import { X, Package, ChevronDown, ChevronRight, Trash2, Plus } from 'lucide-react';
 import ModalOverlay from './common/ModalOverlay';
 import MCPSection from './MCPSection';
 import OAuthFlowSection, { OAuthFlow } from './OAuthFlowSection';
@@ -15,7 +15,7 @@ interface AddonParamSchema {
     key: string;
     label: string;
     description?: string;
-    type: 'toggle' | 'text' | 'password' | 'number' | 'dropdown' | 'slider' | 'file';
+    type: 'toggle' | 'text' | 'password' | 'number' | 'dropdown' | 'slider' | 'file' | 'dict';
     default: unknown;
     persona_configurable: boolean;
     placeholder?: string;
@@ -180,6 +180,15 @@ function ParamControl({
                 />
             );
 
+        case 'dict':
+            return (
+                <DictParamControl
+                    schema={schema}
+                    value={current}
+                    onChange={onChange}
+                />
+            );
+
         default:
             return <span className={styles.unsupported}>（未対応の型: {schema.type}）</span>;
     }
@@ -237,6 +246,118 @@ function DropdownParamControl({
                 <option key={opt} value={opt}>{opt}</option>
             ))}
         </select>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DictParamControl — editable key/value table for dict-type params
+//
+// addon.json で `type: "dict"` を指定したパラメータを編集するための UI。
+// 値は `Record<string, string>` として保存される (現バージョンは値型 string のみ)。
+// 既存値に非文字列が含まれていた場合は表示時に String() で文字列化される。
+// ---------------------------------------------------------------------------
+
+function DictParamControl({
+    schema,
+    value,
+    onChange,
+}: {
+    schema: AddonParamSchema;
+    value: unknown;
+    onChange: (key: string, val: unknown) => void;
+}) {
+    type Row = { id: number; k: string; v: string };
+
+    const nextIdRef = React.useRef<number>(0);
+    const [rows, setRows] = React.useState<Row[]>(() => {
+        const dict = (value && typeof value === 'object' && !Array.isArray(value))
+            ? (value as Record<string, unknown>)
+            : {};
+        const initial = Object.entries(dict).map(([k, v]) => ({
+            id: nextIdRef.current++,
+            k,
+            v: typeof v === 'string' ? v : String(v ?? ''),
+        }));
+        return initial;
+    });
+
+    const commit = (next: Row[]) => {
+        const dict: Record<string, string> = {};
+        for (const r of next) {
+            const k = r.k.trim();
+            if (!k) continue;
+            dict[k] = r.v;
+        }
+        onChange(schema.key, dict);
+    };
+
+    const updateRow = (id: number, patch: Partial<Pick<Row, 'k' | 'v'>>) => {
+        setRows((prev) => {
+            const next = prev.map((r) => r.id === id ? { ...r, ...patch } : r);
+            commit(next);
+            return next;
+        });
+    };
+
+    const addRow = () => {
+        setRows((prev) => [...prev, { id: nextIdRef.current++, k: '', v: '' }]);
+        // 新規空行は commit しない (空キーはサーバ送信時に除外されるため)
+    };
+
+    const deleteRow = (id: number) => {
+        setRows((prev) => {
+            const next = prev.filter((r) => r.id !== id);
+            commit(next);
+            return next;
+        });
+    };
+
+    return (
+        <div className={styles.dictControl}>
+            {rows.length > 0 && (
+                <div className={styles.dictHeader}>
+                    <span className={styles.dictHeaderCell}>キー（誤読される語）</span>
+                    <span className={styles.dictHeaderCell}>値（読ませたい表記）</span>
+                    <span className={styles.dictHeaderSpacer} />
+                </div>
+            )}
+            {rows.length === 0 && (
+                <span className={styles.dictEmpty}>(エントリなし)</span>
+            )}
+            {rows.map((row) => (
+                <div key={row.id} className={styles.dictRow}>
+                    <input
+                        type="text"
+                        className={styles.dictKeyInput}
+                        value={row.k}
+                        placeholder="key"
+                        onChange={(e) => updateRow(row.id, { k: e.target.value })}
+                    />
+                    <input
+                        type="text"
+                        className={styles.dictValueInput}
+                        value={row.v}
+                        placeholder="value"
+                        onChange={(e) => updateRow(row.id, { v: e.target.value })}
+                    />
+                    <button
+                        className={styles.dictDeleteBtn}
+                        onClick={() => deleteRow(row.id)}
+                        title="この行を削除"
+                        type="button"
+                    >
+                        <Trash2 size={13} />
+                    </button>
+                </div>
+            ))}
+            <button
+                className={styles.dictAddBtn}
+                onClick={addRow}
+                type="button"
+            >
+                <Plus size={13} /> 追加
+            </button>
+        </div>
     );
 }
 
@@ -495,7 +616,10 @@ function ParamsSection({
                 <div className={styles.paramsGroup}>
                     <div className={styles.paramsGroupLabel}>デフォルト（全ペルソナ共通）</div>
                     {configurableSchemas.map((schema) => (
-                        <div key={schema.key} className={styles.paramRow}>
+                        <div
+                            key={schema.key}
+                            className={`${styles.paramRow} ${schema.type === 'dict' ? styles.paramRowStacked : ''}`}
+                        >
                             <span className={styles.paramLabel}>{schema.label}</span>
                             <ParamControl
                                 schema={schema}
@@ -533,7 +657,10 @@ function ParamsSection({
                             {personaConfigurableSchemas.length > 0 && (
                                 <div className={styles.personaConfigBlock}>
                                     {personaConfigurableSchemas.map((schema) => (
-                                        <div key={schema.key} className={styles.paramRow}>
+                                        <div
+                                            key={schema.key}
+                                            className={`${styles.paramRow} ${schema.type === 'dict' ? styles.paramRowStacked : ''}`}
+                                        >
                                             <span className={styles.paramLabel}>{schema.label}</span>
                                             <ParamControl
                                                 schema={schema}


### PR DESCRIPTION
## Summary
アドオンが任意の key/value マップをユーザー設定として持てるよう、
`addon.json` の `params_schema` で 2 種類の新機能を導入。

- `type: "dict"` — key/value テーブル UI で編集できる新しい param 型
  (e.g. ユーザー読み方辞書、置換ルール、NG ワードなど)
- `collapsible: true` / `default_collapsed: true` — 個別 param 行を
  アコーディオン (折り畳み可能) で描画。dict のような縦に大きい入力 UI を
  普段は折り畳んでおきたい用途を想定

きっかけは Voice TTS パック側の「読み方辞書」機能だが、汎用機構として
本体に置くことで他パック (NG ワードフィルタ、置換ルール等) でも使える。

## Changes

**Frontend** (`frontend/src/components/AddonManagerModal.tsx`)
- `AddonParamSchema.type` union に `'dict'` を追加
- `AddonParamSchema` に `collapsible?: boolean` / `default_collapsed?: boolean` を追加
- `DictParamControl` (key/value テーブル + 追加/削除ボタン) を新規実装
- `ParamRow` ラッパーを抽出。`schema.collapsible === true` のとき chevron 付き
  アコーディオンで描画、それ以外は従来挙動
- dict 型は paramRow を縦積みレイアウトに切替 (`paramRowStacked`)

**Frontend CSS** (`frontend/src/components/AddonManagerModal.module.css`)
- dict コントロール / アコーディオン用スタイル一式 (light/dark)

**Backend** (`api/routes/addon.py`)
- `AddonParamSchema` Pydantic モデルに `collapsible` / `default_collapsed` を Optional で追加
- `type` フィールドのコメントを `"dict"` も含むよう更新
- ストレージ (`AddonConfig.params_json` / `AddonPersonaConfig.params_json`) は
  既に任意の JSON dict を受けるためスキーマ変更なし

## 後方互換性
- すべて Optional フィールドなので既存アドオンに影響なし
- 既存パック (`addon.json`) を改変しない限り挙動は同じ

## Test plan
- [x] `tsc --noEmit` 通過
- [x] `ruff check api/routes/addon.py` 通過
- [x] 既存 `tests/test_addon_routes_params_merge.py` 7/7 pass (params merge 経路の回帰なし)
- [x] Voice TTS パック側で `pronunciation_dict` (dict + collapsible) を使い、
      ブラウザで以下を実機確認:
  - 折り畳み既定で表示され、クリックで展開
  - key/value 行を追加・編集・削除できる
  - 保存値が再起動後も復元される
  - 同一キーが UI とファイル辞書両方にあるとき UI が優先
- [x] dict 型未対応の本体への影響: アドオン側で `dict` を使った場合
      「（未対応の型: dict）」表示にフォールバックする (元から実装済みの defensive)

## Related
- Voice TTS パック側 (Nature109/saiverse-voice-tts) で本機能を採用済み:
  https://github.com/Nature109/saiverse-voice-tts/commit/f6b3cc6
  (commit `feat: ペルソナ別読み方辞書をアドオン管理 UI で編集可能に` 以降)
