### PR TITLE
fix: 不足していた curl-cffi を requirements.txt に追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,9 @@ xai-sdk>=1.6.0
 # MCP (Model Context Protocol) client
 mcp>=1.10.0
 
+# Codex 系クライアント (llm_clients/openai_codex.py が利用)
+curl-cffi>=0.10.0
+
 # ローカルLLM (llama.cpp) を使う場合:
 #   pip install -r requirements-local-llm.txt
 


### PR DESCRIPTION
## Summary
`llm_clients/openai_codex.py` (line 28) が `from curl_cffi import requests as cffi_requests`
を実行しているが、`requirements.txt` に `curl-cffi` が未登録のため、
`setup.bat` / `pip install -r requirements.txt` 後のクリーン環境では
`python main.py city_a` が起動時に `ModuleNotFoundError: No module named 'curl_cffi'`
で落ちる。

## Changes
- `requirements.txt`: `curl-cffi>=0.10.0` を追加 (Codex 系クライアント用と明記)

## Test plan
- [x] クリーン venv で `pip install -r requirements.txt` 後、
      `python -c "from llm_clients.openai_codex import OpenAICodexClient"` が成功
- [x] `python main.py city_a` の起動が `curl_cffi` 由来エラーで止まらないことを確認
- [x] 動作確認した版: `curl_cffi-0.15.0`

## Notes
- `>=0.10.0` の下限は openai_codex.py が使う API (`cffi_requests` の cookie/session 周辺) が安定して提供される最古版に合わせて緩めに設定。実際の検証は 0.15.0 で実施。
- Windows / Linux / macOS いずれもバイナリ wheel が配布されている (cp310-cp313)
