### PR TITLE
Chrome拡張Exporterのフォーマット変更とbase64画像混入に対応

### DIFF
--- a/tools/utilities/chatlog_exporter_importer.py
+++ b/tools/utilities/chatlog_exporter_importer.py
@@ -213,15 +213,17 @@ def _enforce_monotonic_timestamps(messages: List[ExporterMessage]) -> None:
 
     Some exporters occasionally emit a Response timestamp earlier than its
     paired Prompt (apparently a bug on their side). When a message's timestamp
-    is older than the previous one's, bump it to ``previous + 1s`` so the
-    chronology always matches the document order.
+    is *strictly* older than the previous one's, bump it to ``previous + 1s``.
+    Equal timestamps are left untouched: exporter timestamps are second-
+    resolution, so adjacent messages legitimately sharing the same second
+    must not be rewritten.
     """
     prev: Optional[datetime] = None
     for msg in messages:
         if msg.timestamp is None:
             prev = None
             continue
-        if prev is not None and msg.timestamp <= prev:
+        if prev is not None and msg.timestamp < prev:
             msg.timestamp = prev + timedelta(seconds=1)
         prev = msg.timestamp
 

--- a/tools/utilities/chatlog_exporter_importer.py
+++ b/tools/utilities/chatlog_exporter_importer.py
@@ -208,6 +208,24 @@ def _increment_timestamps(
         msg.timestamp = start_time + timedelta(seconds=i * interval_seconds)
 
 
+def _enforce_monotonic_timestamps(messages: List[ExporterMessage]) -> None:
+    """Force timestamps to follow the file's message order.
+
+    Some exporters occasionally emit a Response timestamp earlier than its
+    paired Prompt (apparently a bug on their side). When a message's timestamp
+    is older than the previous one's, bump it to ``previous + 1s`` so the
+    chronology always matches the document order.
+    """
+    prev: Optional[datetime] = None
+    for msg in messages:
+        if msg.timestamp is None:
+            prev = None
+            continue
+        if prev is not None and msg.timestamp <= prev:
+            msg.timestamp = prev + timedelta(seconds=1)
+        prev = msg.timestamp
+
+
 def _apply_timestamp_strategy(
     messages: List[ExporterMessage],
     *,
@@ -295,6 +313,10 @@ def _parse_json_format(
 
     # Deduplicate messages
     messages = _deduplicate_messages(messages)
+
+    # Some exporters emit a Response timestamp earlier than its Prompt; bump
+    # any out-of-order timestamps so the final timeline matches file order.
+    _enforce_monotonic_timestamps(messages)
 
     # Newer ChatGPT Exporter mis-reports Updated as the thread's last open time;
     # prefer the final per-message timestamp when available.
@@ -409,6 +431,10 @@ def _parse_markdown_format(
 
     # Deduplicate messages
     messages = _deduplicate_messages(messages)
+
+    # Some exporters emit a Response timestamp earlier than its Prompt; bump
+    # any out-of-order timestamps so the final timeline matches file order.
+    _enforce_monotonic_timestamps(messages)
 
     # The Updated header in newer ChatGPT Exporter records the last time the
     # thread was opened rather than the last message's time, so prefer the


### PR DESCRIPTION
## Summary

Chrome拡張のExporter（ChatGPT/Claude/Gemini Exporter）が最近アップデートされ、フォーマットが変わったことに対応する改修です。`tools/utilities/chatlog_exporter_importer.py` のみ変更。

### 修正内容

- **Promptヘッダ直下の固定タイムスタンプを正しく検出**
  正規表現を `\d{4}/\d{2}/\d{2}` → `\d{4}/\d{1,2}/\d{1,2}` に拡張し、`2025/6/11 23:42:09` のような一桁月日にもマッチさせる。これでヘッダ直下のタイムスタンプ行と空行が発言本文に取り込まれてしまう事故を解消。

- **ChatGPT Exporter の Updated バグ対策**
  最終メッセージにタイムスタンプがあれば `updated_at` をそれで上書き。「スレッドを最後に開いた日時」が混入する問題を回避（MD/JSON両方）。

- **タイムスタンプ補間ロジックを統一 (`_apply_timestamp_strategy`)**
  全メッセージが個別タイムスタンプを持つ場合は補間をスキップ。古い形式やGeminiでは従来通りの補間/順次付与で動作するため後方互換性を維持。

- **base64画像参照のサニタイズ**
  Claude Exporterが本文に埋め込む `![name](data:image/...;base64,...)` を `(image)` プレースホルダに置換し、SAIMemoryへの巨大データ流入を防止（MD/JSON両方）。

- **タイムスタンプ逆転の補正 (`_enforce_monotonic_timestamps`)**
  Promptより前の時刻がResponseに記録されるバグへの対策として、直前のメッセージ以前の時刻が付いていたら `直前+1秒` に置換。Updated上書きより先に実施し、補正後の最終タイムスタンプが `updated_at` に反映されるようにした。

## Test plan

ローカルでパース関数を直接呼び出すユニットテストを実施し、以下を確認済み:

- [x] 新ChatGPT MD（一桁月日のタイムスタンプ）が正しく分離される
- [x] `updated_at` が最終メッセージのタイムスタンプで上書きされる
- [x] 古いChatGPT MD（per-msgタイムスタンプなし）は従来通り補間される
- [x] Claudeのbase64画像が `(image)` に置換される（MD/JSON）
- [x] Gemini（タイムスタンプなし）は `gemini_start_time` から順次付与される
- [x] Prompt→Response の時刻逆転が `直前+1秒` に補正され、全体が単調増加になる
- [x] 補正後のタイムスタンプが `updated_at` に反映される
- [x] `ruff check` 通過

https://claude.ai/code/session_01EbyWaKYVnsSETmFWQVPJRz

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbyWaKYVnsSETmFWQVPJRz)_