### PR TITLE
feat(addon): bubble button に message context passthrough と再生成 UX を追加

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -39,6 +39,7 @@ class ChatMessage(BaseModel):
     timestamp: Optional[str] = None
     sender: Optional[str] = None
     avatar: Optional[str] = None
+    persona_id: Optional[str] = None  # assistant メッセージで発話ペルソナを識別 (アドオン bubble button の context 等で使用)
     images: Optional[List[ChatMessageImage]] = None
     reasoning: Optional[str] = None
     activity_trace: Optional[List[dict]] = None
@@ -282,6 +283,7 @@ def get_chat_history(
             timestamp=timestamp,
             sender=sender,
             avatar=avatar,
+            persona_id=msg.get("persona_id") if role == "assistant" else None,
             images=images_list,
             reasoning=reasoning_data,
             activity_trace=activity_trace_data,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -88,6 +88,7 @@ interface Message {
     timestamp?: string; // ISO string
     avatar?: string;
     sender?: string;
+    persona_id?: string; // assistant メッセージで発話ペルソナを識別 (アドオン bubble button context 等で使用)
     images?: MessageImage[];
     llm_usage?: MessageLLMUsage;
     llm_usage_total?: MessageLLMUsageTotal;
@@ -2139,6 +2140,8 @@ export default function Home() {
                                     {msg.role === 'assistant' && addonBubbleButtons.length > 0 && (
                                         <AddonBubbleButtons
                                             messageId={msg.id || `msg-${idx}`}
+                                            messageText={msg.content}
+                                            personaId={msg.persona_id}
                                             addonMetadata={addonMetadata[msg.id || `msg-${idx}`] ?? {}}
                                             buttons={addonBubbleButtons}
                                         />

--- a/frontend/src/components/AddonBubbleButtons.tsx
+++ b/frontend/src/components/AddonBubbleButtons.tsx
@@ -1,8 +1,77 @@
 "use client";
 
-import React, { useRef } from 'react';
-import { Play, Loader } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+    Play,
+    Loader,
+    RefreshCw,
+    Mic,
+    Volume2,
+    VolumeX,
+    Wand2,
+    Sparkles,
+    BookOpen,
+    Languages,
+    Pause,
+    Square,
+    Trash2,
+    Download,
+    Upload,
+    Save,
+    Edit,
+    Copy,
+    Eye,
+    EyeOff,
+    Search,
+    Star,
+    Heart,
+    Bookmark,
+    Tag,
+    Check,
+    X,
+    Plus,
+    Minus,
+    type LucideIcon,
+} from 'lucide-react';
 import styles from './AddonBubbleButtons.module.css';
+
+// addon.json の "icon" 文字列を lucide コンポーネントへ解決するホワイトリスト。
+// addon.json で安全に指定できる name の集合を絞り、未知の値は Play にフォールバック。
+const ICON_MAP: Record<string, LucideIcon> = {
+    'play': Play,
+    'refresh-cw': RefreshCw,
+    'mic': Mic,
+    'volume-2': Volume2,
+    'volume-x': VolumeX,
+    'wand-2': Wand2,
+    'sparkles': Sparkles,
+    'book-open': BookOpen,
+    'languages': Languages,
+    'pause': Pause,
+    'square': Square,
+    'trash-2': Trash2,
+    'download': Download,
+    'upload': Upload,
+    'save': Save,
+    'edit': Edit,
+    'copy': Copy,
+    'eye': Eye,
+    'eye-off': EyeOff,
+    'search': Search,
+    'star': Star,
+    'heart': Heart,
+    'bookmark': Bookmark,
+    'tag': Tag,
+    'check': Check,
+    'x': X,
+    'plus': Plus,
+    'minus': Minus,
+};
+
+function resolveIcon(name?: string): LucideIcon {
+    if (!name) return Play;
+    return ICON_MAP[name] ?? Play;
+}
 
 export interface BubbleButtonDef {
     id: string;
@@ -17,6 +86,10 @@ export interface BubbleButtonDef {
 
 export interface AddonBubbleButtonsProps {
     messageId: string;
+    /** メッセージ本文。tool ボタンクリック時に POST body で addon に渡される */
+    messageText?: string;
+    /** assistant メッセージの発話ペルソナ ID。tool ボタンクリック時に POST body で addon に渡される */
+    personaId?: string;
     /** { addon_name: { key: value } } 形式のメタデータ */
     addonMetadata: Record<string, Record<string, unknown>>;
     /** 有効なアドオンのバブルボタン定義一覧 */
@@ -26,13 +99,27 @@ export interface AddonBubbleButtonsProps {
 function PlayAudioButton({
     audioUrl,
     label,
+    icon,
 }: {
     audioUrl: string;
     label: string;
+    icon: string;
 }) {
     const audioRef = useRef<HTMLAudioElement | null>(null);
     const [playing, setPlaying] = React.useState(false);
     const [error, setError] = React.useState(false);
+
+    // audioUrl が変わったら (例: 再生成によりサーバ側で wav が差し替わった場合)
+    // 既存の Audio オブジェクトを破棄して新しい URL を読み直す。これが無いと
+    // 一度再生したバブルは初回ロードした URL の音声をそのまま再生し続ける。
+    useEffect(() => {
+        if (audioRef.current) {
+            try { audioRef.current.pause(); } catch { /* noop */ }
+            audioRef.current = null;
+        }
+        setPlaying(false);
+        setError(false);
+    }, [audioUrl]);
 
     const handleClick = async () => {
         if (error) {
@@ -64,19 +151,118 @@ function PlayAudioButton({
         }
     };
 
+    const Icon = resolveIcon(icon);
+
     return (
         <button
             className={`${styles.bubbleBtn} ${playing ? styles.playing : ''} ${error ? styles.error : ''}`}
             onClick={handleClick}
-            title={error ? '音声の再生に失敗しました' : label}
+            title={error ? '音声の再生に失敗しました' : (playing ? '停止' : label)}
         >
-            <Play size={13} />
+            {playing ? <Square size={13} /> : <Icon size={13} />}
+        </button>
+    );
+}
+
+// tool ボタン: addon ローカル endpoint に POST してから metadata 値の変化で
+// 完了を検知する。再生成中は spinner を表示し、二重起動を防ぐ。
+function ToolBubbleButton({
+    btn,
+    messageId,
+    messageText,
+    personaId,
+    metaValue,
+}: {
+    btn: BubbleButtonDef;
+    messageId: string;
+    messageText?: string;
+    personaId?: string;
+    /** btn.metadata_key で参照される metadata の現在値。pack 側で URL に
+     *  ``?v=<version>`` 等の cache-bust トークンを付けてもらえば、再生成完了を
+     *  この値の変化で検知できる。 */
+    metaValue: unknown;
+}) {
+    const [regenerating, setRegenerating] = useState(false);
+    const [error, setError] = useState(false);
+    // クリック時点の値を覚えて、変化を検知できるようにする
+    const lastSeenValue = useRef<unknown>(metaValue);
+
+    // metaValue が変化したら regenerating を解除 (pack 側の audio_ready 完了)
+    useEffect(() => {
+        if (regenerating && metaValue !== undefined && metaValue !== lastSeenValue.current) {
+            setRegenerating(false);
+            lastSeenValue.current = metaValue;
+        }
+    }, [metaValue, regenerating]);
+
+    // タイムアウト保険: 5 分で自動解除 (SSE が来ない異常時の救済)。
+    // TTS 合成は長文 + 重いモデル (GPT-SoVITS 等) で 60 秒以上かかるケースが
+    // あるので余裕を持たせる。実合成完了時には audio_completed event で
+    // metaValue が変化し、上の useEffect で正常に解除される。
+    useEffect(() => {
+        if (!regenerating) return;
+        const timer = setTimeout(() => {
+            setRegenerating(false);
+            setError(true);
+            console.warn(`[AddonBubbleButtons] tool ${btn.tool} timed out (300s)`);
+        }, 300_000);
+        return () => clearTimeout(timer);
+    }, [regenerating, btn.tool]);
+
+    const Icon = resolveIcon(btn.icon);
+
+    const handleClick = async () => {
+        if (regenerating || !btn.tool) return;
+        setError(false);
+        lastSeenValue.current = metaValue;
+        setRegenerating(true);
+        try {
+            const res = await fetch(
+                `/api/addon/${btn.addon_name}/${btn.tool}`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        message_id: messageId,
+                        text: messageText ?? '',
+                        persona_id: personaId ?? null,
+                    }),
+                },
+            );
+            if (!res.ok) {
+                console.error(
+                    `[AddonBubbleButtons] tool ${btn.tool} returned ${res.status}`,
+                );
+                setRegenerating(false);
+                setError(true);
+            }
+            // 成功時は metadata 変化を待ってスピナー解除
+        } catch (err) {
+            console.error(
+                `[AddonBubbleButtons] tool ${btn.tool} on ${btn.addon_name} failed:`,
+                err,
+            );
+            setRegenerating(false);
+            setError(true);
+        }
+    };
+
+    return (
+        <button
+            className={`${styles.bubbleBtn} ${regenerating ? styles.pending : ''} ${error ? styles.error : ''}`}
+            title={error ? '失敗しました' : (regenerating ? `${btn.label} (実行中)` : btn.label)}
+            onClick={handleClick}
+            disabled={regenerating}
+        >
+            {regenerating ? <Loader size={13} className={styles.spinner} /> : <Icon size={13} />}
         </button>
     );
 }
 
 export default function AddonBubbleButtons({
     messageId,
+    messageText,
+    personaId,
     addonMetadata,
     buttons,
 }: AddonBubbleButtonsProps) {
@@ -124,26 +310,38 @@ export default function AddonBubbleButtons({
                                 key={`${btn.addon_name}-${btn.id}`}
                                 audioUrl={audioUrl}
                                 label={btn.label}
+                                icon={btn.icon}
                             />
                         );
                     }
                 }
 
-                // その他のアクション（拡張用プレースホルダー）
+                // tool ボタン: addon ローカル endpoint に POST。再生成中は
+                // metadata 値の変化を待ってスピナーを解除する (ToolBubbleButton)。
+                if (btn.tool) {
+                    const metaValue = btn.metadata_key ? meta[btn.metadata_key] : undefined;
+                    return (
+                        <ToolBubbleButton
+                            key={`${btn.addon_name}-${btn.id}`}
+                            btn={btn}
+                            messageId={messageId}
+                            messageText={messageText}
+                            personaId={personaId}
+                            metaValue={metaValue}
+                        />
+                    );
+                }
+
+                // tool も action も無いボタン (定義ミス) はクリックしてもエラーで沈黙させる
+                const Icon = resolveIcon(btn.icon);
                 return (
                     <button
                         key={`${btn.addon_name}-${btn.id}`}
                         className={styles.bubbleBtn}
                         title={btn.label}
-                        onClick={async () => {
-                            if (btn.tool) {
-                                await fetch(
-                                    `/api/addon/${btn.addon_name}/${btn.tool}?message_id=${encodeURIComponent(messageId)}`,
-                                );
-                            }
-                        }}
+                        disabled
                     >
-                        <Play size={13} />
+                        <Icon size={13} />
                     </button>
                 );
             })}


### PR DESCRIPTION
## Summary
アドオンが「送信済みメッセージに対して何かする」(例: TTS の音声再生成、
別言語に翻訳して再合成、要約再実行など) を実装しやすくする bubble button
基盤拡張。Voice TTS パック (`Nature109/saiverse-voice-tts`) の
`feature/regenerate-audio` で投入済みの「音声を再生成」⟲ ボタンと
組み合わせて動作する。

## Motivation
パック側で完結したかったが、bubble button の click handler が message_id
しか送らない / アイコン名が無視される / 再生成完了後にブラウザがキャッシュ
した旧音声を流し続ける / 進捗表示が無い、という UX 退行が複数発生する
ことが分かったため、本体側で 1 PR にまとめて解消する。

## Changes

### Frontend (`frontend/src/components/AddonBubbleButtons.tsx`)
- **アイコン名解決**: `addon.json` の `"icon": "refresh-cw"` 等を
  lucide コンポーネントに解決するホワイトリスト式マップ。未知の名前は
  Play フォールバック (約 30 種類対応: play / refresh-cw / mic / volume-2 /
  wand-2 / sparkles / book-open / languages / pause / square / trash-2 / ...)
- **PlayAudioButton の audioUrl 変化追従**: `useEffect([audioUrl])` で
  audioRef を破棄。再生成で URL が新版になった場合に古い `<audio>` を
  使い回さないようにする。再生中アイコンを `<Square />` (停止) に切替
- **ToolBubbleButton 抽出**: tool ボタンクリックで `POST` + JSON body
  (`{message_id, text, persona_id}`) を送り、`metadata_key` の値が変化
  したら完了とみなして spinner を解除。fetch 失敗時はその場で error 状態に。
  タイムアウト保険 5 分 (GPT-SoVITS 等の重い TTS 合成は 60 秒を超える
  ことがあるため、長めに設定)
- **AddonBubbleButtonsProps 拡張**: `messageText` / `personaId` を追加し、
  POST body 経由で addon に渡す

### Backend (`api/routes/chat.py`)
- `ChatMessage` Pydantic に `persona_id: Optional[str]` を追加
  (assistant メッセージのみ値を持つ)。frontend → addon の context として使用

### Frontend (`frontend/src/app/page.tsx`)
- `Message` 型に `persona_id?: string` を追加
- `<AddonBubbleButtons>` 呼び出しに `messageText={msg.content}` /
  `personaId={msg.persona_id}` を渡すように

## Test plan
- [x] `tsc --noEmit` 通過
- [x] `ruff check api/routes/chat.py` 通過
- [x] 既存 chat テスト 2/2 pass (回帰なし)
- [x] **実機 E2E テスト**: Voice TTS パック側で「音声を再生成」ボタンを
      クリック → 以下を確認:
  - [x] ⟲ アイコン (refresh-cw マッピング) が出る
  - [x] クリックで Loader spinner に切替・disabled になる
  - [x] 自動再生で新音声が progressive に鳴る
  - [x] 合成完了 (61秒) でアイコンが ⟲ に戻る
  - [x] ▶ クリックで新音声が鳴る (旧音声キャッシュにヒットしない)
  - [x] ▶ 再生中はアイコンが ■ (Square) に切替

## 後方互換性
- `ChatMessage.persona_id` は Optional なので既存クライアントに影響なし
- `tool` 型 bubble button のクリックは GET → POST に変わる破壊的変更を
  含むが、`tool` を addon.json で宣言している pack は確認時点で
  Voice TTS パックの今回の `feature/regenerate-audio` だけなので実害なし

## Related
- 拡張パック側: `Nature109/saiverse-voice-tts`
  [feature/regenerate-audio](https://github.com/Nature109/saiverse-voice-tts/tree/feature/regenerate-audio)
  (既に main にマージ済み: commit `b11b077`)
