### PR TITLE
fix(db): use_alter で city→user FK 循環を断ち sorted_tables 警告を解消

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -204,7 +204,11 @@ class Region(Base):
 
 class City(Base):
     __tablename__ = "city"
-    USERID = Column(Integer, ForeignKey("user.USERID"), nullable=False)
+    # use_alter=True で city→user の FK をテーブル作成後の ALTER に回し、
+    # user⇄city / user→building→(region→)city→user の FK 循環を1点で断つ。
+    # city.USERID は user へ戻る唯一の辺なので、ここ1箇所で全閉路が DAG 化され、
+    # SQLAlchemy の sorted_tables が出す unresolvable cycles 警告 (将来 error 化) を解消する。
+    USERID = Column(Integer, ForeignKey("user.USERID", use_alter=True, name="fk_city_user"), nullable=False)
     CITYID = Column(Integer, primary_key=True, autoincrement=True)
     CITYNAME = Column(String(32), nullable=False)
     DESCRIPTION = Column(String(1024), default="", nullable=False)


### PR DESCRIPTION
## 背景

`database/models.py` の user⇄city を核とした相互 FK により、起動時 (`database/migrate.py` の `needs_migration`) や `create_all` で `Base.metadata.sorted_tables` が SAWarning を出していた:

> Cannot correctly sort tables; there are unresolvable cycles between tables "building, city, region, user" ... this warning may raise an error in a future release.

将来の SQLAlchemy では **error 化する可能性が警告文に明記**されている。

## 循環グラフ

```
① user.CURRENT_CITYID     → city      (nullable)
② user.CURRENT_BUILDINGID  → building  (nullable)
③ city.USERID              → user      (NOT NULL)  ← user へ戻る唯一の辺
④ building.CITYID          → city      (NOT NULL)
⑤ building.REGION_ID       → region    (nullable)
⑥ region.CITYID            → city      (NOT NULL)
⑦ region.PARENT_REGION_ID  → region    (自己参照・順序に無関係)
```

閉路は3本:
- **A**: user → city → user (①③)
- **B**: user → building → city → user (②④③)
- **C**: user → building → region → city → user (②⑤⑥③)

3本すべてが `city.USERID → user` (③) を通って user に戻る。**③が user へ戻る唯一の辺**なので、ここ1点を作成後 ALTER に回せば全閉路が DAG 化される。初期案 (user 側の 2 FK に付与) だと閉路 A と B/C を別々に潰すことになり 2 点必要だが、③に集約すれば **最小1点**で済む。

## 変更

`city.USERID` の FK に `use_alter=True, name="fk_city_user"` を付与。

- 列は **NOT NULL のまま**（use_alter は nullability に無関係）
- SQLite では FK 制約は保持される (`fk_city_user` として作成確認済み)
- 既存 DB への影響はテーブル**作成順の話のみ**で無し

## 検証

- `sorted_tables` / `create_all` の SAWarning: **0 件**（region 含む全 45 テーブル正常作成）
- `tests/test_p1_migration.py`: **3 passed**（`-W error::sqlalchemy.exc.SAWarning` で昇格させても通過）
- `ruff check database/models.py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
