### PR TITLE
fix: SAIVERSE_HOME 外へデータが書き込まれることがある

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -8,6 +8,8 @@ router = APIRouter()
 from fastapi.responses import FileResponse
 import os
 
+from saiverse.data_paths import get_saiverse_home
+
 class ChatMessageImage(BaseModel):
     url: str  # URL to access the image
     mime_type: Optional[str] = None
@@ -219,7 +221,7 @@ def get_chat_history(
                     uri = img.get("uri", "")
                     if uri.startswith("saiverse://image/"):
                         filename = uri.replace("saiverse://image/", "")
-                        img_path = str(Path.home() / ".saiverse" / "image" / filename)
+                        img_path = str(get_saiverse_home() / "image" / filename)
                 if img_path:
                     # Serve via static endpoint
                     images_list.append(ChatMessageImage(
@@ -324,7 +326,7 @@ def _store_uploaded_attachment(base64_data: str) -> Optional[Dict[str, str]]:
         
         data = base64.b64decode(encoded)
         
-        dest_dir = Path.home() / ".saiverse" / "image"
+        dest_dir = get_saiverse_home() / "image"
         dest_dir.mkdir(parents=True, exist_ok=True)
         
         dest_name = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex}{ext}"
@@ -360,7 +362,7 @@ def _store_image_attachment(
     building_id: str
 ) -> Dict[str, Any]:
     """Store image and create picture Item."""
-    dest_dir = Path.home() / ".saiverse" / "image"
+    dest_dir = get_saiverse_home() / "image"
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     # Determine extension from mime_type
@@ -405,7 +407,7 @@ def _store_document_attachment(
     building_id: str
 ) -> Dict[str, Any]:
     """Store document and create document Item."""
-    dest_dir = Path.home() / ".saiverse" / "documents"
+    dest_dir = get_saiverse_home() / "documents"
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     dest_name = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex}_{att.filename}"

--- a/api/routes/people/arasuji.py
+++ b/api/routes/people/arasuji.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from typing import Dict, List, Optional
 from api.deps import get_manager
+from saiverse.data_paths import get_persona_memory_db
 from .models import (
     ArasujiStatsResponse, ArasujiListResponse, ArasujiEntryItem, SourceMessageItem,
     GenerateArasujiRequest, GenerationJobStatus, ChronicleCostEstimate,
@@ -63,7 +64,7 @@ def _get_arasuji_db(persona_id: str):
     import sqlite3
     from sai_memory.arasuji.storage import init_arasuji_tables
 
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     if not db_path.exists():
         return None
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
@@ -845,7 +846,7 @@ def _run_chronicle_generation(
 
     try:
         # Get database path
-        db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+        db_path = get_persona_memory_db(persona_id)
         if not db_path.exists():
             _update_job(job_id, status="failed", error=f"Database not found: {db_path}")
             return
@@ -1043,7 +1044,7 @@ async def start_arasuji_generation(
     """
     # Verify persona exists
     from pathlib import Path
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     if not db_path.exists():
         raise HTTPException(status_code=404, detail=f"Memory database not found for {persona_id}")
 

--- a/api/routes/people/memopedia.py
+++ b/api/routes/people/memopedia.py
@@ -7,6 +7,7 @@ from typing import Dict, Any
 
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from api.deps import get_manager
+from saiverse.data_paths import get_personas_dir
 from .models import (
     UpdateMemopediaPageRequest,
     CreateMemopediaPageRequest,
@@ -375,7 +376,7 @@ def _run_memopedia_generation(
         _update_memopedia_job(job_id, message="Initializing...")
         
         # Get persona database path
-        persona_dir = Path.home() / ".saiverse" / "personas" / persona_id
+        persona_dir = get_personas_dir() / persona_id
         db_path = persona_dir / "memory.db"
         
         if not db_path.exists():
@@ -489,7 +490,7 @@ async def start_memopedia_generation(
     6. Save as Memopedia page
     """
     # Validate that persona exists
-    persona_dir = Path.home() / ".saiverse" / "personas" / persona_id
+    persona_dir = get_personas_dir() / persona_id
     if not persona_dir.exists():
         raise HTTPException(status_code=404, detail=f"Persona not found: {persona_id}")
     

--- a/api/routes/people/memory.py
+++ b/api/routes/people/memory.py
@@ -5,6 +5,7 @@ import time
 
 LOGGER = logging.getLogger(__name__)
 from api.deps import get_manager
+from saiverse.data_paths import get_persona_memory_db
 from .models import (
     ThreadSummary, MessageItem, MessagesResponse, UpdateMessageRequest, CreateMessageRequest
 )
@@ -243,7 +244,7 @@ def rescue_stelis_thread(persona_id: str, manager=Depends(get_manager)):
         )
 
     thread_id = active_summary["thread_id"]
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     if not db_path.exists():
         raise HTTPException(status_code=404, detail="Memory database not found")
 

--- a/api/routes/people/reembed.py
+++ b/api/routes/people/reembed.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from api.deps import get_manager
+from saiverse.data_paths import get_persona_memory_db
 from .models import ReembedRequest, ReembedStatusResponse
 import threading
 import logging
@@ -25,7 +26,7 @@ def _run_reembed_task(persona_id: str, force: bool):
         _reembed_status[persona_id] = {"running": True, "progress": 0, "total": 0, "message": "Starting..."}
     
     try:
-        db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+        db_path = get_persona_memory_db(persona_id)
         if not db_path.exists():
             with _reembed_lock:
                 _reembed_status[persona_id] = {"running": False, "message": "Database not found"}
@@ -133,7 +134,7 @@ def reembed_persona_memory(
             return {"success": False, "message": "Re-embed already in progress.", "status": status}
     
     # Verify database exists
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     if not db_path.exists():
         raise HTTPException(status_code=404, detail=f"Memory database not found for {persona_id}")
     

--- a/api/routes/world.py
+++ b/api/routes/world.py
@@ -241,7 +241,8 @@ def create_item(i: ItemCreate, manager: SAIVerseManager = Depends(get_manager)):
             if saiverse_home:
                 full_path = saiverse_home / file_path
             else:
-                full_path = Path.home() / ".saiverse" / file_path
+                from saiverse.data_paths import get_saiverse_home
+                full_path = get_saiverse_home() / file_path
             
             if full_path.exists():
                 item_type = i.item_type.lower()

--- a/builtin_data/tools/get_visual_context.py
+++ b/builtin_data/tools/get_visual_context.py
@@ -37,7 +37,8 @@ def _resolve_image_path(path_or_url: Optional[str]) -> Optional[str]:
     # Handle API URL format
     if path_or_url.startswith(API_MEDIA_PREFIX):
         filename = path_or_url[len(API_MEDIA_PREFIX):]
-        return str(Path.home() / ".saiverse" / "image" / filename)
+        from saiverse.data_paths import get_saiverse_home
+        return str(get_saiverse_home() / "image" / filename)
 
     # Handle saiverse:// URI format
     if path_or_url.startswith("saiverse://"):
@@ -72,7 +73,8 @@ def _resolve_item_file_path(manager, file_path_str: str) -> Optional[str]:
     # Try recovery strategies using saiverse_home
     home = getattr(manager, 'saiverse_home', None)
     if not home:
-        home = Path.home() / ".saiverse"
+        from saiverse.data_paths import get_saiverse_home
+        home = get_saiverse_home()
 
     # Strategy 0: Relative path (new format)
     if not path.is_absolute():

--- a/builtin_data/tools/task_request_creation.py
+++ b/builtin_data/tools/task_request_creation.py
@@ -100,7 +100,8 @@ def _require_persona_id() -> str:
 def _resolve_persona_dir() -> Path:
     persona_path = get_active_persona_path()
     if persona_path is None:
-        base = Path.home() / ".saiverse" / "personas"
+        from saiverse.data_paths import get_personas_dir
+        base = get_personas_dir()
         persona_id = _require_persona_id()
         return base / persona_id
     return persona_path

--- a/builtin_data/tools/thread_switch.py
+++ b/builtin_data/tools/thread_switch.py
@@ -129,7 +129,8 @@ def _build_adapter(persona_id: str, persona_path: Optional[str]) -> SAIMemoryAda
     if persona_path:
         persona_dir = Path(persona_path).expanduser()
         if not persona_dir.is_absolute():
-            persona_dir = Path.home() / ".saiverse" / "personas" / persona_path
+            from saiverse.data_paths import get_personas_dir
+            persona_dir = get_personas_dir() / persona_path
         persona_dir = persona_dir.resolve()
     else:
         ctx_path = get_active_persona_path()

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from pathlib import Path
 load_dotenv()
 
 # Migrate legacy user_data/ to ~/.saiverse/user_data/ if needed
-from saiverse.data_paths import migrate_legacy_user_data
+from saiverse.data_paths import get_saiverse_home, migrate_legacy_user_data
 migrate_legacy_user_data()
 
 try:
@@ -397,7 +397,7 @@ def main():
 
     # Mount uploads directory for user-attached images FIRST (more specific path)
     # Access via /api/static/uploads/filename.png
-    uploads_dir = Path.home() / ".saiverse" / "image"
+    uploads_dir = get_saiverse_home() / "image"
     uploads_dir.mkdir(parents=True, exist_ok=True)
     app.mount("/api/static/uploads", StaticFiles(directory=str(uploads_dir)), name="uploads")
 

--- a/persona/tasks/creation.py
+++ b/persona/tasks/creation.py
@@ -195,7 +195,8 @@ class TaskCreationProcessor:
 
 
 def process_all_personas(base_dir: Optional[Path] = None) -> Dict[str, List[str]]:
-    base = base_dir or (Path.home() / ".saiverse" / "personas")
+    from saiverse.data_paths import get_personas_dir
+    base = base_dir or get_personas_dir()
     results: Dict[str, List[str]] = {}
     if not base.exists():
         return results

--- a/persona/tasks/storage.py
+++ b/persona/tasks/storage.py
@@ -89,7 +89,11 @@ class TaskStorage:
         create_dir: bool = True,
     ) -> None:
         self.persona_id = persona_id
-        home_dir = base_dir or (Path.home() / ".saiverse")
+        if base_dir:
+            home_dir = base_dir
+        else:
+            from saiverse.data_paths import get_saiverse_home
+            home_dir = get_saiverse_home()
         personas_root = home_dir / "personas"
         if create_dir:
             personas_root.mkdir(parents=True, exist_ok=True)

--- a/sai_memory/backup.py
+++ b/sai_memory/backup.py
@@ -21,11 +21,29 @@ from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
 
-BACKUP_ROOT = Path.home() / ".saiverse" / "backups" / "saimemory_rdiff"
-BACKUP_ROOT.mkdir(parents=True, exist_ok=True)
-SIMPLE_BACKUP_ROOT = Path.home() / ".saiverse" / "backups" / "saimemory_simple"
-SIMPLE_BACKUP_ROOT.mkdir(parents=True, exist_ok=True)
-GLOBAL_LOCK_PATH = Path(os.getenv("SAIMEMORY_BACKUP_LOCK_PATH", BACKUP_ROOT / "saimemory_backup.lock"))
+def get_backup_root() -> Path:
+    """rdiff-backup repository root under SAIVERSE_HOME (created on demand)."""
+    from saiverse.data_paths import get_saiverse_home
+
+    root = get_saiverse_home() / "backups" / "saimemory_rdiff"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def get_simple_backup_root() -> Path:
+    """Simple-copy backup root under SAIVERSE_HOME (created on demand)."""
+    from saiverse.data_paths import get_saiverse_home
+
+    root = get_saiverse_home() / "backups" / "saimemory_simple"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def get_global_lock_path() -> Path:
+    env_path = os.getenv("SAIMEMORY_BACKUP_LOCK_PATH")
+    if env_path:
+        return Path(env_path)
+    return get_backup_root() / "saimemory_backup.lock"
 BACKUP_TIMEOUT_SEC = int(os.getenv("SAIMEMORY_BACKUP_TIMEOUT_SEC", "300"))
 LOCK_WAIT_SEC = int(os.getenv("SAIMEMORY_BACKUP_LOCK_WAIT_SEC", "10"))
 RETRY_ON_CORRUPT = os.getenv("SAIMEMORY_BACKUP_RETRY_ON_CORRUPT", "true").strip().lower() in {"1", "true", "yes", "on"}
@@ -69,7 +87,7 @@ def _sqlite_snapshot(db_path: Path) -> Path:
 
 
 def _persona_backup_dir(persona_id: str, root: Path | None = None) -> Path:
-    base = Path(root) if root else BACKUP_ROOT
+    base = Path(root) if root else get_backup_root()
     persona_root = base / persona_id
     persona_root.mkdir(parents=True, exist_ok=True)
     return persona_root
@@ -144,10 +162,11 @@ def _is_process_alive(pid: int) -> bool:
 
 def _check_stale_lock() -> bool:
     """Check if the lock file is stale (holder process is dead). Returns True if stale and cleaned up."""
-    if not GLOBAL_LOCK_PATH.exists():
+    lock_path = get_global_lock_path()
+    if not lock_path.exists():
         return False
     try:
-        content = GLOBAL_LOCK_PATH.read_text().strip()
+        content = lock_path.read_text().strip()
         # Parse pid=XXXXX from lock file
         for part in content.split():
             if part.startswith("pid="):
@@ -156,9 +175,9 @@ def _check_stale_lock() -> bool:
                     LOGGER.warning(
                         "Removing stale backup lock (holder pid=%d is dead): %s",
                         pid,
-                        GLOBAL_LOCK_PATH,
+                        lock_path,
                     )
-                    GLOBAL_LOCK_PATH.unlink(missing_ok=True)
+                    lock_path.unlink(missing_ok=True)
                     return True
                 break
     except Exception as exc:
@@ -179,8 +198,9 @@ def _global_backup_lock(timeout: int = LOCK_WAIT_SEC):
         yield
         return
 
-    GLOBAL_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(GLOBAL_LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o600)
+    lock_path = get_global_lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     start = time.monotonic()
     acquired = False
     try:
@@ -264,7 +284,7 @@ def latest_backup_path(persona_id: str, output_root: Path | None = None) -> Path
 
 def _simple_backup_dir(persona_id: str, root: Path | None = None) -> Path:
     """Get the simple backup directory for a persona."""
-    base = Path(root) if root else SIMPLE_BACKUP_ROOT
+    base = Path(root) if root else get_simple_backup_root()
     persona_dir = base / persona_id
     persona_dir.mkdir(parents=True, exist_ok=True)
     return persona_dir

--- a/saiverse/data_paths.py
+++ b/saiverse/data_paths.py
@@ -304,6 +304,16 @@ def load_prompt(name: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def get_personas_dir() -> Path:
+    """Get the canonical persona data root (SAIVERSE_HOME/personas)."""
+    return get_saiverse_home() / "personas"
+
+
+def get_persona_memory_db(persona_id: str) -> Path:
+    """Get the canonical SAIMemory database path for a persona."""
+    return get_personas_dir() / persona_id / "memory.db"
+
+
 def get_user_icons_dir() -> Path:
     """Get the user icons directory, creating it if needed."""
     icons_dir = USER_DATA_DIR / ICONS_DIR

--- a/saiverse/media_utils.py
+++ b/saiverse/media_utils.py
@@ -296,8 +296,10 @@ def iter_image_media(metadata: Any) -> List[Dict[str, Any]]:
         if uri:
             path = resolve_media_uri(uri)
         
-        # Fallback: use direct path field if URI resolution failed
-        if path is None:
+        # Fallback: use direct path field if URI resolution failed or the
+        # resolved file is missing (e.g. records saved under a different
+        # SAIVERSE_HOME before path derivation was unified)
+        if path is None or not path.exists():
             direct_path = item.get("path")
             if direct_path:
                 if isinstance(direct_path, Path):

--- a/saiverse_memory/native_export.py
+++ b/saiverse_memory/native_export.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
+from saiverse.data_paths import get_persona_memory_db
 from sai_memory.memory.storage import (
     add_message,
     delete_thread,
@@ -147,7 +148,7 @@ def export_threads_native(
     Returns:
         Dict in saiverse_saimemory_v1 format.
     """
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     if not db_path.exists():
         raise FileNotFoundError(f"memory.db not found for persona {persona_id}: {db_path}")
 
@@ -176,7 +177,7 @@ def export_thread_by_id(
     thread_id: str,
 ) -> Dict[str, Any]:
     """Export a single thread by its full thread_id. Used by API."""
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     if not db_path.exists():
         raise FileNotFoundError(f"memory.db not found for persona {persona_id}: {db_path}")
 
@@ -267,7 +268,7 @@ def import_threads_native(
     """
     _validate_native_format(data)
 
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = get_persona_memory_db(persona_id)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = init_db(str(db_path), check_same_thread=True)
 

--- a/scripts/_shared/config.py
+++ b/scripts/_shared/config.py
@@ -19,7 +19,7 @@ def prepare_script_runtime() -> None:
 
 
 def resolve_persona_db_path(persona_id: str) -> Path:
-    return Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    return Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona_id / "memory.db"
 
 
 def load_runtime_config(persona_id: str) -> MemopediaRuntimeConfig:

--- a/scripts/arasuji/build_arasuji_core.py
+++ b/scripts/arasuji/build_arasuji_core.py
@@ -89,7 +89,7 @@ ENV_MAINTAIN_INTERVAL = int(os.getenv("MEMORY_WEAVE_MAINTAIN_INTERVAL", "0"))
 
 def get_persona_db_path(persona_id: str) -> Path:
     """Get the path to a persona's memory.db file."""
-    return Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    return Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona_id / "memory.db"
 
 
 def fetch_messages(

--- a/scripts/backup_saimemory.py
+++ b/scripts/backup_saimemory.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
+
 import argparse
 import logging
 import sys
@@ -16,8 +18,8 @@ from sai_memory.backup import BackupError, run_backup
 
 load_dotenv()
 
-DEFAULT_BACKUP_ROOT = Path.home() / ".saiverse" / "backups" / "saimemory_rdiff"
-DEFAULT_PERSONA_ROOT = Path.home() / ".saiverse" / "personas"
+DEFAULT_BACKUP_ROOT = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "backups" / "saimemory_rdiff"
+DEFAULT_PERSONA_ROOT = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas"
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/export_saimemory_to_json.py
+++ b/scripts/export_saimemory_to_json.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
+
 import argparse
 import json
 import sys
@@ -59,7 +61,7 @@ def _resolve_thread_ids(conn, persona: str, threads: Optional[Iterable[str]]) ->
 
 
 def export_messages(persona: str, threads: Optional[Iterable[str]], start_ts: Optional[str], end_ts: Optional[str]) -> list[dict]:
-    db_path = Path.home() / ".saiverse" / "personas" / persona / "memory.db"
+    db_path = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona / "memory.db"
     if not db_path.exists():
         raise FileNotFoundError(f"memory.db not found for persona {persona}: {db_path}")
 

--- a/scripts/fix_thread_timestamps.py
+++ b/scripts/fix_thread_timestamps.py
@@ -16,6 +16,7 @@ Examples:
     python scripts/fix_thread_timestamps.py nagi_city_a "nagi_city_a:main" "2024-03-15T14:30:00" "2024-03-15T22:00:00"
 """
 
+import os
 import argparse
 import sqlite3
 import sys
@@ -29,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 def get_db_path(persona_id: str) -> Path:
     """ペルソナのメモリDBパスを取得"""
-    return Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    return Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona_id / "memory.db"
 
 
 def parse_datetime(dt_str: str) -> datetime:

--- a/scripts/import_persona_logs_to_saimemory.py
+++ b/scripts/import_persona_logs_to_saimemory.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
+
 import argparse
 import json
 import logging
@@ -22,8 +24,8 @@ LOGGER = logging.getLogger("sai_memory.migrate")
 
 load_dotenv()
 
-PERSONA_ROOT = Path.home() / ".saiverse" / "personas"
-CITIES_ROOT = Path.home() / ".saiverse" / "cities"
+PERSONA_ROOT = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas"
+CITIES_ROOT = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "cities"
 
 
 def _parse_log_path(entry: str) -> Tuple[Optional[str], Path]:

--- a/scripts/maintain_memopedia.py
+++ b/scripts/maintain_memopedia.py
@@ -80,7 +80,7 @@ def load_prompt(name: str) -> str:
 
 def get_persona_db_path(persona_id: str) -> Path:
     """Get the path to a persona's memory.db file."""
-    return Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    return Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona_id / "memory.db"
 
 
 def get_all_descendant_ids(memopedia: Memopedia, page_id: str) -> set:

--- a/scripts/migrate_memory_tags.py
+++ b/scripts/migrate_memory_tags.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
+
 import json
 import sqlite3
 from pathlib import Path
@@ -40,7 +42,7 @@ def migrate_memory_tags(persona_dir: Path) -> None:
 
 
 def main() -> None:
-    base = Path.home() / ".saiverse" / "personas"
+    base = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas"
     if not base.exists():
         print(f"No personas found at {base}")
         return

--- a/scripts/prune_sai_memory.py
+++ b/scripts/prune_sai_memory.py
@@ -6,6 +6,7 @@ Usage example:
     python scripts/prune_sai_memory.py --persona eris_city_a --since "2025-10-08T00:00:00"
 """
 
+import os
 import argparse
 import sqlite3
 from datetime import datetime
@@ -142,7 +143,7 @@ def main() -> None:
 
     cutoff = parse_timestamp(args.since) if args.since is not None else None
     persona_id = args.persona
-    db_path = Path(args.db) if args.db else Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = Path(args.db) if args.db else Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona_id / "memory.db"
 
     if not db_path.exists():
         raise SystemExit(f"memory database not found at {db_path}")

--- a/scripts/reembed_memory.py
+++ b/scripts/reembed_memory.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+
 import argparse
 import json
 import sys
@@ -62,7 +64,7 @@ def _reembed_persona(
     chunk_max: int,
     force: bool = False,
 ) -> None:
-    db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+    db_path = Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / persona_id / "memory.db"
     if not db_path.exists():
         print(f"[skip] memory.db not found for {persona_id}: {db_path}", file=sys.stderr)
         return

--- a/scripts/tag_conversation_messages.py
+++ b/scripts/tag_conversation_messages.py
@@ -2,6 +2,8 @@
 """Add missing 'conversation' tags to SAIMemory messages."""
 from __future__ import annotations
 
+import os
+
 import argparse
 import json
 import sqlite3
@@ -52,7 +54,7 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 
-    db_path = Path(args.db) if args.db else Path.home() / ".saiverse" / "personas" / args.persona / "memory.db"
+    db_path = Path(args.db) if args.db else Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse") / "personas" / args.persona / "memory.db"
     if not db_path.exists():
         parser.error(f"memory.db not found at {db_path}")
 

--- a/tests/test_attachment_paths.py
+++ b/tests/test_attachment_paths.py
@@ -1,0 +1,113 @@
+"""Attachment save/resolve paths must honor SAIVERSE_HOME.
+
+Regression tests for the docker deployment bug where uploads were written to
+``Path.home()/.saiverse/image`` (``/root/.saiverse`` in containers) while
+``media_utils.resolve_media_uri`` resolved ``saiverse://image/...`` URIs
+against ``SAIVERSE_HOME`` (``/data/.saiverse``), so image attachments never
+reached the LLM.
+"""
+import base64
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class AttachmentPathTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name) / "saiverse_home"
+        self._env = patch.dict(os.environ, {"SAIVERSE_HOME": str(self.home)})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def test_store_uploaded_attachment_uses_saiverse_home(self):
+        from api.routes.chat import _store_uploaded_attachment
+
+        payload = "data:image/png;base64," + base64.b64encode(b"fake-png-bytes").decode("ascii")
+        result = _store_uploaded_attachment(payload)
+
+        self.assertIsNotNone(result)
+        dest = Path(result["path"])
+        self.assertEqual(dest.parent, self.home / "image")
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.read_bytes(), b"fake-png-bytes")
+        self.assertTrue(result["uri"].startswith("saiverse://image/"))
+
+    def test_store_image_attachment_uses_saiverse_home(self):
+        from api.routes.chat import AttachmentData, _store_image_attachment
+
+        att = AttachmentData(data="", filename="cat.jpg", type="image", mime_type="image/jpeg")
+        manager = MagicMock()
+        manager.create_picture_item_for_user.return_value = "item-1"
+
+        result = _store_image_attachment(b"jpeg-bytes", att, manager, "building_x")
+
+        dest = Path(result["path"])
+        self.assertEqual(dest.parent, self.home / "image")
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.read_bytes(), b"jpeg-bytes")
+
+    def test_store_document_attachment_uses_saiverse_home(self):
+        from api.routes.chat import AttachmentData, _store_document_attachment
+
+        att = AttachmentData(data="", filename="note.txt", type="document", mime_type="text/plain")
+        manager = MagicMock()
+        manager.create_document_item_for_user.return_value = "item-2"
+
+        result = _store_document_attachment(b"hello doc", att, manager, "building_x")
+
+        dest = Path(result["path"])
+        self.assertEqual(dest.parent, self.home / "documents")
+        self.assertTrue(dest.exists())
+
+    def test_saved_attachment_uri_resolves_back_to_same_file(self):
+        """The URI written into message metadata must resolve to the saved file."""
+        from api.routes.chat import _store_uploaded_attachment
+        from saiverse.media_utils import resolve_media_uri
+
+        payload = "data:image/jpeg;base64," + base64.b64encode(b"roundtrip").decode("ascii")
+        result = _store_uploaded_attachment(payload)
+
+        resolved = resolve_media_uri(result["uri"])
+        self.assertIsNotNone(resolved)
+        self.assertEqual(Path(result["path"]), resolved)
+        self.assertTrue(resolved.exists())
+
+
+class IterImageMediaFallbackTests(unittest.TestCase):
+    """iter_image_media should fall back to the recorded absolute path when the
+    URI resolves to a missing file (e.g. records written before the path fix)."""
+
+    def test_falls_back_to_direct_path_when_resolved_uri_missing(self):
+        from saiverse.media_utils import iter_image_media
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "saiverse_home"
+            real_file = Path(tmp) / "elsewhere" / "photo.jpg"
+            real_file.parent.mkdir(parents=True)
+            real_file.write_bytes(b"jpg")
+
+            with patch.dict(os.environ, {"SAIVERSE_HOME": str(home)}):
+                items = iter_image_media(
+                    {
+                        "images": [
+                            {
+                                "uri": "saiverse://image/photo.jpg",
+                                "path": str(real_file),
+                                "mime_type": "image/jpeg",
+                            }
+                        ]
+                    }
+                )
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["path"], real_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_saiverse_home_paths.py
+++ b/tests/test_saiverse_home_paths.py
@@ -1,0 +1,74 @@
+"""Canonical persona/backup path derivation must honor SAIVERSE_HOME.
+
+Companion to tests/test_attachment_paths.py: any runtime path that is derived
+from ``Path.home()/.saiverse`` instead of ``SAIVERSE_HOME`` silently points at
+the wrong (ephemeral) location inside containers.
+"""
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class PersonaPathHelperTests(unittest.TestCase):
+    def test_get_personas_dir_honors_saiverse_home(self):
+        from saiverse.data_paths import get_personas_dir
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"SAIVERSE_HOME": tmp}):
+                self.assertEqual(get_personas_dir(), Path(tmp) / "personas")
+
+    def test_get_persona_memory_db_honors_saiverse_home(self):
+        from saiverse.data_paths import get_persona_memory_db
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"SAIVERSE_HOME": tmp}):
+                self.assertEqual(
+                    get_persona_memory_db("akane_city_a"),
+                    Path(tmp) / "personas" / "akane_city_a" / "memory.db",
+                )
+
+
+class BackupRootTests(unittest.TestCase):
+    def test_backup_roots_honor_saiverse_home(self):
+        from sai_memory.backup import get_backup_root, get_simple_backup_root
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"SAIVERSE_HOME": tmp}):
+                self.assertEqual(
+                    get_backup_root(), Path(tmp) / "backups" / "saimemory_rdiff"
+                )
+                self.assertEqual(
+                    get_simple_backup_root(), Path(tmp) / "backups" / "saimemory_simple"
+                )
+
+    def test_simple_backup_writes_under_saiverse_home(self):
+        """run_backup_auto (as called on startup, without output_root) must
+        place backups inside SAIVERSE_HOME, not Path.home()."""
+        from sai_memory.backup import run_backup_auto
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            db_path = Path(tmp) / "memory.db"
+            with sqlite3.connect(db_path) as conn:
+                conn.execute("CREATE TABLE t (x INTEGER)")
+                conn.execute("INSERT INTO t VALUES (1)")
+
+            with patch.dict(os.environ, {"SAIVERSE_HOME": str(home)}):
+                result = run_backup_auto(
+                    persona_id="p1",
+                    db_path=db_path,
+                    prefer_simple=True,
+                )
+
+            self.assertIsNotNone(result)
+            self.assertTrue(
+                str(result).startswith(str(home / "backups")),
+                f"backup written outside SAIVERSE_HOME: {result}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utilities/memory_settings_ui.py
+++ b/tools/utilities/memory_settings_ui.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
 import gradio as gr
+
+from saiverse.data_paths import get_persona_memory_db
 import pandas as pd
 from gradio.events import SelectData
 
@@ -1454,7 +1456,7 @@ def create_memory_settings_ui(manager) -> None:
             """Get database connection for arasuji."""
             from pathlib import Path
             import sqlite3
-            db_path = Path.home() / ".saiverse" / "personas" / persona_id / "memory.db"
+            db_path = get_persona_memory_db(persona_id)
             if not db_path.exists():
                 return None
             conn = sqlite3.connect(str(db_path), check_same_thread=False)


### PR DESCRIPTION
## 概要

https://discord.com/channels/1471532452966174946/1471646730729689299/1523686504847773786

アイテムのアップロード先や `sai_memory` のバックアップ先などで `Path.home()` を直接参照している箇所があり、`$SAIVERSE_HOME` 外のパスにデータを書き込むことがある。本 PR では、これらすべてを `saiverse.data_paths.get_saiverse_home()` 経由で `SAIVERSE_HOME` から導出するよう統一し、同種のヘルパー（`get_personas_dir()`、`get_persona_memory_db()`）を追加、バックアップモジュールの root/lock パスを import 時の定数ではなく遅延評価（環境変数を都度参照）する関数に変更した。

- アップロードされた画像・ドキュメント添付ファイルは `Path.home()/.saiverse` 配下に保存される一方、`saiverse://` URI の解決は `$SAIVERSE_HOME` を基準に行われていた。両者が異なる環境では、添付ファイルが resolver の見ない場所へ静かに保存されてしまい、LLM には実際の画像・ドキュメントが渡らず「添付アイテム作成: 画像…」のようなプレースホルダのテキストしか見えていなかった。
  - インストールスクリプトの標準設定を用いる限りでは `$HOME` と `$SAIVERSE_HOME`（未設定時のデフォルトは `~/.saiverse`）が一致するため、この問題は表面化しない。
- 同種のバグがないか監査したところ、API ルート・ツールのフォールバック・スクリプト群に `Path.home()/.saiverse` のハードコードが他に約30箇所見つかった。特に `sai_memory/backup.py` で、モジュールレベルの `BACKUP_ROOT` / `SIMPLE_BACKUP_ROOT` が import 時に `Path.home()` から評価（かつ `mkdir`）されていたため、`SAIMEMORY_BACKUP_ON_START=true` によるペルソナの `memory.db` 起動時バックアップが `SAIVERSE_HOME` の外に書かれていた。

## 含まれる変更

**`fix(media): derive attachment paths from SAIVERSE_HOME, not Path.home()`**
- `api/routes/chat.py`、`main.py`、`builtin_data/tools/get_visual_context.py`、`api/routes/world.py`: 添付ファイルの保存・配信・表示パスをすべて `get_saiverse_home()` 経由に変更。
- `saiverse/media_utils.py`: `iter_image_media` が、URI から解決したファイルが見つからない場合に記録済みの絶対パスへフォールバックするよう修正。これにより本修正前（あるいは別の `SAIVERSE_HOME` 下）で書き込まれたレコードも、添付を丸ごと落とすのではなく緩やかに動作するようになった。
- テスト: `tests/test_attachment_paths.py`（アップロード／画像／ドキュメント添付のパス導出、URI の往復解決、フォールバック挙動）。

**`fix(paths): honor SAIVERSE_HOME across persona memory and backup paths`**
- `saiverse/data_paths.py`: 正規ヘルパー `get_personas_dir()` / `get_persona_memory_db(persona_id)` を追加。
- `sai_memory/backup.py`: `BACKUP_ROOT` / `SIMPLE_BACKUP_ROOT` / `GLOBAL_LOCK_PATH` のモジュールレベル定数を、呼び出し時に `SAIVERSE_HOME` から導出する遅延関数 `get_backup_root()` / `get_simple_backup_root()` / `get_global_lock_path()` に置き換え。
- メモリ関連の API ルート（`memory`、`arasuji`、`reembed`、`memopedia`、`native_export`）とツールのフォールバック（`thread_switch`、`task_request_creation`、`persona/tasks/{creation,storage}.py`）を正規ヘルパーに切り替え。
- `scripts/` 配下の11本のホスト側スクリプト: これらの一部は（sys.path の都合で）`saiverse` パッケージを import できないため、代わりに `Path(os.getenv("SAIVERSE_HOME") or Path.home() / ".saiverse")` というインラインのフォールバックを使用。
- テスト: `tests/test_saiverse_home_paths.py`（ヘルパーの正しさ、バックアップ root の導出、`run_backup_auto(prefer_simple=True)` が `SAIVERSE_HOME` 配下に書き込むことを確認する振る舞いテスト）。
