### PR TITLE
docs(voice-tts): 公開前にやることを Phase 4-E に洗い出し、依存管理の数え漏れと警告の助言を issue 化

### DIFF
--- a/docs/intent/addon_catalog_management.md
+++ b/docs/intent/addon_catalog_management.md
@@ -1,6 +1,6 @@
 # Intent: アドオンカタログ管理 (curated registry + ワンタッチ導入)
 
-**ステータス**: Phase 4 完了 (voice-tts 除く、2026-05-23)。voice-tts は Nature109 共有 repo の PR レビュー後に Phase 4-E として後追い対応予定
+**ステータス**: Phase 4 完了 (voice-tts 除く、2026-05-23)。voice-tts の Phase 4-E は未着手 (前提だった PR #4 は 2026-05-24 にマージ済み)。公開前に必要な作業と、まはーが決めることは、2026-09-11 に Phase 4-E の節へ洗い出してある
 
 ## これは何か
 
@@ -249,7 +249,63 @@ voice-tts は `external/GPT-SoVITS/` (5.2GB) を `setup.bat` で初回 DL する
 - **4-F registry public 化**: github.com/maha0525/saiverse-addon-registry を public で作成 + push、 raw.githubusercontent.com 経由で env override なしで fetch できることを実機確認 ✅
 - **インシデント (2026-05-23)**: Phase 4-D で stackchan のコード path 変更を push したが migration 起動時呼び出しを「voice-tts 完了後」 と遅延、 結果まはー の SAIVerse 再起動でアバター画像 / ペアリング情報が UI から不可視に。 手動コピーで復旧後、 `ENABLED_ADDONS_FOR_STARTUP` フィルタを設けて voice-tts 以外を起動時 migration 有効化 (`c362b1e`)。 教訓: 「コード path 変更と migration はセット commit」、 詳細は memory `feedback_code_path_migration_coupling.md`
 
-### Phase 4-E: voice-tts v2 化 (PR レビュー待ち)
+### Phase 4-E: voice-tts v2 化 (未着手、2026-09-11 に公開前の作業を洗い出し)
+
+voice-tts の upstream (元になっているリポジトリ) は `Nature109/saiverse-voice-tts` で、GitHub 上でそれを複製したフォーク `maha0525/saiverse-voice-tts` もある。PR #4〜#6 は maha0525 が作成し、#4 は Nature109 のアカウントがマージした。
+
+この節では、次の語をこの意味で使う。
+
+- **requirements.lock** は、本体が動作を確かめた版に全パッケージを固定した一覧 ([dependency_management.md](dependency_management.md))。
+- **constraints** は、pip の `-c` オプションで渡す「この一覧に書いてある版から動かすな」という指定。
+- **venv** は、SAIVerse が使う Python の仮想環境 (virtual environment)。本体とアドオンのパッケージは同じ venv に入る。
+- **衝突** は、パッケージ同士の版の条件が両立しないこと (pip check の警告文と同じ呼び方)。
+- **GIL** (Global Interpreter Lock) は、Python が一度に一つのスレッドにしか処理をさせない仕組み。
+
+#### 2026-09-11 時点の現状
+
+- 旧手順が前提にしていた PR #4 (音声の配信経路と再生キューの変更) は、2026-05-24 にマージ済み。upstream の main ブランチには、それ以降のコミットが無い。
+- `addon.json` に `manifest_version` も `setup` も無い。upstream の main ブランチ、フォークの main ブランチ、まはーの手元の `expansion_data/saiverse-voice-tts/` の三つで確認した。このままでは、アドオンカタログから GPT-SoVITS を入れられない。
+- 公開の registry.json に voice-tts は載っていない (載っているのは Elyth・X・stackchan)。
+- 合成した音声は、旧来の `~/.saiverse/user_data/voice/out/` に保存されている (`tools/speak/playback_worker.py` の `_OUT_DIR`)。
+- ペルソナごとの参照音声は、本体のアップロード処理 (`api/routes/addon.py` の `_resolve_file_dir`) によって `~/.saiverse/user_data/addon_files/saiverse-voice-tts/personas/<persona_id>/` に保存され、その絶対パスが DB の `AddonPersonaConfig.params_json` に記録される。voice-tts の合成では、記録された絶対パスがそのまま使われる (`tools/speak/profiles.py` の `_resolve_ref_audio`)。
+- 本体の `saiverse/addon_migrations.py` には、voice-tts の参照音声 (`addon_files/saiverse-voice-tts/` から `addon_data/saiverse-voice-tts/inputs/` へ) と合成音声 (`voice/out/` から `addon_data/saiverse-voice-tts/outputs/` へ) を移す処理がすでにある。`ENABLED_ADDONS_FOR_STARTUP` に voice-tts が入っていないので、起動時には実行されない。
+- upstream にまだマージされていない PR が 2 本ある。#5 は GPT-SoVITS の合成の別プロセス化 (2026-05-24 に作成)。#6 は、音声のストリームが止まったときに SAIVerse の終了処理が止まったままにならないよう、待ち時間に上限を付ける修正 (2026-08-27 に作成)。まはーの手元の `feature/tts-out-of-process` ブランチ (#5 のブランチ) には、`tools/speak/engine/gpt_sovits.py` と `tools/speak/playback_worker.py` にコミットされていない変更がある。
+- voice-tts には Windows 用の `setup.bat` しかなく、`setup.sh` は無い。voice-tts の requirements.txt のコメントには、どのプラットフォームでも使える導入コマンドとして `python scripts/install_backends.py gpt_sovits` が書かれている。
+
+#### 旧手順の 3 番が、いまのままでは成り立たない理由
+
+旧手順 (この節の最後に残してある) の 3 番は、「`setup.bat` を `platform_script` の step で登録する」としていた。これは requirements.lock の導入 (2026-09-02) より前に書かれたもので、いまは次の二つの理由で成り立たない。3 番を計画から外すかどうかは、まはーが決める。
+
+1. `setup.bat` は `scripts/install_backends.py` を通して、GPT-SoVITS の requirements.txt をそのまま `pip install -r` する。その中の `numpy<2.0` と `pydantic<=2.10.6` は、requirements.lock (numpy は Python 3.12 以上で 2.5.2、3.11 で 2.4.6。pydantic は 2.13.5) と両立しない。さらに、`gradio<5` で入る gradio 4.44.1 は `pillow<11` を、それが連れてくる gradio-client 1.3.0 は `websockets<13` を、`torchmetrics<=1.5` で入る torchmetrics 1.5.0 は `numpy<2.0` を要求していて、requirements.lock の pillow 11.3.0・websockets 16.1.1・numpy と衝突する。
+2. `saiverse/addon_installer.py` では、requirements.lock が constraints として pip に渡されるのは `pip_install` の step だけで、`platform_script` の step で実行されるスクリプトには渡されない ([addon_setup_scripts_bypass_lock_constraints.md](../issues/addon_setup_scripts_bypass_lock_constraints.md))。旧手順のまま実行すると、venv の本体のパッケージが requirements.lock の版から引き下げられる。
+
+#### 公開前にやること (2026-09-11 にメティスが洗い出した。進め方はまはー未決)
+
+1. **voice-tts 用の GPT-SoVITS の requirements を、voice-tts 側で持つ。** GPT-SoVITS の requirements.txt を元に、次を変える。
+   - `gradio` を外す。GPT-SoVITS の推論で読み込まれるコード (`GPT_SoVITS/TTS_infer_pack/TTS.py` から import を辿れる範囲) は、gradio を import していない。gradio を import しているのは、WebUI の 5 つ (`webui.py`、`GPT_SoVITS/inference_webui.py`、`GPT_SoVITS/inference_webui_fast.py`、`tools/uvr5/webui.py`、`tools/subfix_webui.py`) と `tools/my_utils.py` だった。`tools/my_utils.py` を import しているのは、WebUI、学習・データ準備・書き出し用のスクリプト、実験的なストリーミング推論のスクリプト (`GPT_SoVITS/stream_v2pro.py`) で、voice-tts の入口 (`tools/speak/engine/gpt_sovits.py` の `from TTS_infer_pack.TTS import TTS, TTS_Config`) から辿れる範囲には無い。これはコードを辿った確認で、gradio を外した venv で合成してはいない。
+   - `numpy<2.0` と `pydantic<=2.10.6` の上限を外す。2026-09-03 00:11 の再起動で、numpy 2.5.2 と pydantic 2.13.5 が入った venv (まはーの開発機、Windows、Python 3.13) のまま、voice-tts の合成は成功している ([dependency_management.md](dependency_management.md) §5 の 6)。
+   - `torchmetrics<=1.5` を `torchmetrics>=1.5.2` にする。torchmetrics は `GPT_SoVITS/AR/models/t2s_model.py` が import していて、推論で必要になる。1.5.0 は `numpy<2.0` を要求するが、1.5.2 以降は numpy の上限を持たない (PyPI で確認)。1.5.2 以降で推論が通るかは未確認。
+   - voice-tts の requirements.txt に、numba の版の条件を足す ([dependency_management.md](dependency_management.md) §3-3 に残っている宿題)。まはーの開発機の venv では 2026-09-02 20:47 に numba 0.67.0 へ上がっていて、9/3 の合成はその版で成功した。
+2. **`saiverse/addon_installer.py` で、`platform_script` / `python_script` の step で実行されるスクリプトの中の pip にも、requirements.lock が constraints として渡るようにする (本体側)。** [addon_setup_scripts_bypass_lock_constraints.md](../issues/addon_setup_scripts_bypass_lock_constraints.md)。
+3. **`addon.json` を manifest v2 にする。** `manifest_version`・`setup_version`・`data_subdirs`・`setup.steps` を書く。1 の requirements をどの step で入れるか (`pip_install` の step に分けるか、スクリプトの中に残すか) は未決。スクリプトを使うなら、`platform_script` の step の `unix` 側のスクリプトも要る。いまの `saiverse/addon_installer.py` は、実行中の OS 向けのスクリプトが無いとその step を失敗にせず飛ばして先へ進むので、`setup.sh` が無いまま載せると、macOS と Linux では GPT-SoVITS が入らないまま導入が成功したように見える。
+4. **参照音声と合成音声を、永続データの規約の場所へ移す。** 本体の `ENABLED_ADDONS_FOR_STARTUP` に voice-tts を加えると、起動時に参照音声のファイルが `addon_data/saiverse-voice-tts/inputs/` へ移る。しかし DB に記録された参照音声の絶対パスと、本体のアップロード処理の保存先は、古い `addon_files/` のまま残る。合成では記録された絶対パスがそのまま使われるので、参照音声のファイルが見つからずにエラーになる。移行を有効にするときは、同じリリースで次の三つを揃える (2026-05-23 のインシデントの教訓「コード path 変更と migration はセット commit」)。
+   - 本体: voice-tts の参照音声のアップロード先を、移行先の `addon_data/saiverse-voice-tts/inputs/` と揃える。ファイルを受け付ける他のアドオンの保存先をどう扱うかも、あわせて決める。
+   - 本体: DB の `AddonPersonaConfig.params_json` に記録された、古い場所の絶対パスを書き換える。
+   - voice-tts: 合成音声の保存先 (`_OUT_DIR`) を `get_addon_data_dir(...)/outputs/` に変える。
+5. **upstream に PR を出してマージし、registry.json に voice-tts を載せる。**
+6. **公開前の検証。** 隔離した `SAIVERSE_HOME` と、requirements.lock だけを入れた新しい venv に、アドオンカタログの導入経路で voice-tts を入れ、GPT-SoVITS で実際に声が出るところまで確かめる。[dependency_management.md](dependency_management.md) §5 の 4 で「voice-tts の実導入は本番 venv の同期のときに」と後に回していた検証にあたる。証拠は次の項目ごとに残す。2026-09-11 の時点では、すべて未検証。
+   - Windows で、カタログから入れて声が出る: 未検証。
+   - macOS で、カタログから入れて声が出る: 未検証 (`setup.sh` が無い)。
+   - Linux で、カタログから入れて声が出る: 未検証 (`setup.sh` が無い)。
+   - 参照音声を設定済みのペルソナがいる既存の環境に 4 の移行を当てて、そのペルソナの声が出る: 未検証。
+
+#### まはーが決めること (2026-09-11 時点で未決)
+
+- **旧手順の 3 番 (`setup.bat` を `platform_script` の step で実行する) を、計画から外すか。**
+- **upstream にまだマージされていない PR #5・#6 を、公開前にマージするか。** #5 は GPT-SoVITS の合成を別プロセスに移して、SAIVerse 本体のどのスレッドが GIL を握り続けても合成が遅くならないようにするもので、[mcp_cancel_scope_spin_gil_starvation.md](../issues/mcp_cancel_scope_spin_gil_starvation.md) の修正方針 B にあたる。GIL 飢餓の元になった本体側の不具合を直す修正方針 A は、2026-05-24 に回帰テストと一緒に実装済み。
+- **Irodori-TTS を公開に含めるか。** Irodori-TTS の pyproject.toml は `transformers>=5.12.1,<6`・`peft>=0.18.0`・`gradio>=5.0.0` を要求していて、GPT-SoVITS の requirements.txt の `transformers>=4.43,<=4.50`・`peft<0.18.0`・`gradio<5` と両立しない。同じ venv に両方は入らない。`addon.json` のエンジンの選択肢 (`engine`) には、今も `irodori` がある。
+
+#### 旧手順 (2026-05-23。3 番は、上に書いた理由でいまのままでは成り立たない)
 
 voice-tts repo は `origin = Nature109/saiverse-voice-tts` の共有 repo で、 現在 PR #4 (subscribe-before-open) がレビュー待ち。 v2 化は別 PR で出す方針:
 

--- a/docs/intent/dependency_management.md
+++ b/docs/intent/dependency_management.md
@@ -1,6 +1,6 @@
 # Intent Document: 依存関係の管理 (lock ファイルと「上げる / 止める」の裁定簿)
 
-**ステータス**: 完了 (2026-09-03。実装・レビュー 3 巡・lock だけの venv でのフルスイート・本番 venv の同期と再起動 (まはー、エリスと会話・声あり)・OpenAI / Anthropic / xAI の実 API 一回ずつ (隔離環境、下記 §5) まで済。残るのは develop へのマージとリリース発行、それと報告者の macOS で LLM 呼び出しが通ることの確認 (リリース後))
+**ステータス**: 完了 (2026-09-03。実装・レビュー 3 巡・lock だけの venv でのフルスイート・本番 venv の同期と再起動 (まはー、エリスと会話・声あり)・OpenAI / Anthropic / xAI の実 API 一回ずつ (隔離環境、下記 §5) まで済。残るのは develop へのマージとリリース発行、それと報告者の macOS で LLM 呼び出しが通ることの確認 (リリース後))。2026-09-11 に、アドオンの setup の `platform_script` / `python_script` の step で実行されるスクリプトの中の pip が constraints の外にあり、§2-2 で数え漏れていたと分かった。[addon_setup_scripts_bypass_lock_constraints.md](../issues/addon_setup_scripts_bypass_lock_constraints.md) で追跡している
 
 ## 概要
 
@@ -45,7 +45,7 @@ SAIVerse が使う Python の部品 (ライブラリ) について、**「意図
 | `.github/workflows/discord_gateway.yml` | `discord_gateway/requirements-dev.txt` (中で `-r ../requirements.txt`) | CI (Python 3.11) |
 | `docs/getting-started/installation.md` | 手動手順に `pip install -r requirements.txt` | 手で入れる人 |
 
-lock を導入するなら、この **7 箇所すべて**が lock を読むように揃える。一箇所でも requirements.txt を直接読む経路が残ると、その経路だけ違う組み合わせが入る (入口の検査ではなく境界の保証として、読む側を数え切る)。
+lock を導入するなら、この **7 箇所すべて**が lock を読むように揃える。一箇所でも requirements.txt を直接読む経路が残ると、その経路だけ違う組み合わせが入る (入口の検査ではなく境界の保証として、読む側を数え切る)。**2026-09-11 に数え漏れが一つ見つかった**: アドオンの setup の `platform_script` / `python_script` の step で実行されるスクリプトの中の pip (たとえば voice-tts の `scripts/install_backends.py`) は、上の表のどれにも当たらず、requirements.lock も constraints として渡らない ([addon_setup_scripts_bypass_lock_constraints.md](../issues/addon_setup_scripts_bypass_lock_constraints.md))。
 
 ### 2-3. 変更後の形
 
@@ -57,7 +57,7 @@ requirements.lock     ← 全部品の版を固定した一覧 (機械が作る�
 - **requirements.txt** は「本体が直接 import する部品」だけを、**下限 + 理由つきの上限**で書く。`==` は使わない (釘を打つのは lock の仕事)。上限を書くときは必ず一行の理由を添える (mcp<2 の書き方が手本)。
 - **requirements.lock** は `requirements.txt` から機械生成する。全部品 (間接依存も含む) が `==` で並び、プラットフォーム差 (Windows / macOS / Linux、Python 3.11〜3.13) は環境マーカーで一枚に収める。ユーザー側は素の pip で読める形式 (`pip install -r requirements.lock`) に限る — ユーザーに新しい道具を入れさせない。
 - 生成の道具は開発者だけが使う。`uv pip compile --universal` を第一候補とする (開発機に導入済み、pip 互換の出力、プラットフォーム横断の一枚を作れる)。ユーザーの手元では uv は不要。
-- **アドオンの pip install には lock を constraints として渡す** (`pip install -r <addon>/requirements.txt -c requirements.lock`)。アドオンは本体が固定した部品を動かせなくなり、動かす必要があるなら導入時に失敗して理由が出る (黙って壊れる代わりに)。
+- **アドオンの pip install には lock を constraints として渡す** (`pip install -r <addon>/requirements.txt -c requirements.lock`)。アドオンは本体が固定した部品を動かせなくなり、動かす必要があるなら導入時に失敗して理由が出る (黙って壊れる代わりに)。2026-09-11 の時点で実際に渡しているのは、setup の `pip_install` の step だけ (§2-2 の数え漏れ)。
 
 ### 2-4. 不変条件と持ち主
 
@@ -66,7 +66,7 @@ requirements.lock     ← 全部品の版を固定した一覧 (機械が作る�
 | ユーザーの手元に入る部品の版は lock と一致する | `requirements.lock` |
 | lock は requirements.txt の範囲の中にある | 生成の道具 (compile が保証) |
 | 止めている部品には理由がある | `requirements.txt` のコメント行 |
-| アドオンは本体の部品を動かせない | `addon_installer.py` が constraints を渡す |
+| アドオンは本体の部品を動かせない | `addon_installer.py` が constraints を渡す。**2026-09-11 時点で渡しているのは `pip_install` の step だけで、`platform_script` / `python_script` の step で実行されるスクリプトの中の pip には渡っていない** ([addon_setup_scripts_bypass_lock_constraints.md](../issues/addon_setup_scripts_bypass_lock_constraints.md)) |
 | 更新完了マーカーは lock の内容と結びつく | `update_engine.completion_fingerprint` (lock の sha256 を含める) |
 
 ### 2-5. 移行
@@ -108,6 +108,8 @@ requirements.lock     ← 全部品の版を固定した一覧 (機械が作る�
 torch / transformers / librosa / numba / gradio / funasr など、venv にある 269 個のうち本体の直接依存 (約 30 個) を除く大半は voice-tts が連れてきたもの。これらは本体の requirements には入っていない (現状で正しい)。本体がやることは **constraints で「本体の部品を動かすな」と言う**ことまで。numba の上限などアドオン自身の部品の整合はアドオン側の requirements の責任 (voice-tts に numba の固定を足すのはアドオンのリポジトリの宿題)。
 
 ただし本体の更新は、壊したことを**その場で見せる**義務は負う。`update_engine.update_dependencies` は lock を入れた直後に `pip check` を回し、lock の外にあるパッケージ (アドオンか手で入れたもの) との衝突を `[deps] pip check: ...` の WARNING として更新ログに残す (2026-09-02 の voice-tts の実害は、翌日まで誰も気づかなかったことが問題だった)。衝突と読むのは `pip check` の exit 1 だけで、それ以外の非ゼロ (2 = pip 自身の使い方の誤りや内部エラー、負数 = シグナル) は「pip check が走らず、衝突は検査できなかった」として stderr と一緒に別の WARNING で残す (pip の落ち方をアドオンの衝突に見せない)。可視化だけで、更新は失敗にしないし巻き戻しもしない — 直すのはアドオン側。
+
+2026-09-11 に、この警告の最後の文の助言 (「該当のアドオンは入れ直す (アドオンを入れ直す) 必要があるかもしれません。」) が当てはまらない衝突が見つかった。voice-tts が入れる GPT-SoVITS の requirements.txt 自体が requirements.lock と両立しない場合で、アドオンを入れ直しても衝突は消えない ([pip_check_warning_reinstall_advice.md](../issues/pip_check_warning_reinstall_advice.md))。
 
 ### 3-4. SDK を上げる前に分かっていること (2026-09-02 の下調べ)
 
@@ -165,3 +167,4 @@ torch / transformers / librosa / numba / gradio / funasr など、venv にある
 - 2026-09-02: voice-tts の無音事故 (numba × NumPy 2.5) を契機に起草。まはー「そろそろやらなきゃダメかな。依存関係全体を洗いたい、新しくするべきとこ新しくして、古いまま止めなきゃだめなやつはそう設定する整理が必要」。Python 推奨は 3.13 へ、feature ブランチで対応、と裁定。
 - 2026-09-02 深夜 (レビュー 1 巡目): ローカル LLM と Codex (ブランチ全体、develop 基点)。**採用**: ①lock の onnxruntime 1.24.1 は Intel Mac の wheel も sdist も無く、Intel Mac では lock が入らない (Codex high) → `onnxruntime<1.24` を理由つきで置き、`scripts/check_lock_platforms.py` を新設して同族を機械検査 (§3-2)。②packaging 無しの退化パーサーがマーカー付き行を「必要」と読み、macOS で Windows 限定の pin を未導入と判定して起動のたびに更新へ送る (ローカル low) → マーカー付き行は未検査扱いへ。③壊れた dist-info (版が読めない) を満たしている扱いにしていた (Codex medium) → 未検査へ。④requirements.txt の `==` 禁止を契約テストへ (ローカル low)。**採用せず**: lock が読めない・メタデータが列挙できないときに CHECK_READY を返す fail-open (Codex high) — 以前からの設計で、代案の INCONCLUSIVE も起動する点は同じ (印を書かない) なので挙動差が無い。`strict_content_type=False` は CSRF 防御の保留 (Codex high) — 0.116 には検査自体が無かったので退行ではないが、issue の優先度を high に上げてフロントエンドを監査対象に加えた。thinking と sampling の同時送信 (Codex medium) — この分岐は以前から同じ引数を top-level で送っており、`extra_body` への移動で挙動は変わっていない (別件)。
 - 2026-09-02 深夜 (レビュー 2〜3 巡目、Codex)。**2 巡目 3 件すべて採用**: `check_lock_platforms.py` が PyPI に問えなかった pin を通していた → fail-closed に / wheel の判定を文字列の部分一致から `packaging.tags` へ (macOS の床 13 / 14) / 本体の更新が同居アドオンの部品を壊しても気づけない → `update_dependencies` の直後に `pip check` を回して衝突を WARNING で更新ログに残す (止めない・戻さない、§3-3)。**3 巡目 4 件すべて採用**: lock の無い旧版 (v0.3.3 以前) からの更新が途中で失敗したとき、巻き戻しが旧版に無い lock を探して失敗する → 巻き戻し経路だけ旧版の requirements.txt を読む (§2-5) / manylinux の列挙を glibc の床 2.31 からの生成へ / Requires-Python と yanked をファイル単位で判定 / `pip check` は exit 1 だけを衝突として読み、他の非 0 は「検査できなかった」と書く。3 巡で採用した指摘の的は「lock の中身 (Intel Mac)」→「新設した検査の精度」→「移行の一回きりの経路」と外周へ移っており、私の見立てでは収束。4 巡目を投げるかはまはーの判断。
+- 2026-09-11: まはーの環境で v0.3.12 へ更新したときに pip check の警告が 3 件出た件を調べ、欠陥を二つ見つけて issue にした。一つは、`saiverse/addon_installer.py` で requirements.lock が constraints として pip に渡されるのが `pip_install` の step だけで、`platform_script` / `python_script` の step で実行されるスクリプトには渡されないこと (ステータス行・§2-2・§2-3・§2-4 に注記、[addon_setup_scripts_bypass_lock_constraints.md](../issues/addon_setup_scripts_bypass_lock_constraints.md))。もう一つは、pip check の警告の「アドオンを入れ直す」という助言が、入れ直しでは解けない衝突にも出ること (§3-3、[pip_check_warning_reinstall_advice.md](../issues/pip_check_warning_reinstall_advice.md))。

--- a/docs/issues/addon_setup_scripts_bypass_lock_constraints.md
+++ b/docs/issues/addon_setup_scripts_bypass_lock_constraints.md
@@ -1,0 +1,34 @@
+# アドオンの setup で platform_script / python_script の step が実行するスクリプトの中の pip には、requirements.lock が constraints として渡らない
+
+**起票**: 2026-09-11 (voice-tts をアドオンカタログに載せる前に必要な作業を洗い出す中で見つけた)
+**状態**: 未着手
+**優先度**: high (メティスの判断。voice-tts を今の setup のままアドオンカタログに載せると、setup の step を持つアドオンとして最初にこの経路を通るため)
+**関連**: [dependency_management.md](../intent/dependency_management.md) §2-2・§2-3・§2-4、[addon_catalog_management.md](../intent/addon_catalog_management.md) Phase 4-E、[pip_check_warning_reinstall_advice.md](pip_check_warning_reinstall_advice.md)、`saiverse/addon_installer.py`
+
+## 現象
+
+`saiverse/addon_installer.py` は、アドオンカタログからアドオンを入れるときに、addon.json (manifest v2) の setup の step を順に実行する。[dependency_management.md](../intent/dependency_management.md) §2-4 は「アドオンは本体の部品を動かせない」を不変条件にしていて、その持ち主を「`addon_installer.py` が constraints を渡す」としている。constraints は、pip の `-c` オプションで渡す「この一覧に書いてある版から動かすな」という指定のこと。
+
+実際に requirements.lock が constraints として pip に渡されるのは、setup の step のうち `pip_install` だけだった (2026-09-11 にコードで確認)。
+
+- `pip_install` の step (`_exec_pip_install`) では、`python -m pip install -r <アドオンの requirements> -c requirements.lock` が実行される。
+- `platform_script` の step (`_exec_platform_script`) と `python_script` の step (`_exec_python_script`) では、アドオンのスクリプトが、SAIVerse のプロセスの環境変数をそのまま写した環境で起動される。requirements.lock を constraints として渡す指定は付かない。
+
+そのため、スクリプトの中で pip を呼ぶアドオンは、venv (SAIVerse が使う Python の環境) に入っている本体のパッケージを、requirements.lock の版から動かせる。
+
+## いま影響を受けるもの
+
+公開の registry.json に載っている Elyth・X・stackchan は、どれも setup の step を持たないので、2026-09-11 の時点ではこの経路を通るアドオンは無い。
+
+voice-tts を今の setup のままアドオンカタログに載せると、最初にこの経路を通る。[addon_catalog_management.md](../intent/addon_catalog_management.md) の Phase 4-E の旧手順 (2026-05-23) は、voice-tts の `setup.bat` を `platform_script` の step で実行する予定にしていた。`setup.bat` は voice-tts の `scripts/install_backends.py` を呼び、その中で GPT-SoVITS の requirements.txt が constraints なしで `pip install -r` される。GPT-SoVITS の requirements.txt は `numpy<2.0` と `pydantic<=2.10.6` を要求していて、requirements.lock (numpy は Python 3.12 以上で 2.5.2、3.11 で 2.4.6。pydantic は 2.13.5) と両立しない。constraints が無いまま実行すると、pip は venv の numpy と pydantic を requirements.lock の版から引き下げに行く。2026-09-01 に本体の pip install が voice-tts の numba を壊した事故 ([dependency_management.md](../intent/dependency_management.md) §1-1) の、向きが逆のものになる。
+
+## 直し方の方向 (未決)
+
+pip は環境変数 `PIP_CONSTRAINT` でも constraints を受け取る。`addon_installer.py` が `platform_script` と `python_script` のスクリプトを起動するときに、`PIP_CONSTRAINT` に requirements.lock のパスを入れて渡せば、スクリプトの中の pip にも requirements.lock の版が効く。requirements.lock と両立しない要求を持つアドオンは、本体のパッケージを黙って動かす代わりに、導入の時点で pip が失敗して理由が出るようになる。
+
+直すときに確かめること:
+
+- `PIP_CONSTRAINT` が `-c` と同じ範囲に効くか。環境変数は、pip がソースからパッケージをビルドするときに裏で起動する pip にも引き継がれることがあり、ビルドに使うパッケージにまで版の指定がかかって、`-c` と振る舞いが違う可能性がある (未確認。pip の変更履歴で確かめる)。voice-tts の `setup.bat` と `scripts/install_backends.py` のコメントには、editdistance や opencc をソースからビルドすることがあると書いてある。
+- voice-tts の `setup.bat` が行う CUDA 版 torch の入れ直し (`--index-url https://download.pytorch.org/whl/cu128 --force-reinstall`) が、`PIP_CONSTRAINT` の下でも通るか。torch 自体は requirements.lock に載っていないが、`--force-reinstall` は torch の依存も入れ直す。その中の filelock・fsspec・sympy・typing-extensions は requirements.lock に載っているので、PyTorch の配布元にその版が無ければ、解決に失敗する可能性がある。
+- `pip_install` の step と同じく、`platform_script` / `python_script` の step でも constraints が渡ることをテストで固定する。
+- 直したら、[dependency_management.md](../intent/dependency_management.md) のステータス行と §2-2・§2-3・§2-4 に付けた注記を外す。

--- a/docs/issues/mcp_cancel_scope_spin_gil_starvation.md
+++ b/docs/issues/mcp_cancel_scope_spin_gil_starvation.md
@@ -1,6 +1,6 @@
 # Issue: MCP 再接続時の anyio キャンセルスコープ違反による無限スピン → GIL 飢餓で全体劣化
 
-**ステータス**: 🟡 進行中 (根本原因特定済み・修正未着手)
+**ステータス**: 🟡 未解決 (修正方針 A は 2026-05-24 にコミット 1786e6d0 で実装済みで、回帰テスト `tests/test_mcp_connection_owner_task.py` も同じコミットで入っている。B は voice-tts の upstream に PR #5 として 2026-05-24 に出したまま、未マージ)
 **優先度**: high
 **作成日**: 2026-05-24
 **関連**: `tools/mcp_client.py`、`expansion_data/saiverse-voice-tts/tools/speak/playback_worker.py`、anyio
@@ -103,3 +103,4 @@ eris_city_a の発話の音声合成が「同じ発言を無限に合成し続�
 - 2026-05-24: **修正 A 実装完了**。`MCPConnection` を所有タスク方式に変更 (`tools/mcp_client.py`): `connect()` は専用の長命タスク `_run_connection()` を起動して ready を待つだけにし、transport/session の `async with` をその単一タスク内で開閉。`disconnect()` は `_exit_stack.aclose()` を自前で呼ばず、shutdown イベントを set して所有タスクの自己巻き戻しを待つ (15s タイムアウト→cancel フォールバック付き)。stdio/sse/streamable_http の3経路すべて統一。ruff・ast parse クリーン、既存 MCP テスト 21件パス。
   - **検証の限界**: 既存テストはマネージャ層をモックしており、所有タスク方式の anyio 実挙動 (クロスタスク回避) そのものは未カバー。真の検証には実 MCP サーバ＋切断誘発が必要 (= 本 issue の稀シナリオ自体)。所有タスク方式は「開いたタスクと同じタスクで閉じる」を構造的に保証するため、原理的にクロスタスク違反は起きない設計。
   - **残**: B (TTS 別プロセス化、多重防御) は未着手。A の anyio 挙動を直接検証する回帰テスト (偽 transport で cross-task 条件を再現) も未作成。
+- 2026-09-11: 冒頭のステータス行が「修正未着手」のまま残っていたので、上のログ (A の実装完了) と、B を実装した voice-tts の upstream の PR #5 (2026-05-24 作成、未マージ) に合わせて書き直した。上のログの「残」にある A の回帰テストは、A と同じコミット 1786e6d0 で `tests/test_mcp_connection_owner_task.py` として入っていた。

--- a/docs/issues/pip_check_warning_reinstall_advice.md
+++ b/docs/issues/pip_check_warning_reinstall_advice.md
@@ -1,0 +1,37 @@
+# 更新ログの pip check の警告が、アドオンの入れ直しでは解けない衝突にも「アドオンを入れ直す」と助言する
+
+**起票**: 2026-09-11 (まはーの環境で v0.3.12 へ更新したときに出た警告の調査から)
+**状態**: 未着手
+**優先度**: low
+**関連**: `scripts/update_engine.py` の `_report_addon_conflicts`、[dependency_management.md](../intent/dependency_management.md) §3-3、[addon_setup_scripts_bypass_lock_constraints.md](addon_setup_scripts_bypass_lock_constraints.md)、[addon_catalog_management.md](../intent/addon_catalog_management.md) Phase 4-E
+
+## 出た警告
+
+2026-09-11 21:57 に、まはーの環境で v0.3.12 へ更新したとき、更新ログに次の警告が出た。pip check は、venv に入っているパッケージ同士で版の条件が両立しないもの (dependency_management.md と警告文では「衝突」と呼んでいる) を調べる pip のコマンドで、更新の最後に実行している。
+
+```
+[deps] pip check: gradio 4.44.1 has requirement pillow<11.0,>=8.0, but you have pillow 11.3.0.
+[deps] pip check: gradio-client 1.3.0 has requirement websockets<13.0,>=10.0, but you have websockets 16.1.1.
+[deps] pip check: torchmetrics 1.5.0 has requirement numpy<2.0,>1.20.0, but you have numpy 2.5.2.
+[deps] 上の 3 件は requirements.lock の外にあるパッケージ (アドオンか手で入れたもの) との衝突です。本体の更新自体は完了しています。該当のアドオンは入れ直す (アドオンを入れ直す) 必要があるかもしれません。
+```
+
+## 調べて分かったこと (2026-09-11)
+
+- gradio・gradio-client・torchmetrics は、voice-tts が GPT-SoVITS の requirements.txt (`gradio<5`、`torchmetrics<=1.5`、`pytorch-lightning>=2.4` を含む) を入れたときに入ったもの。venv の dist-info の日付は、3 つとも 2026-04-17 13:56 だった。
+- 本体の requirements.txt に gradio があったのは 2026-01-30 (コミット 267a4e4f で削除) までで、版は 5.38.0 だった。最初の公開版 v0.1.0 (2026-02-11) の requirements.txt には gradio が無いので、公開版から入れたユーザーの venv に本体が gradio を入れたことは無い。
+- 衝突の相手の pillow 11.3.0・websockets 16.1.1・numpy 2.5.2 は 2026-09-01 04:18 から venv に入っていて、requirements.lock のこの 3 つの版は 2026-09-02 の導入から変わっていない。v0.3.12 への更新で新しく生まれた衝突ではない。
+- 2026-09-03 00:11 の再起動で、同じ組み合わせのまま voice-tts の合成は成功していた ([dependency_management.md](../intent/dependency_management.md) §5 の 6)。
+- voice-tts は公開の registry.json に載っていない。この 3 件が出るのは、voice-tts の `setup.bat` か、`python scripts/install_backends.py gpt_sovits` (voice-tts の requirements.txt が、プラットフォームを問わない入口として案内している) を手で実行して、GPT-SoVITS を入れた環境になる。
+
+## 問題
+
+警告の最後の文は「該当のアドオンは入れ直す (アドオンを入れ直す) 必要があるかもしれません。」と助言する。しかしこの 3 件は、アドオンを入れ直しても消えない。GPT-SoVITS の requirements.txt 自体が `numpy<2.0` を要求していて、requirements.lock の numpy (Python 3.12 以上で 2.5.2、3.11 で 2.4.6) と両立する組み合わせが無いからだ。そのうえ voice-tts の `scripts/install_backends.py` は constraints を渡さずに pip を呼ぶので、助言どおりに入れ直すと、venv の numpy などを requirements.lock の版から引き下げに行く ([addon_setup_scripts_bypass_lock_constraints.md](addon_setup_scripts_bypass_lock_constraints.md))。
+
+文面には「入れ直す (アドオンを入れ直す)」という、同じ語の重複もある。
+
+## 直し方の方向 (未決)
+
+アドオンの入れ直しでは解けない衝突 (アドオンが入れる外部のリポジトリの requirements が requirements.lock と両立しない場合) があることを前提に、助言の文面を見直す。
+
+voice-tts については、[addon_catalog_management.md](../intent/addon_catalog_management.md) Phase 4-E の「voice-tts 用の GPT-SoVITS の requirements を voice-tts 側で持つ」作業が済めば、新しく入れる環境ではこの 3 件は出なくなる。すでに gradio 4.44.1 が入っている venv では、gradio と gradio-client を手で削除するまで、gradio の 2 件は残る。

--- a/docs/overview/landscape.md
+++ b/docs/overview/landscape.md
@@ -378,7 +378,7 @@ graph TD
 
 ### Addon（拡張パッケージ）
 
-Tools / Playbooks / Phenomena / MCP サーバー / ペルソナフックを束ねて配布・導入・管理する単位。`addon.json`（manifest v2）で宣言し、永続データは `~/.saiverse/user_data/addon_data/<addon_id>/` に置く。導入は審査済みレジストリ経由のワンタッチ UI または手動 git clone。既存アドオン（Elyth / voice-tts / stack-chan / X / ComfyUI ローカル画像生成）は v2 化済み。**カタログ機構は Phase 1〜4 実装済**。ローカル画像生成 (`generate_image_local`) は 2026-08-01 に builtin からアドオン (saiverse-comfyui-addon) へ切り出された — ComfyUI・生成モデルの別途導入が前提の機能を builtin に置かないため。
+Tools / Playbooks / Phenomena / MCP サーバー / ペルソナフックを束ねて配布・導入・管理する単位。`addon.json`（manifest v2）で宣言し、永続データは `~/.saiverse/user_data/addon_data/<addon_id>/` に置く。導入は審査済みレジストリ経由のワンタッチ UI または手動 git clone。既存アドオンのうち Elyth / stack-chan / X / ComfyUI ローカル画像生成は v2 化済みで、voice-tts は未着手（`docs/intent/addon_catalog_management.md` の Phase 4-E）。**カタログ機構は Phase 1〜4 実装済**（Phase 4 のうち、voice-tts を扱う 4-E だけが未着手）。ローカル画像生成 (`generate_image_local`) は 2026-08-01 に builtin からアドオン (saiverse-comfyui-addon) へ切り出された — ComfyUI・生成モデルの別途導入が前提の機能を builtin に置かないため。
 
 ### MCP（外部ツールサーバー）
 

--- a/docs/overview/roadmap_status.md
+++ b/docs/overview/roadmap_status.md
@@ -105,7 +105,7 @@
 
 - ✅ **RSS フィード施設** — Building 単位の購読 + プリセット施設化 + 知覚バッファ投入 (`rss_feed_intake.md`、2026-08-03 実装完了)。世界の供給側の第一弾。実機検証は門 Wave 5
 - 🟡 **SwitchBot**（Intent doc draft 済、レビュー待ち。Cloud API v1.1 / 入出力両経路。Observer の利用者）
-- 🟡 **voice-tts**（GPT-SoVITS、実装済。GIL 飢餓問題対応中）
+- 🟡 **voice-tts**（GPT-SoVITS、実装済。アドオンカタログへの掲載は未着手で、公開前に必要な作業は `addon_catalog_management.md` の Phase 4-E に洗い出してある。GIL 飢餓対策の合成の別プロセス化は、upstream の PR #5 が未マージ）
 - 🟡 **stack-chan**（Vessel 統合 §5 + 能動入力 BLE HID リモコン構想）
 - 🔲 **Discord**（見守り機能の軽量アドオン化構想）
 - 🔲 **Withings 連携**（定期データ取得 + 通知ペルソナ、構想）


### PR DESCRIPTION
## 何が入るか

voice-tts をアドオンカタログで公開する前に必要な作業と、その調べの中で見つかった本体側の欠陥 2 件を、文書に記録する。コードの変更は無い。

きっかけは、2026-09-11 に v0.3.12 へ更新したとき、まはーの環境で pip check の警告が 3 件出たこと。警告の出どころは voice-tts が入れる GPT-SoVITS の requirements.txt で、そこから公開前の作業の洗い出しになった。すぐには着手しないので、次に取りかかるときに読む場所へ残す。

### 変更する文書

- `docs/intent/addon_catalog_management.md` — Phase 4-E (voice-tts v2 化) の節を書き直した。
  - 2026-09-11 時点の現状 (addon.json に setup が無い、registry.json に未掲載、upstream で未マージの PR #5・#6 など)
  - 旧手順の 3 番 (`setup.bat` を `platform_script` の step で実行する) が、requirements.lock の導入後はいまのままでは成り立たない理由
  - 公開前にやること 6 件 (GPT-SoVITS の requirements を voice-tts 側で持つ、参照音声の移行は本体のアップロード先と DB の記録もセットで直す、Windows・macOS・Linux ごとの検証など)
  - まはーが決めること 3 件 (旧手順の 3 番を外すか、PR #5・#6 を公開前にマージするか、Irodori-TTS を含めるか)
  - 旧手順そのものは消さずに残した
- 新しい issue 2 件
  - `docs/issues/addon_setup_scripts_bypass_lock_constraints.md` — `saiverse/addon_installer.py` で requirements.lock が constraints として pip に渡るのは `pip_install` の step だけで、`platform_script` / `python_script` の step で実行されるスクリプトの中の pip には渡らない件
  - `docs/issues/pip_check_warning_reinstall_advice.md` — 更新ログの pip check の警告の「アドオンを入れ直す」という助言が、入れ直しでは解けない衝突にも出る件
- `docs/intent/dependency_management.md` — 上の 2 件への注記 (ステータス行・§2-2・§2-3・§2-4・§3-3・§7)
- `docs/overview/landscape.md` — 「voice-tts は v2 化済み」を実態 (Phase 4-E は未着手) に合わせた
- `docs/overview/roadmap_status.md` — voice-tts の行に Phase 4-E への道しるべを置いた
- `docs/issues/mcp_cancel_scope_spin_gil_starvation.md` — ステータス行が「修正未着手」のまま残っていたのを、修正方針 A (回帰テストと一緒に 1786e6d0 で実装済み) と、B の PR #5 が未マージである現状に合わせた

## 確認したこと

- 書いた事実は、コード (`saiverse/addon_installer.py`、`saiverse/addon_migrations.py`、`api/routes/addon.py`、voice-tts と GPT-SoVITS のファイル)、git の履歴、venv の dist-info、PyPI、GitHub の PR で裏を取った。
- 既存の決定との衝突と、コードとの食い違いを別の検査で洗い、見つかった指摘 (参照音声の移行の穴、回帰テストの有無、まだ決まっていないことを決定の形で書いていた箇所など) を反映した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
